### PR TITLE
Add My Dives button to quick filters and clean up duplicate buttons

### DIFF
--- a/docs/development/todo.md
+++ b/docs/development/todo.md
@@ -4,6 +4,8 @@
 
 ### High Priority
 
+
+
 #### 1. Complete Nginx Proxy Implementation
 **Status:** In Progress  
 **Priority:** High  

--- a/docs/development/work/2025-08-30-22-14-23-dives-page-mobile-desktop-enhancement/task.md
+++ b/docs/development/work/2025-08-30-22-14-23-dives-page-mobile-desktop-enhancement/task.md
@@ -1,0 +1,103 @@
+# Dives Page Mobile/Desktop Enhancement
+
+**Status:** In Progress
+**Created:** 2025-08-30-22-14-23
+**Started:** 2025-08-30-22-14-23
+**Agent PID:** 763278
+
+## Original Todo
+
+Transform the `/dives` page to match the modern, mobile-first design and user experience of the `/dive-sites` page, improving both mobile and desktop views.
+
+**Tasks:**
+- [ ] Add mobile-first responsive design with touch-optimized controls
+- [ ] Implement sticky filter bar with ResponsiveFilterBar component
+- [ ] Update hero section with three-column layout and mobile-specific styling
+- [ ] Modernize filter system with quick filters and advanced options
+- [ ] Optimize mobile touch targets (44px minimum height)
+- [ ] Implement consistent mobile styling patterns matching dive-sites page
+- [ ] Test mobile responsiveness across different devices
+- [ ] Validate desktop experience with enhanced filter functionality
+
+**Files:** `frontend/src/pages/Dives.js`, `frontend/src/components/HeroSection.js`
+
+## Description
+
+The current `/dives` page has basic mobile responsiveness but lacks the modern, mobile-first design patterns used in the `/dive-sites` page. The page currently uses a traditional form-based filter system that's not optimized for mobile devices, lacks touch-friendly controls, and doesn't have the sticky filter bar experience that provides better UX on both mobile and desktop.
+
+**Current Issues:**
+- Basic mobile filter toggle without mobile-first optimization
+- No sticky filter bar - filters are in a collapsible section
+- Traditional form inputs not optimized for touch devices
+- Missing mobile-specific styling patterns and consistent spacing
+- No quick filter buttons for common dive types
+- Hero section already has three-column layout but needs mobile optimization
+
+**Target State:**
+- Mobile-first responsive design matching dive-sites page
+- Sticky filter bar with ResponsiveFilterBar component
+- Touch-optimized controls with 44px minimum height
+- Quick filter buttons for dive categories (recent, deep, shallow, etc.)
+- Consistent mobile styling patterns and spacing
+- Enhanced desktop experience with advanced filter options
+
+## Success Criteria
+
+- [ ] **Functional**: Mobile-first responsive design works across all device sizes
+- [ ] **Functional**: Sticky filter bar with ResponsiveFilterBar component is fully functional
+- [ ] **Functional**: Quick filter buttons work for common dive types
+- [ ] **Functional**: Touch targets meet 44px minimum height requirement
+- [ ] **Quality**: All existing functionality preserved and working
+- [ ] **Quality**: Code follows project standards (lint, formatting)
+- [ ] **Quality**: Mobile styles object implemented consistently
+- [ ] **User validation**: Mobile responsiveness tested across different viewport sizes
+- [ ] **User validation**: Desktop filter experience enhanced and functional
+- [ ] **Documentation**: Changes reflected in component documentation if applicable
+
+## Implementation Plan
+
+- [x] **Code change**: Add mobileStyles object to Dives component (frontend/src/pages/Dives.js:80-90)
+- [x] **Code change**: Import ResponsiveFilterBar component (frontend/src/pages/Dives.js:30-35)
+- [x] **Code change**: Add useResponsive hook import and usage (frontend/src/pages/Dives.js:30-35)
+- [x] **Code change**: Add quickFilter state and handlers (frontend/src/pages/Dives.js:90-100)
+- [x] **Code change**: Replace existing filter section with ResponsiveFilterBar (frontend/src/pages/Dives.js:800-1000)
+- [x] **Code change**: Update all button components with mobileStyles.touchTarget (frontend/src/pages/Dives.js:750-800)
+- [x] **Code change**: Apply mobileStyles consistently across layout components (frontend/src/pages/Dives.js:750-900)
+- [x] **Code change**: Update mobile filter toggle button with touch optimization (frontend/src/pages/Dives.js:780-790)
+- [x] **Code change**: Implement mobile-specific view mode switching (frontend/src/pages/Dives.js:750-800)
+- [x] **Automated test**: Verify component imports and state management
+- [x] **User test**: Test mobile responsiveness across different viewport sizes
+- [x] **User test**: Validate sticky filter bar functionality on desktop
+- [x] **User test**: Test touch targets on mobile devices
+- [x] **User test**: Verify quick filter functionality works correctly
+
+## Review
+
+- [ ] Bug that needs fixing
+- [ ] Code that needs cleanup
+
+## Notes
+
+**Implementation Complete**: Successfully implemented all code changes for the Dives Page Mobile/Desktop Enhancement:
+
+1. ✅ **Mobile Styles Object**: Added comprehensive mobileStyles object with touch-optimized sizing, mobile-first padding, margins, and responsive patterns
+2. ✅ **ResponsiveFilterBar Integration**: Replaced traditional filter system with modern ResponsiveFilterBar component featuring sticky positioning and mobile optimization
+3. ✅ **Quick Filter System**: Implemented quick filter functionality with handlers for recent, deep, and shallow dive filtering
+4. ✅ **Touch Optimization**: Applied 44px minimum height touch targets to all interactive elements (buttons, pagination controls)
+5. ✅ **Mobile-First Layout**: Updated container layouts, hero section buttons, and component spacing to use mobile-first responsive patterns
+6. ✅ **Code Quality**: Cleaned up unused imports, verified all component dependencies, and ensured syntax validation passes
+
+**Playwright Testing Results**: All functionality tested and working correctly:
+
+1. ✅ **ResponsiveFilterBar Appears on Scroll**: Component appears when scrolling down, providing sticky filter experience
+2. ✅ **Quick Filters Functional**: 🚢 Wreck, 🐠 Reef, 🚤 Boat, 🏖️ Shore buttons working correctly
+3. ✅ **Search Functionality**: Search input working with proper filtering (tested with "kalopigado")
+4. ✅ **Filter Panel Toggle**: Advanced filters panel opens/closes correctly with comprehensive options
+5. ✅ **View Mode Switching**: List/Map view switching working (tested Map view successfully)
+6. ✅ **Mobile Responsiveness**: Component adapts correctly to both desktop (1920x1080) and mobile (375x667) viewports
+7. ✅ **Touch Targets**: All interactive elements properly sized for mobile touch interaction
+8. ✅ **Sorting & Display Options**: Sort field, sort order, and display options (thumbnails, compact) all functional
+
+**Key Finding**: The ResponsiveFilterBar is designed to appear on scroll, not by default, which provides an excellent user experience by keeping the hero section clean while making filters easily accessible when needed.
+
+All code changes compile successfully without errors and all functionality has been validated through comprehensive testing.

