### PR TITLE
Fix dive list rating display and implement consistent tag colors

### DIFF
--- a/frontend/src/pages/DiveSiteDetail.js
+++ b/frontend/src/pages/DiveSiteDetail.js
@@ -22,6 +22,7 @@ import { useAuth } from '../contexts/AuthContext';
 import { formatCost, DEFAULT_CURRENCY } from '../utils/currency';
 import { getDifficultyLabel, getDifficultyColorClasses } from '../utils/difficultyHelpers';
 import { handleRateLimitError } from '../utils/rateLimitHandler';
+import { getTagColor } from '../utils/tagHelpers';
 
 // Helper function to safely extract error message
 const getErrorMessage = error => {
@@ -480,7 +481,7 @@ const DiveSiteDetail = () => {
                         {dive.tags.map(tag => (
                           <span
                             key={tag.id}
-                            className='px-2 py-1 bg-gray-100 text-gray-700 text-xs rounded-full'
+                            className={`px-2 py-1 text-xs rounded-full ${getTagColor(tag.name)}`}
                           >
                             {tag.name}
                           </span>
@@ -835,7 +836,7 @@ const DiveSiteDetail = () => {
                 {diveSite.tags.map(tag => (
                   <span
                     key={tag.id}
-                    className='px-3 py-1 bg-blue-100 text-blue-800 rounded-full text-sm font-medium'
+                    className={`px-3 py-1 rounded-full text-sm font-medium ${getTagColor(tag.name)}`}
                   >
                     {tag.name}
                   </span>

--- a/frontend/src/pages/DiveSites.js
+++ b/frontend/src/pages/DiveSites.js
@@ -31,6 +31,7 @@ import useSorting from '../hooks/useSorting';
 import { getDifficultyLabel, getDifficultyColorClasses } from '../utils/difficultyHelpers';
 import { handleRateLimitError } from '../utils/rateLimitHandler';
 import { getSortOptions } from '../utils/sortOptions';
+import { getTagColor } from '../utils/tagHelpers';
 
 const DiveSites = () => {
   const { user, isAdmin } = useAuth();
@@ -783,20 +784,7 @@ const DiveSites = () => {
             </div>
           </div>
 
-          {/* Action Buttons - Mobile-first responsive design */}
-          <div className='flex flex-col sm:flex-row justify-center sm:justify-end items-center mb-4 sm:mb-6 gap-3 sm:gap-4'>
-            {user && (
-              <div className='flex flex-col sm:flex-row gap-3 w-full sm:w-auto'>
-                <button
-                  onClick={() => navigate('/dive-sites/create')}
-                  className='bg-green-600 hover:bg-green-700 active:bg-green-800 text-white px-4 py-3 sm:py-2 rounded-lg flex items-center justify-center gap-2 text-sm sm:text-base font-medium shadow-sm transition-all duration-200 hover:shadow-md active:shadow-inner min-h-[44px] sm:min-h-0 touch-manipulation w-full sm:w-auto'
-                >
-                  <Plus size={20} />
-                  Create Dive Site
-                </button>
-              </div>
-            )}
-          </div>
+
 
           {/* Results Section - Mobile-first responsive design */}
           {/* Dive Sites List - Show when data is available and viewMode is list */}
@@ -936,7 +924,7 @@ const DiveSites = () => {
                       {site.tags.slice(0, 3).map((tag, index) => (
                         <span
                           key={index}
-                          className='inline-flex items-center px-1.5 py-0.5 text-xs font-medium bg-blue-100 text-blue-800 rounded'
+                          className={`inline-flex items-center px-1.5 py-0.5 text-xs font-medium rounded ${getTagColor(tag.name || tag)}`}
                         >
                           {tag.name || tag}
                         </span>

--- a/frontend/src/pages/Dives.js
+++ b/frontend/src/pages/Dives.js
@@ -37,6 +37,7 @@ import useSorting from '../hooks/useSorting';
 import { getDifficultyLabel, getDifficultyColorClasses } from '../utils/difficultyHelpers';
 import { handleRateLimitError } from '../utils/rateLimitHandler';
 import { getSortOptions } from '../utils/sortOptions';
+import { getTagColor } from '../utils/tagHelpers';
 
 const Dives = () => {
   const { user, isAdmin } = useAuth();
@@ -768,69 +769,7 @@ const Dives = () => {
     return colors[type] || 'bg-gray-100 text-gray-800';
   };
 
-  const getTagColor = tagName => {
-    // Create a consistent color mapping based on tag name
-    const colorMap = {
-      beginner: 'bg-green-100 text-green-800',
-      intermediate: 'bg-yellow-100 text-yellow-800',
-      advanced: 'bg-orange-100 text-orange-800',
-      expert: 'bg-red-100 text-red-800',
-      deep: 'bg-blue-100 text-blue-800',
-      shallow: 'bg-cyan-100 text-cyan-800',
-      wreck: 'bg-purple-100 text-purple-800',
-      reef: 'bg-emerald-100 text-emerald-800',
-      cave: 'bg-indigo-100 text-indigo-800',
-      wall: 'bg-slate-100 text-slate-800',
-      drift: 'bg-teal-100 text-teal-800',
-      night: 'bg-violet-100 text-violet-800',
-      photography: 'bg-pink-100 text-pink-800',
-      marine: 'bg-cyan-100 text-cyan-800',
-      training: 'bg-amber-100 text-amber-800',
-      tech: 'bg-red-100 text-red-800',
-      boat: 'bg-blue-100 text-blue-800',
-      shore: 'bg-green-100 text-green-800',
-    };
 
-    // Try exact match first
-    const lowerTagName = tagName.toLowerCase();
-    if (colorMap[lowerTagName]) {
-      return colorMap[lowerTagName];
-    }
-
-    // Try partial matches
-    for (const [key, color] of Object.entries(colorMap)) {
-      if (lowerTagName.includes(key) || key.includes(lowerTagName)) {
-        return color;
-      }
-    }
-
-    // Default color scheme based on hash of tag name
-    const colors = [
-      'bg-blue-100 text-blue-800',
-      'bg-green-100 text-green-800',
-      'bg-yellow-100 text-yellow-800',
-      'bg-orange-100 text-orange-800',
-      'bg-red-100 text-red-800',
-      'bg-purple-100 text-purple-800',
-      'bg-pink-100 text-pink-800',
-      'bg-indigo-100 text-indigo-800',
-      'bg-cyan-100 text-cyan-800',
-      'bg-teal-100 text-teal-800',
-      'bg-emerald-100 text-emerald-800',
-      'bg-amber-100 text-amber-800',
-      'bg-violet-100 text-violet-800',
-      'bg-slate-100 text-slate-800',
-    ];
-
-    // Simple hash function for consistent color assignment
-    let hash = 0;
-    for (let i = 0; i < tagName.length; i++) {
-      hash = (hash << 5) - hash + tagName.charCodeAt(i);
-      hash = hash & hash; // Convert to 32-bit integer
-    }
-
-    return colors[Math.abs(hash) % colors.length];
-  };
 
   if (error) {
     return (
@@ -1129,11 +1068,30 @@ const Dives = () => {
                     </div>
                   </div>
 
-                  <div className='flex items-center gap-4 mb-4'>
+                  <div className='flex items-center justify-between mb-4'>
                     <div className='flex items-center gap-2'>
                       <Star className='w-4 h-4 text-yellow-400' />
-                      <span className='text-sm text-gray-600'>{dive.rating}/10</span>
+                      <span className='text-sm text-gray-600'>{dive.user_rating}/10</span>
                     </div>
+                    
+                    {/* Tags */}
+                    {dive.tags && dive.tags.length > 0 && (
+                      <div className='flex flex-wrap gap-1'>
+                        {dive.tags.slice(0, 4).map(tag => (
+                          <span
+                            key={tag.id}
+                            className={`inline-flex items-center px-2 py-1 text-xs font-medium rounded-full ${getTagColor(tag.name)}`}
+                          >
+                            {tag.name}
+                          </span>
+                        ))}
+                        {dive.tags.length > 4 && (
+                          <span className='inline-flex items-center px-2 py-1 text-xs font-medium bg-gray-100 text-gray-600 rounded-full'>
+                            +{dive.tags.length - 4}
+                          </span>
+                        )}
+                      </div>
+                    )}
                   </div>
 
                   <p className={`text-gray-700 ${compactLayout ? 'text-sm' : 'text-base'}`}>
@@ -1209,10 +1167,32 @@ const Dives = () => {
                         <Clock className='w-4 h-4 text-gray-400' />
                         <span className='text-sm text-gray-600'>{dive.duration}min</span>
                       </div>
+                    </div>
+
+                    <div className='flex items-center justify-between mb-4'>
                       <div className='flex items-center gap-2'>
                         <Star className='w-4 h-4 text-yellow-400' />
-                        <span className='text-sm text-gray-600'>{dive.rating}/10</span>
+                        <span className='text-sm text-gray-600'>{dive.user_rating}/10</span>
                       </div>
+                      
+                      {/* Tags */}
+                      {dive.tags && dive.tags.length > 0 && (
+                        <div className='flex flex-wrap gap-1'>
+                          {dive.tags.slice(0, 2).map(tag => (
+                            <span
+                              key={tag.id}
+                              className={`inline-flex items-center px-2 py-1 text-xs font-medium rounded-full ${getTagColor(tag.name)}`}
+                            >
+                              {tag.name}
+                            </span>
+                          ))}
+                          {dive.tags.length > 2 && (
+                            <span className='inline-flex items-center px-2 py-1 text-xs font-medium bg-gray-100 text-gray-600 rounded-full'>
+                              +{dive.tags.length - 2}
+                            </span>
+                          )}
+                        </div>
+                      )}
                     </div>
 
                     <Link

--- a/frontend/src/utils/tagHelpers.js
+++ b/frontend/src/utils/tagHelpers.js
@@ -1,0 +1,74 @@
+/**
+ * Tag Color Utility Functions
+ * 
+ * Provides consistent tag color mapping across the application
+ * to ensure visual consistency between filter tags and display tags.
+ */
+
+/**
+ * Get color classes for a tag based on its name
+ * @param {string} tagName - The name of the tag
+ * @returns {string} Tailwind CSS color classes
+ */
+export const getTagColor = tagName => {
+  // Create a consistent color mapping based on tag name
+  const colorMap = {
+    beginner: 'bg-green-100 text-green-800',
+    intermediate: 'bg-yellow-100 text-yellow-800',
+    advanced: 'bg-orange-100 text-orange-800',
+    expert: 'bg-red-100 text-red-800',
+    deep: 'bg-indigo-100 text-indigo-800',
+    shallow: 'bg-cyan-100 text-cyan-800',
+    wreck: 'bg-purple-100 text-purple-800',
+    reef: 'bg-emerald-100 text-emerald-800',
+    cave: 'bg-indigo-100 text-indigo-800',
+    wall: 'bg-slate-100 text-slate-800',
+    drift: 'bg-teal-100 text-teal-800',
+    night: 'bg-violet-100 text-violet-800',
+    photography: 'bg-pink-100 text-pink-800',
+    marine: 'bg-cyan-100 text-cyan-800',
+    training: 'bg-amber-100 text-amber-800',
+    tech: 'bg-red-100 text-red-800',
+    boat: 'bg-blue-100 text-blue-800',
+    shore: 'bg-green-100 text-green-800',
+  };
+
+  // Try exact match first
+  const lowerTagName = tagName.toLowerCase();
+  if (colorMap[lowerTagName]) {
+    return colorMap[lowerTagName];
+  }
+
+  // Try partial matches
+  for (const [key, color] of Object.entries(colorMap)) {
+    if (lowerTagName.includes(key) || key.includes(lowerTagName)) {
+      return color;
+    }
+  }
+
+  // Default color scheme based on hash of tag name
+  const colors = [
+    'bg-blue-100 text-blue-800',
+    'bg-green-100 text-green-800',
+    'bg-yellow-100 text-yellow-800',
+    'bg-orange-100 text-orange-800',
+    'bg-red-100 text-red-800',
+    'bg-purple-100 text-purple-800',
+    'bg-pink-100 text-pink-800',
+    'bg-indigo-100 text-indigo-800',
+    'bg-cyan-100 text-cyan-800',
+    'bg-teal-100 text-teal-800',
+    'bg-emerald-100 text-emerald-800',
+    'bg-amber-100 text-amber-800',
+    'bg-violet-100 text-violet-800',
+    'bg-slate-100 text-slate-800',
+  ];
+
+  // Simple hash function for consistent color assignment
+  let hash = 0;
+  for (let i = 0; i < tagName.length; i++) {
+    hash = (hash << 5) - hash + tagName.charCodeAt(i);
+    hash = hash & hash; // Convert to 32-bit integer
+  }
+  return colors[Math.abs(hash) % colors.length];
+};


### PR DESCRIPTION
This comprehensive commit addresses multiple UI/UX improvements for the dive list and dive sites views, including rating display fixes, tag color consistency, and UI optimization.

- Fix empty rating display showing '<star> /10' instead of actual ratings
- Update dive list to use 'user_rating' field instead of 'rating' field
- Ensure ratings display correctly in both list and grid view modes

- Create shared tagHelpers.js utility with getTagColor function
- Implement consistent tag color mapping across entire application
- Update dive sites, dive site detail, and dive list views to use shared colors
- Improve visual distinction by changing 'Deep' tag from blue to indigo
- Ensure tags like 'Boat Dive', 'Reef', 'Wreck', 'Deep' have consistent colors

- Add dive tags display to dive list view (previously missing)
- Optimize screen real estate by displaying tags in same row as ratings
- Remove duplicate 'Create Dive Site' button to reduce UI clutter
- Maintain single 'Add Dive Site' button in hero section for better UX

- frontend/src/utils/tagHelpers.js: Shared utility for consistent tag coloring

- frontend/src/pages/Dives.js: Fix rating display, add tags, optimize layout
- frontend/src/pages/DiveSites.js: Use shared tag colors, remove duplicate button
- frontend/src/pages/DiveSiteDetail.js: Use shared tag colors for consistency

- Consistent tag colors across all views (dive sites, dive list, dive detail)
- Better visual distinction between different tag types
- Cleaner interface with reduced redundant UI elements
- Improved information density in dive list view

- All changes tested with Playwright browser automation
- Verified rating display works correctly in dive list
- Confirmed tag colors are consistent across all views
- Validated remaining 'Add Dive Site' button functionality