### PR TITLE
Fix mobile filter overlay for 354x604 screens

### DIFF
--- a/frontend/src/components/DiveSitesFilterBar.js
+++ b/frontend/src/components/DiveSitesFilterBar.js
@@ -23,13 +23,26 @@ const DiveSitesFilterBar = ({
   // Check if we're on mobile
   useEffect(() => {
     const checkMobile = () => {
-      setIsMobile(window.innerWidth <= 768);
+      // More reliable mobile detection
+      const width = window.innerWidth;
+      const height = window.innerHeight;
+      const userAgent = navigator.userAgent;
+
+      const isMobileDevice =
+        width <= 768 ||
+        /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(userAgent) ||
+        height <= 650; // Force mobile for small height screens
+
+      // Force mobile for very small screens (like 354x604)
+      const forceMobile = width <= 400 || height <= 650;
+
+      setIsMobile(isMobileDevice || forceMobile);
     };
 
     checkMobile();
     window.addEventListener('resize', checkMobile);
     return () => window.removeEventListener('resize', checkMobile);
-  }, []);
+  }, [showFilters, isExpanded]);
 
   // Tag color function - same as in Dives.js
   const getTagColor = tagName => {
@@ -368,14 +381,14 @@ const DiveSitesFilterBar = ({
 
       {/* Mobile: Filter Overlay */}
       {showFilters && isMobile && (
-        <div className='fixed inset-0 z-50 bg-black bg-opacity-50 flex items-end sm:items-center justify-center'>
-          <div className='bg-white w-full h-[85vh] sm:h-auto sm:max-w-md sm:max-h-[80vh] rounded-t-2xl sm:rounded-2xl shadow-2xl overflow-hidden'>
+        <div className='fixed inset-0 z-[60] bg-black bg-opacity-50 flex items-start justify-center'>
+          <div className='bg-white w-full h-screen rounded-none shadow-2xl overflow-hidden filter-overlay-mobile pt-safe pb-safe'>
             {/* Header */}
-            <div className='flex items-center justify-between p-4 border-b border-gray-200 bg-gray-50'>
+            <div className='flex items-center justify-between p-4 border-b border-gray-200 bg-gray-50 header'>
               <h3 className='text-lg font-semibold text-gray-900'>Filters</h3>
               <button
                 onClick={handleToggleFilters}
-                className='p-2 rounded-lg hover:bg-gray-200 transition-colors'
+                className='p-2 rounded-lg hover:bg-gray-200 transition-colors min-h-[44px] min-w-[44px] flex items-center justify-center'
                 aria-label='Close filters'
               >
                 <X className='h-5 w-5 text-gray-600' />
@@ -384,16 +397,16 @@ const DiveSitesFilterBar = ({
 
             {/* Scrollable Content */}
             <div className='flex-1 overflow-y-auto p-4'>
-              <div className='space-y-4'>
+              <div className='space-y-6'>
                 {/* Difficulty Level Filter */}
                 <div>
-                  <label className='block text-sm font-medium text-gray-700 mb-2'>
+                  <label className='block text-sm font-medium text-gray-700 mb-3'>
                     Difficulty Level
                   </label>
                   <select
                     value={filters.difficulty_level || ''}
                     onChange={e => onFilterChange('difficulty_level', e.target.value)}
-                    className='w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm'
+                    className='w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 text-base min-h-[48px]'
                   >
                     <option value=''>All Levels</option>
                     <option value='beginner'>Beginner</option>
@@ -405,7 +418,7 @@ const DiveSitesFilterBar = ({
 
                 {/* Min Rating Filter */}
                 <div>
-                  <label className='block text-sm font-medium text-gray-700 mb-2'>
+                  <label className='block text-sm font-medium text-gray-700 mb-3'>
                     Min Rating (≥)
                   </label>
                   <input
@@ -416,41 +429,39 @@ const DiveSitesFilterBar = ({
                     placeholder='Show sites rated ≥ this value'
                     value={filters.min_rating || ''}
                     onChange={e => onFilterChange('min_rating', e.target.value)}
-                    className='w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm'
+                    className='w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 text-base min-h-[48px]'
                   />
                 </div>
 
                 {/* Country Filter */}
                 <div>
-                  <label className='block text-sm font-medium text-gray-700 mb-2'>Country</label>
+                  <label className='block text-sm font-medium text-gray-700 mb-3'>Country</label>
                   <input
                     type='text'
                     placeholder='Enter country name'
                     value={filters.country || ''}
                     onChange={e => onFilterChange('country', e.target.value)}
-                    className='w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm'
+                    className='w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 text-base min-h-[48px]'
                   />
                 </div>
 
                 {/* Region Filter */}
                 <div>
-                  <label className='block text-xs sm:text-sm font-medium text-gray-700 mb-2'>
-                    Region
-                  </label>
+                  <label className='block text-sm font-medium text-gray-700 mb-3'>Region</label>
                   <input
                     type='text'
                     placeholder='Enter region name'
                     value={filters.region || ''}
                     onChange={e => onFilterChange('region', e.target.value)}
-                    className='w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm'
+                    className='w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 text-base min-h-[48px]'
                   />
                 </div>
 
                 {/* Tags Filter */}
                 {filters.availableTags && filters.availableTags.length > 0 && (
                   <div>
-                    <label className='block text-sm font-medium text-gray-700 mb-2'>Tags</label>
-                    <div className='flex flex-wrap gap-2'>
+                    <label className='block text-sm font-medium text-gray-700 mb-3'>Tags</label>
+                    <div className='flex flex-wrap gap-3 tags-grid'>
                       {filters.availableTags.map(tag => (
                         <button
                           key={tag.id}
@@ -463,7 +474,7 @@ const DiveSitesFilterBar = ({
                               : [...currentTagIds, tagId];
                             onFilterChange('tag_ids', newTagIds);
                           }}
-                          className={`px-3 py-2 rounded-full text-sm font-medium transition-all duration-200 hover:scale-105 ${
+                          className={`px-4 py-3 rounded-full text-sm font-medium transition-all duration-200 hover:scale-105 min-h-[48px] tag-button ${
                             (filters.tag_ids || []).includes(tag.id)
                               ? `${getTagColor(tag.name)} border-2 border-current shadow-md`
                               : `${getTagColor(tag.name)} opacity-60 hover:opacity-100 border-2 border-transparent`
@@ -479,16 +490,16 @@ const DiveSitesFilterBar = ({
             </div>
 
             {/* Footer Actions */}
-            <div className='border-t border-gray-200 p-4 bg-gray-50 flex gap-3'>
+            <div className='border-t border-gray-200 p-4 bg-gray-50 flex gap-3 footer-actions'>
               <button
                 onClick={onClearFilters}
-                className='flex-1 px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors'
+                className='flex-1 px-4 py-3 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors min-h-[48px]'
               >
                 Clear All
               </button>
               <button
                 onClick={handleToggleFilters}
-                className='flex-1 px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 transition-colors'
+                className='flex-1 px-4 py-3 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 transition-colors min-h-[48px]'
               >
                 Apply Filters
               </button>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -8,9 +8,32 @@
   --navbar-height-mobile: 4rem;  /* 64px - matches h-16 */
   --sticky-offset-desktop: calc(var(--navbar-height-desktop) + 0px); /* No gap */
   --sticky-offset-mobile: calc(var(--navbar-height-mobile) + 0px);  /* No gap */
+  
+  /* Safe area variables for modern mobile devices */
+  --safe-area-top: env(safe-area-inset-top, 0px);
+  --safe-area-bottom: env(safe-area-inset-bottom, 0px);
+  --safe-area-left: env(safe-area-inset-left, 0px);
+  --safe-area-right: env(safe-area-inset-right, 0px);
 }
 
 /* Custom styles */
+
+/* Safe Area Utility Classes */
+.pt-safe {
+  padding-top: var(--safe-area-top);
+}
+
+.pb-safe {
+  padding-bottom: var(--safe-area-bottom);
+}
+
+.pl-safe {
+  padding-left: var(--safe-area-left);
+}
+
+.pr-safe {
+  padding-right: var(--safe-area-right);
+}
 
 /* Sticky Positioning for Search and Filters */
 .sticky-below-navbar {
@@ -708,6 +731,231 @@
   .modal {
     margin: 16px;
     max-width: calc(100vw - 32px);
+  }
+}
+
+/* Mobile Filter Overlay Optimizations */
+@media (max-width: 640px) {
+  /* Ensure filter overlay takes full screen on very small devices */
+  .filter-overlay-mobile {
+    height: 100vh !important;
+    height: 100dvh !important; /* Dynamic viewport height for mobile browsers */
+  }
+  
+  /* Optimize form elements for small screens */
+  .filter-overlay-mobile input,
+  .filter-overlay-mobile select,
+  .filter-overlay-mobile button {
+    min-height: 48px;
+    font-size: 16px;
+  }
+  
+  /* Better spacing for small screens */
+  .filter-overlay-mobile .space-y-6 > * + * {
+    margin-top: 1.5rem;
+  }
+  
+  /* Ensure footer actions are always visible */
+  .filter-overlay-mobile .footer-actions {
+    position: sticky;
+    bottom: 0;
+    background: #f9fafb;
+    border-top: 1px solid #e5e7eb;
+    padding: 1rem;
+  }
+}
+
+/* Force mobile overlay for small height screens (like 354x604) */
+@media (max-height: 700px) {
+  .filter-overlay-mobile {
+    position: fixed !important;
+    top: 0 !important;
+    left: 0 !important;
+    width: 100vw !important;
+    height: 100vh !important;
+    height: 100dvh !important;
+    z-index: 1000 !important;
+    background: white !important;
+    overflow-y: auto !important;
+    border-radius: 0 !important;
+    box-shadow: none !important;
+  }
+  
+  /* Ensure all filter content is visible */
+  .filter-overlay-mobile .space-y-6 {
+    padding-bottom: 80px; /* Space for footer actions */
+  }
+  
+  /* Make footer actions sticky at bottom */
+  .filter-overlay-mobile .footer-actions {
+    position: fixed !important;
+    bottom: 0 !important;
+    left: 0 !important;
+    right: 0 !important;
+    background: #f9fafb !important;
+    border-top: 1px solid #e5e7eb !important;
+    padding: 1rem !important;
+    z-index: 1001 !important;
+  }
+}
+
+/* Additional fallback for very small screens */
+@media (max-width: 400px) and (max-height: 700px) {
+  /* Force mobile overlay behavior */
+  .filter-overlay-mobile,
+  .filter-overlay-mobile * {
+    position: relative !important;
+  }
+  
+  /* Ensure proper mobile layout */
+  .filter-overlay-mobile {
+    display: flex !important;
+    flex-direction: column !important;
+    height: 100vh !important;
+    height: 100dvh !important;
+  }
+  
+  /* Make content scrollable */
+  .filter-overlay-mobile .space-y-6 {
+    flex: 1 !important;
+    overflow-y: auto !important;
+    padding-bottom: 100px !important; /* Extra space for footer */
+  }
+}
+
+/* Debug styles to help identify mobile overlay issues */
+.filter-overlay-mobile {
+  /* Ensure mobile overlay is visible */
+  display: block !important;
+  visibility: visible !important;
+  opacity: 1 !important;
+}
+
+/* Force mobile behavior for small screens regardless of JavaScript detection */
+@media (max-width: 768px), (max-height: 700px) {
+  .filter-overlay-mobile {
+    /* Override any inline styles that might prevent mobile overlay */
+    position: fixed !important;
+    top: 0 !important;
+    left: 0 !important;
+    width: 100% !important;
+    height: 100% !important;
+    z-index: 1000 !important;
+    background: white !important;
+    overflow-y: auto !important;
+  }
+}
+
+/* Force mobile overlay for very small screens */
+@media (max-width: 400px), (max-height: 700px) {
+  /* Ensure mobile overlay is always visible on small screens */
+  .filter-overlay-mobile {
+    display: block !important;
+    visibility: visible !important;
+    opacity: 1 !important;
+    position: fixed !important;
+    top: 0 !important;
+    left: 0 !important;
+    width: 100vw !important;
+    height: 100vh !important;
+    height: 100dvh !important;
+    z-index: 1000 !important;
+    background: white !important;
+    overflow-y: auto !important;
+    border-radius: 0 !important;
+    box-shadow: none !important;
+  }
+  
+  /* Hide desktop filters on small screens */
+  .filter-overlay-mobile + .desktop-filters {
+    display: none !important;
+  }
+}
+
+/* Additional mobile overlay styles */
+.filter-overlay-mobile {
+  /* Base mobile overlay styles */
+  background: white;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+/* Ensure mobile overlay is always on top */
+.filter-overlay-mobile {
+  z-index: 1000 !important;
+  position: fixed !important;
+  top: 0 !important;
+  left: 0 !important;
+  width: 100% !important;
+  height: 100% !important;
+}
+
+/* Ultra-small mobile screen optimizations (for screens like 354x604) */
+@media (max-width: 375px) {
+  .filter-overlay-mobile {
+    padding: 0.75rem;
+  }
+  
+  .filter-overlay-mobile .space-y-6 > * + * {
+    margin-top: 1.25rem;
+  }
+  
+  .filter-overlay-mobile input,
+  .filter-overlay-mobile select,
+  .filter-overlay-mobile button {
+    min-height: 44px;
+    padding: 0.75rem 1rem;
+  }
+  
+  .filter-overlay-mobile .tags-grid {
+    gap: 0.5rem;
+  }
+  
+  .filter-overlay-mobile .tag-button {
+    padding: 0.5rem 0.75rem;
+    font-size: 0.875rem;
+  }
+}
+
+/* Extra small mobile screen optimizations (for screens like 354x604) */
+@media (max-width: 360px) {
+  .filter-overlay-mobile {
+    padding: 0.5rem;
+  }
+  
+  .filter-overlay-mobile .space-y-6 > * + * {
+    margin-top: 1rem;
+  }
+  
+  .filter-overlay-mobile input,
+  .filter-overlay-mobile select,
+  .filter-overlay-mobile button {
+    min-height: 40px;
+    padding: 0.5rem 0.75rem;
+    font-size: 14px;
+  }
+  
+  .filter-overlay-mobile .tags-grid {
+    gap: 0.375rem;
+  }
+  
+  .filter-overlay-mobile .tag-button {
+    padding: 0.375rem 0.625rem;
+    font-size: 0.75rem;
+    min-height: 36px;
+  }
+  
+  .filter-overlay-mobile .header h3 {
+    font-size: 1rem;
+  }
+  
+  .filter-overlay-mobile .footer-actions {
+    padding: 0.75rem;
+  }
+  
+  .filter-overlay-mobile .footer-actions button {
+    padding: 0.75rem 1rem;
+    font-size: 0.875rem;
   }
 }
 


### PR DESCRIPTION
- Enhanced mobile detection logic with height-based fallbacks
- Added CSS media queries to force mobile overlay on small screens
- Improved mobile detection using width, height, and user agent
- Added CSS fallbacks for screens <= 650px height and <= 400px width
- Optimized mobile overlay for ultra-small screens (354x604)
- Enhanced touch targets and mobile-specific styling
- Added safe area support for modern mobile devices

Fixes filter overlay not showing completely and navbar gap issues on mobile devices with small screen dimensions.