### PR TITLE
Fix difficulty level validation in dive and dive site editing

### DIFF
--- a/frontend/src/pages/EditDive.js
+++ b/frontend/src/pages/EditDive.js
@@ -13,6 +13,7 @@ import {
   getDivingCenters,
 } from '../api';
 import { useAuth } from '../contexts/AuthContext';
+import { getDifficultyValue } from '../utils/difficultyHelpers';
 
 const EditDive = () => {
   const { id } = useParams();
@@ -308,7 +309,7 @@ const EditDive = () => {
       suit_type: formData.suit_type && formData.suit_type !== '' ? formData.suit_type : null,
       difficulty_level:
         formData.difficulty_level && formData.difficulty_level !== ''
-          ? formData.difficulty_level
+          ? getDifficultyValue(formData.difficulty_level)
           : null,
       visibility_rating: formData.visibility_rating ? parseInt(formData.visibility_rating) : null,
       user_rating: formData.user_rating ? parseInt(formData.user_rating) : null,

--- a/frontend/src/pages/EditDiveSite.js
+++ b/frontend/src/pages/EditDiveSite.js
@@ -7,6 +7,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import api from '../api';
 import { useAuth } from '../contexts/AuthContext';
 import { getCurrencyOptions, DEFAULT_CURRENCY, formatCost } from '../utils/currency';
+import { getDifficultyValue } from '../utils/difficultyHelpers';
 
 // Helper function to safely extract error message
 const getErrorMessage = error => {
@@ -402,6 +403,13 @@ const EditDiveSite = () => {
       updateData.max_depth = parseFloat(formData.max_depth);
     } else {
       updateData.max_depth = null;
+    }
+
+    // Convert difficulty_level to integer if provided, or set to null if empty
+    if (formData.difficulty_level && formData.difficulty_level.trim() !== '') {
+      updateData.difficulty_level = getDifficultyValue(formData.difficulty_level);
+    } else {
+      updateData.difficulty_level = null;
     }
 
     // Update the dive site first


### PR DESCRIPTION
Add proper string-to-integer conversion for difficulty_level field in EditDive and EditDiveSite components to prevent 422 validation errors when updating dives and dive sites.

- Import getDifficultyValue utility function in both components
- Convert difficulty_level from string labels to integer values
- Ensure backend schema validation requirements are met

Fixes validation errors when editing dive difficulty levels and dive site difficulty levels in the frontend forms.