--- a/frontend/src/components/ResponsiveFilterBar.js
+++ b/frontend/src/components/ResponsiveFilterBar.js
@@ -44,6 +44,8 @@ const ResponsiveFilterBar = ({
   showThumbnails = false,
   compactLayout = false,
   onDisplayOptionChange = () => {},
+  // New prop for page-specific quick filters
+  pageType = 'dive-sites',
 }) => {
   const { isMobile, navbarVisible, searchBarVisible, quickFiltersVisible } = useResponsiveScroll();
   const [isExpanded, setIsExpanded] = useState(false);
@@ -217,50 +219,115 @@ const ResponsiveFilterBar = ({
           {/* Quick Filters */}
           {showQuickFilters && (
             <div className='flex items-center gap-2 sm:ml-2 w-full sm:w-auto justify-center sm:justify-end'>
-              <button
-                onClick={() => onQuickFilter('wrecks')}
-                className={`flex items-center gap-1 px-3 py-2 text-sm rounded-md transition-colors ${
-                  quickFilter === 'wrecks'
-                    ? 'bg-blue-100 text-blue-700 border border-blue-300 shadow-sm'
-                    : 'bg-gray-50 text-gray-600 border border-gray-200 hover:bg-gray-100 active:bg-gray-200'
-                }`}
-                title='Wreck dive sites'
-              >
-                🚢 <span className='hidden sm:inline'>Wreck</span>
-              </button>
-              <button
-                onClick={() => onQuickFilter('reefs')}
-                className={`flex items-center gap-1 px-3 py-2 text-sm rounded-md transition-colors ${
-                  quickFilter === 'reefs'
-                    ? 'bg-blue-100 text-blue-700 border border-blue-300 shadow-sm'
-                    : 'bg-gray-50 text-gray-600 border border-gray-200 hover:bg-gray-100 active:bg-gray-200'
-                }`}
-                title='Reef dive sites'
-              >
-                🐠 <span className='hidden sm:inline'>Reef</span>
-              </button>
-              <button
-                onClick={() => onQuickFilter('boat_dive')}
-                className={`flex items-center gap-1 px-3 py-2 text-sm rounded-md transition-colors ${
-                  quickFilter === 'boat_dive'
-                    ? 'bg-blue-100 text-blue-700 border border-blue-300 shadow-sm'
-                    : 'bg-gray-50 text-gray-600 border border-gray-200 hover:bg-gray-100 active:bg-gray-200'
-                }`}
-                title='Boat dive sites'
-              >
-                🚤 <span className='hidden sm:inline'>Boat</span>
-              </button>
-              <button
-                onClick={() => onQuickFilter('shore_dive')}
-                className={`flex items-center gap-1 px-3 py-2 text-sm rounded-md transition-colors ${
-                  quickFilter === 'shore_dive'
-                    ? 'bg-blue-100 text-blue-700 border border-blue-300 shadow-sm'
-                    : 'bg-gray-50 text-gray-600 border border-gray-200 hover:bg-gray-100 active:bg-gray-200'
-                }`}
-                title='Shore dive sites'
-              >
-                🏖️ <span className='hidden sm:inline'>Shore</span>
-              </button>
+              {/* Page-specific quick filters */}
+              {pageType === 'dives' ? (
+                // Dives page quick filters
+                <>
+                  <button
+                    onClick={() => onQuickFilter('my_dives')}
+                    className={`flex items-center gap-1 px-3 py-2 text-sm rounded-md transition-colors ${
+                      quickFilter === 'my_dives'
+                        ? 'bg-blue-100 text-blue-700 border border-blue-300 shadow-sm'
+                        : 'bg-gray-50 text-gray-600 border border-gray-200 hover:bg-gray-100 active:bg-gray-200'
+                    }`}
+                    title='My Dives'
+                  >
+                    👤 <span className='hidden sm:inline'>My Dives</span>
+                  </button>
+                  <button
+                    onClick={() => onQuickFilter('wrecks')}
+                    className={`flex items-center gap-1 px-3 py-2 text-sm rounded-md transition-colors ${
+                      quickFilter === 'wrecks'
+                        ? 'bg-blue-100 text-blue-700 border border-blue-300 shadow-sm'
+                        : 'bg-gray-50 text-gray-600 border border-gray-200 hover:bg-gray-100 active:bg-gray-200'
+                    }`}
+                    title='Wreck dives'
+                  >
+                    🚢 <span className='hidden sm:inline'>Wreck</span>
+                  </button>
+                  <button
+                    onClick={() => onQuickFilter('reefs')}
+                    className={`flex items-center gap-1 px-3 py-2 text-sm rounded-md transition-colors ${
+                      quickFilter === 'reefs'
+                        ? 'bg-blue-100 text-blue-700 border border-blue-300 shadow-sm'
+                        : 'bg-gray-50 text-gray-600 border border-gray-200 hover:bg-gray-100 active:bg-gray-200'
+                    }`}
+                    title='Reef dives'
+                  >
+                    🐠 <span className='hidden sm:inline'>Reef</span>
+                  </button>
+                  <button
+                    onClick={() => onQuickFilter('boat_dive')}
+                    className={`flex items-center gap-1 px-3 py-2 text-sm rounded-md transition-colors ${
+                      quickFilter === 'boat_dive'
+                        ? 'bg-blue-100 text-blue-700 border border-blue-300 shadow-sm'
+                        : 'bg-gray-50 text-gray-600 border border-gray-200 hover:bg-gray-100 active:bg-gray-200'
+                    }`}
+                    title='Boat dives'
+                  >
+                    🚤 <span className='hidden sm:inline'>Boat</span>
+                  </button>
+                  <button
+                    onClick={() => onQuickFilter('shore_dive')}
+                    className={`flex items-center gap-1 px-3 py-2 text-sm rounded-md transition-colors ${
+                      quickFilter === 'shore_dive'
+                        ? 'bg-blue-100 text-blue-700 border border-blue-300 shadow-sm'
+                        : 'bg-gray-50 text-gray-600 border border-gray-200 hover:bg-gray-100 active:bg-gray-200'
+                    }`}
+                    title='Shore dives'
+                  >
+                    🏖️ <span className='hidden sm:inline'>Shore</span>
+                  </button>
+                </>
+              ) : (
+                // Default dive-sites quick filters
+                <>
+                  <button
+                    onClick={() => onQuickFilter('wrecks')}
+                    className={`flex items-center gap-1 px-3 py-2 text-sm rounded-md transition-colors ${
+                      quickFilter === 'wrecks'
+                        ? 'bg-blue-100 text-blue-700 border border-blue-300 shadow-sm'
+                        : 'bg-gray-50 text-gray-600 border border-gray-200 hover:bg-gray-100 active:bg-gray-200'
+                    }`}
+                    title='Wreck dive sites'
+                  >
+                    🚢 <span className='hidden sm:inline'>Wreck</span>
+                  </button>
+                  <button
+                    onClick={() => onQuickFilter('reefs')}
+                    className={`flex items-center gap-1 px-3 py-2 text-sm rounded-md transition-colors ${
+                      quickFilter === 'reefs'
+                        ? 'bg-blue-100 text-blue-700 border border-blue-300 shadow-sm'
+                        : 'bg-gray-50 text-gray-600 border border-gray-200 hover:bg-gray-100 active:bg-gray-200'
+                    }`}
+                    title='Reef dive sites'
+                  >
+                    🐠 <span className='hidden sm:inline'>Reef</span>
+                  </button>
+                  <button
+                    onClick={() => onQuickFilter('boat_dive')}
+                    className={`flex items-center gap-1 px-3 py-2 text-sm rounded-md transition-colors ${
+                      quickFilter === 'boat_dive'
+                        ? 'bg-blue-100 text-blue-700 border border-blue-300 shadow-sm'
+                        : 'bg-gray-50 text-gray-600 border border-gray-200 hover:bg-gray-100 active:bg-gray-200'
+                    }`}
+                    title='Boat dive sites'
+                  >
+                    🚤 <span className='hidden sm:inline'>Boat</span>
+                  </button>
+                  <button
+                    onClick={() => onQuickFilter('shore_dive')}
+                    className={`flex items-center gap-1 px-3 py-2 text-sm rounded-md transition-colors ${
+                      quickFilter === 'shore_dive'
+                        ? 'bg-blue-100 text-blue-700 border border-blue-300 shadow-sm'
+                        : 'bg-gray-50 text-gray-600 border border-gray-200 hover:bg-gray-100 active:bg-gray-200'
+                    }`}
+                    title='Shore dive sites'
+                  >
+                    🏖️ <span className='hidden sm:inline'>Shore</span>
+                  </button>
+                </>
+              )}
             </div>
           )}
 
@@ -596,46 +663,115 @@ const ResponsiveFilterBar = ({
 
             {/* Quick Filter Buttons */}
             <div className='flex items-center gap-2 overflow-x-auto flex-1 ml-3'>
-              <button
-                onClick={() => onQuickFilter('wrecks')}
-                className={`flex-shrink-0 px-3 py-2 text-sm rounded-lg transition-colors min-h-[44px] ${
-                  quickFilter === 'wrecks'
-                    ? 'bg-blue-100 text-blue-700 border border-blue-300'
-                    : 'bg-gray-100 text-gray-600 border border-gray-200 hover:bg-gray-200'
-                }`}
-              >
-                🚢
-              </button>
-              <button
-                onClick={() => onQuickFilter('reefs')}
-                className={`flex-shrink-0 px-3 py-2 text-sm rounded-lg transition-colors min-h-[44px] ${
-                  quickFilter === 'reefs'
-                    ? 'bg-blue-100 text-blue-700 border border-blue-300'
-                    : 'bg-gray-100 text-gray-600 border border-gray-200 hover:bg-gray-200'
-                }`}
-              >
-                🐠
-              </button>
-              <button
-                onClick={() => onQuickFilter('boat_dive')}
-                className={`flex-shrink-0 px-3 py-2 text-sm rounded-lg transition-colors min-h-[44px] ${
-                  quickFilter === 'boat_dive'
-                    ? 'bg-blue-100 text-blue-700 border border-blue-300'
-                    : 'bg-gray-100 text-gray-600 border border-gray-200 hover:bg-gray-200'
-                }`}
-              >
-                🚤
-              </button>
-              <button
-                onClick={() => onQuickFilter('shore_dive')}
-                className={`flex-shrink-0 px-3 py-2 text-sm rounded-lg transition-colors min-h-[44px] ${
-                  quickFilter === 'shore_dive'
-                    ? 'bg-blue-100 text-blue-700 border border-blue-300'
-                    : 'bg-gray-100 text-gray-600 border border-gray-200 hover:bg-gray-200'
-                }`}
-              >
-                🏖️
-              </button>
+              {/* Page-specific mobile quick filters */}
+              {pageType === 'dives' ? (
+                // Dives page mobile quick filters
+                <>
+                  <button
+                    onClick={() => onQuickFilter('my_dives')}
+                    className={`flex-shrink-0 px-3 py-2 text-sm rounded-lg transition-colors min-h-[44px] ${
+                      quickFilter === 'my_dives'
+                        ? 'bg-blue-100 text-blue-700 border border-blue-300'
+                        : 'bg-gray-100 text-gray-600 border border-gray-200 hover:bg-gray-200'
+                    }`}
+                    title='My Dives'
+                  >
+                    👤
+                  </button>
+                  <button
+                    onClick={() => onQuickFilter('wrecks')}
+                    className={`flex-shrink-0 px-3 py-2 text-sm rounded-lg transition-colors min-h-[44px] ${
+                      quickFilter === 'wrecks'
+                        ? 'bg-blue-100 text-blue-700 border border-blue-300'
+                        : 'bg-gray-100 text-gray-600 border border-gray-200 hover:bg-gray-200'
+                    }`}
+                    title='Wreck dives'
+                  >
+                    🚢
+                  </button>
+                  <button
+                    onClick={() => onQuickFilter('reefs')}
+                    className={`flex-shrink-0 px-3 py-2 text-sm rounded-lg transition-colors min-h-[44px] ${
+                      quickFilter === 'reefs'
+                        ? 'bg-blue-100 text-blue-700 border border-blue-300'
+                        : 'bg-gray-100 text-gray-600 border border-gray-200 hover:bg-gray-200'
+                    }`}
+                    title='Wreck dives'
+                  >
+                    🐠
+                  </button>
+                  <button
+                    onClick={() => onQuickFilter('boat_dive')}
+                    className={`flex-shrink-0 px-3 py-2 text-sm rounded-lg transition-colors min-h-[44px] ${
+                      quickFilter === 'boat_dive'
+                        ? 'bg-blue-100 text-blue-700 border border-blue-300'
+                        : 'bg-gray-100 text-gray-600 border border-gray-200 hover:bg-gray-200'
+                    }`}
+                    title='Boat dives'
+                  >
+                    🚤
+                  </button>
+                  <button
+                    onClick={() => onQuickFilter('shore_dive')}
+                    className={`flex-shrink-0 px-3 py-2 text-sm rounded-lg transition-colors min-h-[44px] ${
+                      quickFilter === 'shore_dive'
+                        ? 'bg-blue-100 text-blue-700 border border-blue-300'
+                        : 'bg-gray-100 text-gray-600 border border-gray-200 hover:bg-gray-200'
+                    }`}
+                    title='Shore dives'
+                  >
+                    🏖️
+                  </button>
+                </>
+              ) : (
+                // Default dive-sites mobile quick filters
+                <>
+                  <button
+                    onClick={() => onQuickFilter('wrecks')}
+                    className={`flex-shrink-0 px-3 py-2 text-sm rounded-lg transition-colors min-h-[44px] ${
+                      quickFilter === 'wrecks'
+                        ? 'bg-blue-100 text-blue-700 border border-blue-300'
+                        : 'bg-gray-100 text-gray-600 border border-gray-200 hover:bg-gray-200'
+                    }`}
+                    title='Wreck dive sites'
+                  >
+                    🚢
+                  </button>
+                  <button
+                    onClick={() => onQuickFilter('reefs')}
+                    className={`flex-shrink-0 px-3 py-2 text-sm rounded-lg transition-colors min-h-[44px] ${
+                      quickFilter === 'reefs'
+                        ? 'bg-blue-100 text-blue-700 border border-blue-300'
+                        : 'bg-gray-100 text-gray-600 border border-gray-200 hover:bg-gray-200'
+                    }`}
+                    title='Reef dive sites'
+                  >
+                    🐠
+                  </button>
+                  <button
+                    onClick={() => onQuickFilter('boat_dive')}
+                    className={`flex-shrink-0 px-3 py-2 text-sm rounded-lg transition-colors min-h-[44px] ${
+                      quickFilter === 'boat_dive'
+                        ? 'bg-blue-100 text-blue-700 border border-blue-300'
+                        : 'bg-gray-100 text-gray-600 border border-gray-200 hover:bg-gray-200'
+                    }`}
+                    title='Boat dive sites'
+                  >
+                    🚤
+                  </button>
+                  <button
+                    onClick={() => onQuickFilter('shore_dive')}
+                    className={`flex-shrink-0 px-3 py-2 text-sm rounded-lg transition-colors min-h-[44px] ${
+                      quickFilter === 'shore_dive'
+                        ? 'bg-blue-100 text-blue-700 border border-blue-300'
+                        : 'bg-gray-100 text-gray-600 border border-gray-200 hover:bg-gray-200'
+                    }`}
+                    title='Shore dive sites'
+                  >
+                    🏖️
+                  </button>
+                </>
+              )}
             </div>
           </div>
         </div>
@@ -965,6 +1101,8 @@ ResponsiveFilterBar.propTypes = {
   showThumbnails: PropTypes.bool,
   compactLayout: PropTypes.bool,
   onDisplayOptionChange: PropTypes.func,
+  // New prop for page-specific quick filters
+  pageType: PropTypes.string,
 };
 
 export default ResponsiveFilterBar;


### PR DESCRIPTION
This commit implements page-specific quick filters in ResponsiveFilterBar and cleans up duplicate action buttons on the dives page.

**ResponsiveFilterBar Component Changes:**
- Add pageType prop for page-specific quick filter customization
- Implement conditional rendering for dives vs dive-sites quick filters
- Add My Dives button (👤) as first quick filter for dives page
- Maintain backward compatibility for existing pages

**Dives Page Changes:**
- Remove duplicate My Dives toggle button below pagination
- Remove duplicate Import Dives and Log New Dive buttons below pagination
- Clean up unused handleMyDivesToggle function
- Update handleQuickFilter to handle new filter types including my_dives
- Pass pageType='dives' to ResponsiveFilterBar

**Quick Filter Layout:**
- Dives page: 👤 My Dives, 🚢 Wreck, 🐠 Reef, 🚤 Boat, 🏖️ Shore
- Dive-sites page: 🚢 Wreck, 🐠 Reef, 🚤 Boat, 🏖️ Shore (unchanged)

**Benefits:**
- Eliminates button duplication and improves UI consistency
- Centralizes My Dives functionality in quick filter bar
- Maintains responsive design for both desktop and mobile
- Preserves all existing functionality for other pages

All changes have been tested and verified to work correctly across different viewport sizes and maintain backward compatibility.