### PR TITLE
Add login with username or email functionality

### DIFF
--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -45,7 +45,12 @@ def get_password_hash(password: str) -> str:
     return pwd_context.hash(password)
 
 def authenticate_user(db: Session, username: str, password: str) -> Optional[User]:
+    # Try to find user by username first, then by email
     user = db.query(User).filter(User.username == username).first()
+    if not user:
+        # If not found by username, try email
+        user = db.query(User).filter(User.email == username).first()
+    
     if not user:
         return None
     if not verify_password(password, user.password_hash):

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -138,7 +138,7 @@ async def login(
     if not user:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Incorrect username or password",
+            detail="Incorrect username/email or password",
             headers={"WWW-Authenticate": "Bearer"},
         )
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -32,7 +32,7 @@ class UserResponse(UserBase):
         from_attributes = True
 
 class LoginRequest(BaseModel):
-    username: str = Field(..., min_length=1, max_length=50)
+    username: str = Field(..., min_length=1, max_length=255, description="Username or email address")
     password: str = Field(..., min_length=1, max_length=128)
     turnstile_token: Optional[str] = Field(None, description="Cloudflare Turnstile token (required if Turnstile is enabled)")
 

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -396,14 +396,24 @@ class TestAuth:
         assert "User account is disabled" in me_response.json()["detail"]
 
     def test_login_invalid_username(self, client):
-        """Test login with invalid username."""
+        """Test login with invalid username or email."""
         response = client.post("/api/v1/auth/login", json={
             "username": "nonexistent",
             "password": "password"
         })
 
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
-        assert "Incorrect username or password" in response.json()["detail"]
+        assert "Incorrect username/email or password" in response.json()["detail"]
+
+    def test_login_invalid_email(self, client):
+        """Test login with invalid email."""
+        response = client.post("/api/v1/auth/login", json={
+            "username": "nonexistent@example.com",
+            "password": "password"
+        })
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert "Incorrect username/email or password" in response.json()["detail"]
 
     def test_login_invalid_password(self, client, test_user):
         """Test login with invalid password."""
@@ -413,7 +423,31 @@ class TestAuth:
         })
 
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
-        assert "Incorrect username or password" in response.json()["detail"]
+        assert "Incorrect username/email or password" in response.json()["detail"]
+
+    def test_login_with_email(self, client, test_user):
+        """Test login with email instead of username."""
+        response = client.post("/api/v1/auth/login", json={
+            "username": "test@example.com",
+            "password": "TestPass123!"
+        })
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert "access_token" in data
+        assert data["token_type"] == "bearer"
+
+    def test_login_with_username(self, client, test_user):
+        """Test login with username (existing functionality)."""
+        response = client.post("/api/v1/auth/login", json={
+            "username": "testuser",
+            "password": "TestPass123!"
+        })
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert "access_token" in data
+        assert data["token_type"] == "bearer"
 
     def test_login_missing_data(self, client):
         """Test login with missing data."""

--- a/frontend/src/pages/Login.js
+++ b/frontend/src/pages/Login.js
@@ -142,18 +142,21 @@ const Login = () => {
           <div className='space-y-4'>
             <div>
               <label htmlFor='username' className='block text-sm font-medium text-gray-700'>
-                Username
+                Username or Email
               </label>
-              <input
-                id='username'
-                name='username'
-                type='text'
-                required
-                value={formData.username}
-                onChange={handleChange}
-                className='mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-blue-500 focus:border-blue-500 text-sm'
-                placeholder='Enter your username'
-              />
+              <div className='mt-1'>
+                <input
+                  id='username'
+                  name='username'
+                  type='text'
+                  autoComplete='username'
+                  required
+                  className='appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm'
+                  placeholder='Enter your username or email'
+                  value={formData.username}
+                  onChange={handleChange}
+                />
+              </div>
             </div>
 
             <div>


### PR DESCRIPTION
Users can now login using either their username or email address. This improves user experience by providing flexibility in login credentials while maintaining security.

- Modified authenticate_user function to check both username and email
- Updated frontend labels and placeholders to indicate both options
- Enhanced error messages to reflect username/email flexibility
- Added comprehensive tests for both login methods
- Updated schema documentation for clarity

Fixes #17