### PR TITLE
Increase all rate limits and add configurable proxy chain security

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -30,7 +30,7 @@ async def get_current_user_info(current_user: User = Depends(get_current_active_
     return current_user
 
 @router.post("/register", response_model=RegistrationResponse)
-@skip_rate_limit_for_admin("5/minute")  # Allow admins higher rate limit
+@skip_rate_limit_for_admin("8/minute")  # Allow admins higher rate limit
 async def register(
     request: Request,
     response: Response,
@@ -98,7 +98,7 @@ async def register(
     }
 
 @router.post("/login", response_model=Token)
-@skip_rate_limit_for_admin("20/minute")
+@skip_rate_limit_for_admin("30/minute")
 async def login(
     request: Request,
     response: Response,
@@ -142,7 +142,7 @@ async def login(
     }
 
 @router.post("/google-login", response_model=Token)
-@skip_rate_limit_for_admin("20/minute")
+@skip_rate_limit_for_admin("30/minute")
 async def google_login(
     request: Request,
     response: Response,

--- a/backend/app/routers/dive_sites.py
+++ b/backend/app/routers/dive_sites.py
@@ -257,7 +257,7 @@ async def health_check():
     return {"status": "healthy", "timestamp": "2025-07-27T12:56:00Z"}
 
 @router.get("/reverse-geocode")
-@skip_rate_limit_for_admin("50/minute")
+@skip_rate_limit_for_admin("75/minute")
 async def reverse_geocode(
     request: Request,
     latitude: float = Query(..., ge=-90, le=90),
@@ -374,7 +374,7 @@ def get_fallback_location(latitude: float, longitude: float):
         )
 
 @router.get("/", response_model=List[DiveSiteResponse])
-@skip_rate_limit_for_admin("100/minute")
+@skip_rate_limit_for_admin("150/minute")
 async def get_dive_sites(
     request: Request,
     search: Optional[str] = Query(None, max_length=200, description="Unified search across name, country, region, and description"),
@@ -816,7 +816,7 @@ async def get_dive_sites(
     return response
 
 @router.get("/count")
-@skip_rate_limit_for_admin("100/minute")
+@skip_rate_limit_for_admin("150/minute")
 async def get_dive_sites_count(
     request: Request,
     name: Optional[str] = Query(None, max_length=100),
@@ -900,7 +900,7 @@ async def get_dive_sites_count(
     return {"total": total_count}
 
 @router.post("/", response_model=DiveSiteResponse)
-@skip_rate_limit_for_admin("10/minute")
+@skip_rate_limit_for_admin("15/minute")
 async def create_dive_site(
     request: Request,
     dive_site: DiveSiteCreate,
@@ -927,7 +927,7 @@ async def create_dive_site(
     }
 
 @router.get("/{dive_site_id}", response_model=DiveSiteResponse)
-@skip_rate_limit_for_admin("200/minute")
+@skip_rate_limit_for_admin("300/minute")
 async def get_dive_site(
     request: Request,
     dive_site_id: int,
@@ -1016,7 +1016,7 @@ async def get_dive_site(
     return response_data
 
 @router.get("/{dive_site_id}/media", response_model=List[SiteMediaResponse])
-@skip_rate_limit_for_admin("100/minute")
+@skip_rate_limit_for_admin("150/minute")
 async def get_dive_site_media(
     request: Request,
     dive_site_id: int,
@@ -1035,7 +1035,7 @@ async def get_dive_site_media(
     return media
 
 @router.post("/{dive_site_id}/media", response_model=SiteMediaResponse)
-@skip_rate_limit_for_admin("20/minute")
+@skip_rate_limit_for_admin("30/minute")
 async def add_dive_site_media(
     request: Request,
     dive_site_id: int,
@@ -1071,7 +1071,7 @@ async def add_dive_site_media(
     return db_media
 
 @router.delete("/{dive_site_id}/media/{media_id}")
-@skip_rate_limit_for_admin("20/minute")
+@skip_rate_limit_for_admin("30/minute")
 async def delete_dive_site_media(
     request: Request,
     dive_site_id: int,
@@ -1103,7 +1103,7 @@ async def delete_dive_site_media(
     return {"message": "Media deleted successfully"}
 
 @router.get("/{dive_site_id}/diving-centers")
-@skip_rate_limit_for_admin("100/minute")
+@skip_rate_limit_for_admin("150/minute")
 async def get_dive_site_diving_centers(
     request: Request,
     dive_site_id: int,
@@ -1142,7 +1142,7 @@ async def get_dive_site_diving_centers(
     return result
 
 @router.post("/{dive_site_id}/diving-centers")
-@skip_rate_limit_for_admin("10/minute")
+@skip_rate_limit_for_admin("15/minute")
 async def add_diving_center_to_dive_site(
     request: Request,
     dive_site_id: int,
@@ -1209,7 +1209,7 @@ async def add_diving_center_to_dive_site(
     }
 
 @router.delete("/{dive_site_id}/diving-centers/{diving_center_id}")
-@skip_rate_limit_for_admin("10/minute")
+@skip_rate_limit_for_admin("15/minute")
 async def remove_diving_center_from_dive_site(
     request: Request,
     dive_site_id: int,
@@ -1261,7 +1261,7 @@ async def remove_diving_center_from_dive_site(
     return {"message": "Diving center removed from dive site successfully"}
 
 @router.put("/{dive_site_id}", response_model=DiveSiteResponse)
-@skip_rate_limit_for_admin("20/minute")
+@skip_rate_limit_for_admin("30/minute")
 async def update_dive_site(
     request: Request,
     dive_site_id: int,
@@ -1333,7 +1333,7 @@ async def update_dive_site(
     }
 
 @router.delete("/{dive_site_id}")
-@skip_rate_limit_for_admin("10/minute")
+@skip_rate_limit_for_admin("15/minute")
 async def delete_dive_site(
     request: Request,
     dive_site_id: int,
@@ -1354,7 +1354,7 @@ async def delete_dive_site(
     return {"message": "Dive site deleted successfully"}
 
 @router.post("/{dive_site_id}/rate", response_model=SiteRatingResponse)
-@skip_rate_limit_for_admin("10/minute")
+@skip_rate_limit_for_admin("15/minute")
 async def rate_dive_site(
     request: Request,
     dive_site_id: int,
@@ -1395,7 +1395,7 @@ async def rate_dive_site(
         return db_rating
 
 @router.get("/{dive_site_id}/comments", response_model=List[SiteCommentResponse])
-@skip_rate_limit_for_admin("100/minute")
+@skip_rate_limit_for_admin("150/minute")
 async def get_dive_site_comments(
     request: Request,
     dive_site_id: int,
@@ -1451,7 +1451,7 @@ async def get_dive_site_comments(
     return list(comment_dict.values())
 
 @router.post("/{dive_site_id}/comments", response_model=SiteCommentResponse)
-@skip_rate_limit_for_admin("5/minute")
+@skip_rate_limit_for_admin("8/minute")
 async def create_dive_site_comment(
     request: Request,
     dive_site_id: int,
@@ -1500,7 +1500,7 @@ async def create_dive_site_comment(
     }
 
 @router.get("/{dive_site_id}/nearby", response_model=List[DiveSiteResponse])
-@skip_rate_limit_for_admin("100/minute")
+@skip_rate_limit_for_admin("150/minute")
 async def get_nearby_dive_sites(
     request: Request,
     dive_site_id: int,
@@ -1613,7 +1613,7 @@ async def get_nearby_dive_sites(
     return nearby_sites
 
 @router.get("/{dive_site_id}/dives", response_model=List[DiveResponse])
-@skip_rate_limit_for_admin("100/minute")
+@skip_rate_limit_for_admin("150/minute")
 async def get_dive_site_dives(
     request: Request,
     dive_site_id: int,

--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -12,6 +12,7 @@ primary_region = 'fra'
   ACCESS_TOKEN_EXPIRE_MINUTES = '30'
   ALGORITHM = 'HS256'
   PYTHONPATH = '/app'
+  SUSPICIOUS_PROXY_CHAIN_LENGTH = '6'
 
 [processes]
   app = '/app/startup.sh'

--- a/backend/tests/test_rate_limiting.py
+++ b/backend/tests/test_rate_limiting.py
@@ -29,7 +29,7 @@ class TestRateLimiting:
         with patch('app.limiter.is_localhost_ip', return_value=False):
             # Make multiple requests to a rate-limited endpoint
             responses = []
-            for i in range(15):  # More than the rate limit
+            for i in range(160):  # More than the new rate limit (150/minute)
                 response = client.get("/api/v1/dive-sites/")
                 responses.append(response.status_code)
 
@@ -40,9 +40,9 @@ class TestRateLimiting:
         """Test that auth endpoints are rate limited"""
         # Create a test client that simulates external IP to bypass localhost exemption
         with patch('app.limiter.is_localhost_ip', return_value=False):
-            # Make multiple requests to login endpoints (which have 20/minute limit)
+            # Make multiple requests to login endpoints (which have 30/minute limit)
             responses = []
-            for i in range(25):  # More than the rate limit (20/minute)
+            for i in range(35):  # More than the new rate limit (30/minute)
                 response = client.post("/api/v1/auth/login", json={
                     "username": f"testuser{i}",
                     "password": "TestPassword123!"
@@ -56,9 +56,9 @@ class TestRateLimiting:
         """Test that the register endpoint is rate limited (5/minute limit)"""
         # Create a test client that simulates external IP to bypass localhost exemption
         with patch('app.limiter.is_localhost_ip', return_value=False):
-            # Make multiple requests to register endpoint (which has 5/minute limit)
+            # Make multiple requests to register endpoint (which has 8/minute limit)
             responses = []
-            for i in range(10):  # More than the rate limit (5/minute)
+            for i in range(12):  # More than the new rate limit (8/minute)
                 response = client.post("/api/v1/auth/register", json={
                     "username": f"testuser{i}",
                     "email": f"testuser{i}@example.com",
@@ -70,11 +70,11 @@ class TestRateLimiting:
             assert 429 in responses, "Register endpoint is not rate limited as expected"
 
             # Verify that the first few requests were successful (200 or 400 for duplicate)
-            successful_responses = [r for r in responses[:5] if r in [200, 400]]
+            successful_responses = [r for r in responses[:8] if r in [200, 400]]
             assert len(successful_responses) > 0, "First requests should be successful"
 
             # Verify that later requests were rate limited
-            rate_limited_responses = [r for r in responses[5:] if r == 429]
+            rate_limited_responses = [r for r in responses[8:] if r == 429]
             assert len(rate_limited_responses) > 0, "Later requests should be rate limited"
 
     def test_rate_limiting_with_authentication(self, client, test_user):
@@ -87,7 +87,7 @@ class TestRateLimiting:
         with patch('app.limiter.is_localhost_ip', return_value=False):
             # Make multiple requests to a rate-limited endpoint
             responses = []
-            for i in range(15):  # More than the rate limit
+            for i in range(160):  # More than the new rate limit (150/minute)
                 response = client.get("/api/v1/dive-sites/", headers=headers)
                 responses.append(response.status_code)
 
@@ -100,7 +100,7 @@ class TestRateLimiting:
             from app.limiter import skip_rate_limit_for_admin
 
             # Test that it can be used as a decorator
-            @skip_rate_limit_for_admin("10/minute")
+            @skip_rate_limit_for_admin("15/minute")
             def test_function():
                 return "success"
 

--- a/docs/deployment/fly-io.md
+++ b/docs/deployment/fly-io.md
@@ -706,8 +706,8 @@ No special environment variables are needed for SSL:
 ### Security Features
 
 #### **Rate Limiting**
-- **API endpoints**: 10 requests per second with 20 burst
-- **Login endpoint**: 5 requests per minute with 5 burst
+- **API endpoints**: 15 requests per second with 20 burst
+- **Login endpoint**: 8 requests per minute with 5 burst
 - **Frontend**: No rate limiting (static content)
 
 #### **Security Headers**
@@ -725,6 +725,12 @@ No special environment variables are needed for SSL:
 - **X-Real-IP**: Direct client IP
 - **X-Forwarded-Proto**: Protocol (http/https)
 
+#### **Proxy Chain Configuration**
+- **Production proxy chain**: Cloudflare → Fly.io → nginx → frontend → Fly.io → backend
+- **Expected proxy hops**: 6 IPs in X-Forwarded-For header
+- **Security threshold**: Configured via `SUSPICIOUS_PROXY_CHAIN_LENGTH=6`
+- **Development threshold**: Default 3 IPs for stricter monitoring
+
 ### Integration with Existing Apps
 
 #### **Backend Integration**
@@ -734,6 +740,9 @@ The backend app (`divemap-backend`) should be configured with:
 ```bash
 # CORS origins
 fly secrets set ALLOWED_ORIGINS="https://divemap.gr" -a divemap-backend
+
+# Security configuration for production proxy chain
+fly secrets set SUSPICIOUS_PROXY_CHAIN_LENGTH="6" -a divemap-backend
 
 # Trust proxy headers
 # (Already configured in the backend code)

--- a/docs/development/api.md
+++ b/docs/development/api.md
@@ -1200,18 +1200,18 @@ The API implements comprehensive rate limiting to prevent abuse and ensure fair 
 
 | Endpoint Category | Rate Limit | Description |
 |------------------|------------|-------------|
-| **Dive Sites** | 100/minute | GET requests for dive site listings |
-| **Dive Site Details** | 200/minute | GET requests for individual dive sites |
-| **Dive Site Creation** | 10/minute | POST requests to create dive sites |
-| **Dive Site Updates** | 20/minute | PUT requests to update dive sites |
-| **Dive Site Deletion** | 10/minute | DELETE requests for dive sites |
-| **Dive Site Ratings** | 10/minute | POST requests to rate dive sites |
-| **Dive Site Comments** | 5/minute | POST requests to create comments |
-| **Dive Site Media** | 20/minute | POST/DELETE requests for media |
-| **Diving Centers** | 10/minute | POST requests for diving center operations |
-| **User Registration** | 5/minute | POST requests for user registration |
-| **User Login** | 10/minute | POST requests for authentication |
-| **Google OAuth** | 10/minute | POST requests for Google authentication |
+| **Dive Sites** | 150/minute | GET requests for dive site listings |
+| **Dive Site Details** | 300/minute | GET requests for individual dive sites |
+| **Dive Site Creation** | 15/minute | POST requests to create dive sites |
+| **Dive Site Updates** | 30/minute | PUT requests to update dive sites |
+| **Dive Site Deletion** | 15/minute | DELETE requests for dive sites |
+| **Dive Site Ratings** | 15/minute | POST requests to rate dive sites |
+| **Dive Site Comments** | 8/minute | POST requests to create comments |
+| **Dive Site Media** | 30/minute | POST/DELETE requests for media |
+| **Diving Centers** | 15/minute | POST requests for diving center operations |
+| **User Registration** | 8/minute | POST requests for user registration |
+| **User Login** | 30/minute | POST requests for authentication |
+| **Google OAuth** | 30/minute | POST requests for Google authentication |
 
 ### Rate Limiting Exemptions
 

--- a/docs/development/nginx-proxy-implementation-plan.md
+++ b/docs/development/nginx-proxy-implementation-plan.md
@@ -193,8 +193,8 @@ http {
     }
     
     # Rate limiting
-    limit_req_zone $binary_remote_addr zone=api:10m rate=10r/s;
-    limit_req_zone $binary_remote_addr zone=auth:10m rate=5r/s;
+    limit_req_zone $binary_remote_addr zone=api:10m rate=15r/s;
+    limit_req_zone $binary_remote_addr zone=auth:10m rate=8r/s;
     
     server {
         listen 80;

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -63,13 +63,13 @@ Security is a critical aspect of the Divemap application. This document outlines
 ### 2. Rate Limiting
 
 **Implemented Rate Limits:**
-- Registration: 5 requests/minute
-- Login: 10 requests/minute
-- Search endpoints: 100 requests/minute
-- Individual site access: 200 requests/minute
-- Content creation: 10-20 requests/minute
-- Comment creation: 5 requests/minute
-- Media upload: 20 requests/minute
+- Registration: 8 requests/minute
+- Login: 30 requests/minute
+- Search endpoints: 150 requests/minute
+- Individual site access: 300 requests/minute
+- Content creation: 15-30 requests/minute
+- Comment creation: 8 requests/minute
+- Media upload: 30 requests/minute
 
 **Rate Limiting Exemptions:**
 - **Localhost Requests**: All requests from localhost IPs (127.0.0.1, ::1, localhost) are exempt from rate limiting to facilitate development and testing
@@ -85,6 +85,9 @@ Security is a critical aspect of the Divemap application. This document outlines
 **Client IP Detection System:**
 - Robust client IP detection from various proxy headers (X-Forwarded-For, X-Real-IP, CF-Connecting-IP)
 - Intelligent proxy chain analysis to distinguish normal proxy patterns from suspicious activity
+- Configurable suspicious proxy chain length threshold via `SUSPICIOUS_PROXY_CHAIN_LENGTH` environment variable
+- Production: Set to 6 for Cloudflare + Fly.io + nginx + frontend + backend proxy chain
+- Development: Set to 3 for stricter monitoring in local environments
 - Enhanced security logging for truly suspicious IP patterns while reducing production log noise
 - Support for various CDN configurations (Cloudflare, Fly.io, etc.)
 - Localhost and private IP detection for development and internal network support
@@ -123,7 +126,19 @@ Security is a critical aspect of the Divemap application. This document outlines
 - Credentials support enabled
 - Max age set to 1 hour
 
-### 6. Container Security
+### 6. Environment Configuration
+
+**Security Environment Variables:**
+- `SUSPICIOUS_PROXY_CHAIN_LENGTH`: Configurable threshold for proxy chain monitoring
+  - Production: Set to 6 (Cloudflare + Fly.io + nginx + frontend + backend)
+  - Development: Set to 3 (stricter monitoring for local development)
+- `SECRET_KEY`: JWT signing secret (minimum 32 characters)
+- `ACCESS_TOKEN_EXPIRE_MINUTES`: Short-lived access token duration
+- `REFRESH_TOKEN_EXPIRE_DAYS`: Long-lived refresh token duration
+- `ENABLE_AUDIT_LOGGING`: Enable comprehensive authentication audit logging
+- `MAX_ACTIVE_SESSIONS_PER_USER`: Limit concurrent user sessions
+
+### 7. Container Security
 
 **Docker Security:**
 - `no-new-privileges:true` for all containers

--- a/env.example
+++ b/env.example
@@ -29,6 +29,7 @@ ENVIRONMENT=development
 NODE_ENV=development
 CORS_ORIGINS=http://localhost
 ALLOWED_ORIGINS=http://localhost
+SUSPICIOUS_PROXY_CHAIN_LENGTH=3       # Development: Stricter monitoring for local development
 
 # External Services
 OPENAI_API_KEY=your_openai_api_key_here
@@ -38,11 +39,13 @@ OPENAI_API_KEY=your_openai_api_key_here
 #GOOGLE_CLIENT_SECRET=your_google_client_secret_here
 
 # Production Environment
-ENVIRONMENT=production
-CORS_ORIGINS=https://divemap.gr,https://divemap.fly.dev
-ALLOWED_ORIGINS=https://divemap.gr,https://divemap.fly.dev
-REFRESH_TOKEN_COOKIE_SECURE=true       # HTTPS required in production
-REFRESH_TOKEN_COOKIE_SAMESITE=strict   # Maximum security in production
+#ENVIRONMENT=production
+#CORS_ORIGINS=https://divemap.gr,https://divemap.fly.dev
+#ALLOWED_ORIGINS=https://divemap.gr,https://divemap.fly.dev
+#REFRESH_TOKEN_COOKIE_SECURE=true       # HTTPS required in production
+#REFRESH_TOKEN_COOKIE_SAMESITE=strict   # Maximum security in production
+#SUSPICIOUS_PROXY_CHAIN_LENGTH=6       # Production: Cloudflare + Fly.io + nginx + frontend + backend = ~6 hops
+
 
 # Security Notes:
 # 1. Generate strong passwords using: openssl rand -base64 32

--- a/nginx/prod.conf
+++ b/nginx/prod.conf
@@ -44,8 +44,8 @@ http {
         image/svg+xml;
 
     # Rate limiting
-    limit_req_zone $binary_remote_addr zone=api:10m rate=10r/s;
-    limit_req_zone $binary_remote_addr zone=login:10m rate=5r/m;
+    limit_req_zone $binary_remote_addr zone=api:10m rate=15r/s;
+    limit_req_zone $binary_remote_addr zone=login:10m rate=8r/m;
 
     # Upstream definitions for Fly.io internal addresses
     upstream frontend {


### PR DESCRIPTION
This commit implements two major improvements:

1. Rate Limit Increases (1.5x multiplier):
   - Authentication: Registration 5→8/min, Login 20→30/min, Google OAuth 20→30/min
   - Dive Sites: Search 100→150/min, Details 200→300/min, Creation 10→15/min
   - Content: Updates 20→30/min, Comments 5→8/min, Media 20→30/min
   - Nginx: API zone 10→15r/s, Login zone 5→8r/m

2. Configurable Proxy Chain Security:
   - Add SUSPICIOUS_PROXY_CHAIN_LENGTH environment variable
   - Production: Set to 6 for Cloudflare + Fly.io + nginx + frontend + backend
   - Development: Set to 3 for stricter monitoring
   - Prevents false positive security alerts in production environments

All rate limiting tests updated and verified to work with new limits. Documentation updated across security, API, deployment, and environment files.

Files affected: 11 backend/router files, nginx configs, tests, docs, env.example