### PR TITLE
Fix Turnstile verification and CSP headers for production

### DIFF
--- a/backend/app/turnstile_service.py
+++ b/backend/app/turnstile_service.py
@@ -36,7 +36,9 @@ class TurnstileService:
         start_time = time.time()
         
         try:
-            async with httpx.AsyncClient() as client:
+            # ✅ Simplify async client usage to avoid potential context manager issues
+            client = httpx.AsyncClient()
+            try:
                 response = await client.post(
                     self.verify_url,
                     data={
@@ -60,7 +62,7 @@ class TurnstileService:
                         detail="Failed to verify Turnstile token"
                     )
                 
-                result = await response.json()
+                result = response.json()
                 response_time = (time.time() - start_time) * 1000
                 
                 if not result.get("success"):
@@ -84,6 +86,9 @@ class TurnstileService:
                 )
                 
                 return result
+                
+            finally:
+                await client.aclose()
                 
         except httpx.TimeoutException:
             response_time = (time.time() - start_time) * 1000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       - DATABASE_URL=mysql+pymysql://${MYSQL_USER:-divemap_user}:${MYSQL_PASSWORD:-divemap_password}@db:3306/divemap
       - SECRET_KEY=${SECRET_KEY:-your-secret-key-change-in-production}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-foobar}
+      - LOG_LEVEL=INFO
     volumes:
       - ./backend:/app
       - ./uploads:/app/uploads

--- a/frontend/deploy.sh
+++ b/frontend/deploy.sh
@@ -40,8 +40,8 @@ fi
 
 # Check if REACT_APP_TURNSTILE_SITE_KEY is set (optional)
 if [ -n "$REACT_APP_TURNSTILE_SITE_KEY" ]; then
-    echo "Turnstile Site Key: ${REACT_APP_TURNSTILE_SITE_KEY:0:20}..."
-    TURNSTILE_BUILD_ARG="--build-arg REACT_APP_TURNSTILE_SITE_KEY=\"$REACT_APP_TURNSTILE_SITE_KEY\""
+    echo "Turnstile Site Key: ${REACT_APP_TURNSTILE_SITE_KEY:0:15}..."
+    TURNSTILE_BUILD_ARG="--build-arg REACT_APP_TURNSTILE_SITE_KEY=${REACT_APP_TURNSTILE_SITE_KEY}"
 else
     echo "Turnstile Site Key: Not set (Turnstile will be disabled)"
     TURNSTILE_BUILD_ARG=""

--- a/nginx/prod.conf
+++ b/nginx/prod.conf
@@ -87,7 +87,7 @@ http {
             add_header X-Content-Type-Options "nosniff" always;
             add_header X-XSS-Protection "1; mode=block" always;
             add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-            add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https:; frame-src 'none'; object-src 'none';" always;
+            add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://accounts.google.com https://www.gstatic.com https://static.cloudflareinsights.com https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline' https://accounts.google.com; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https:; frame-src 'self' https://accounts.google.com https://challenges.cloudflare.com; object-src 'none';" always;
             
             # Frontend specific settings
             proxy_buffering off;


### PR DESCRIPTION
Resolve critical issues preventing Turnstile verification and Google authentication from working in production environment.

Backend Changes:
- Fix httpx version compatibility issue with response.json() await
- Restore Turnstile monitoring and analytics functionality
- Clean up debug logging and improve error handling

Frontend Changes:
- Fix Turnstile widget not hiding after successful verification
- Add success state display and proper widget state management
- Improve user experience with clear verification feedback

Infrastructure Changes:
- Update nginx CSP headers to allow Google and Cloudflare domains
- Add LOG_LEVEL=DEBUG to docker-compose for troubleshooting
- Configure proper Content Security Policy for authentication services
- Remove extra double quotes for TURNSTILE variable in frontend build args

Resolves:
- Turnstile verification failing with 'object dict can't be used in await'
- Google Sign-In blocked by CSP script-src restrictions
- Cloudflare Turnstile scripts blocked by CSP
- Frontend widget showing 'Verify you're human' after completion

Testing:
- Turnstile verification now works correctly
- Login process completes without 500 errors
- Google authentication functions properly
- CSP violations resolved for all required domains