### PR TITLE
Fix dive title hidden below navbar

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -18,6 +18,11 @@
 
 /* Custom styles */
 
+/* Fix for main content padding to ensure it appears below navbar */
+main.pt-16 {
+  padding-top: 4rem !important; /* 64px - ensure content appears below navbar */
+}
+
 /* Safe Area Utility Classes */
 .pt-safe {
   padding-top: var(--safe-area-top);

--- a/frontend/src/pages/DiveSites.js
+++ b/frontend/src/pages/DiveSites.js
@@ -921,14 +921,28 @@ const DiveSites = () => {
                   {/* Tags */}
                   {site.tags && site.tags.length > 0 && (
                     <div className='flex flex-wrap gap-1'>
-                      {site.tags.slice(0, 3).map((tag, index) => (
-                        <span
-                          key={index}
-                          className={`inline-flex items-center px-1.5 py-0.5 text-xs font-medium rounded ${getTagColor(tag.name || tag)}`}
-                        >
-                          {tag.name || tag}
-                        </span>
-                      ))}
+                      {site.tags.slice(0, 3).map((tag, index) => {
+                        const tagName = tag.name || tag;
+                        const tagId = tag.id || tag;
+                        return (
+                          <button
+                            key={index}
+                            onClick={(e) => {
+                              e.preventDefault();
+                              e.stopPropagation();
+                              const currentTagIds = filters.tag_ids || [];
+                              const newTagIds = currentTagIds.includes(tagId)
+                                ? currentTagIds.filter(id => id !== tagId)
+                                : [...currentTagIds, tagId];
+                              handleFilterChange('tag_ids', newTagIds);
+                            }}
+                            className={`inline-flex items-center px-1.5 py-0.5 text-xs font-medium rounded cursor-pointer hover:opacity-80 transition-opacity ${getTagColor(tagName)}`}
+                            title={`Filter by ${tagName}`}
+                          >
+                            {tagName}
+                          </button>
+                        );
+                      })}
                       {site.tags.length > 3 && (
                         <span className='inline-flex items-center px-1.5 py-0.5 text-xs font-medium bg-gray-100 text-gray-600 rounded'>
                           +{site.tags.length - 3}
@@ -1042,14 +1056,28 @@ const DiveSites = () => {
                     {site.tags && site.tags.length > 0 && (
                       <div className='mb-4'>
                         <div className='flex flex-wrap gap-2'>
-                          {site.tags.slice(0, 3).map((tag, index) => (
-                            <span
-                              key={index}
-                              className='inline-flex items-center px-2 py-1 text-xs font-medium bg-blue-100 text-blue-800 rounded-full'
-                            >
-                              {tag.name || tag}
-                            </span>
-                          ))}
+                          {site.tags.slice(0, 3).map((tag, index) => {
+                            const tagName = tag.name || tag;
+                            const tagId = tag.id || tag;
+                            return (
+                              <button
+                                key={index}
+                                onClick={(e) => {
+                                  e.preventDefault();
+                                  e.stopPropagation();
+                                  const currentTagIds = filters.tag_ids || [];
+                                  const newTagIds = currentTagIds.includes(tagId)
+                                    ? currentTagIds.filter(id => id !== tagId)
+                                    : [...currentTagIds, tagId];
+                                  handleFilterChange('tag_ids', newTagIds);
+                                }}
+                                className='inline-flex items-center px-2 py-1 text-xs font-medium bg-blue-100 text-blue-800 rounded-full cursor-pointer hover:opacity-80 transition-opacity'
+                                title={`Filter by ${tagName}`}
+                              >
+                                {tagName}
+                              </button>
+                            );
+                          })}
                           {site.tags.length > 3 && (
                             <span className='inline-flex items-center px-2 py-1 text-xs font-medium bg-gray-100 text-gray-600 rounded-full'>
                               +{site.tags.length - 3} more

--- a/nginx/fly.toml
+++ b/nginx/fly.toml
@@ -34,8 +34,8 @@ primary_region = 'fra'
     grace_period = "10s"
     interval = "30s"
     method = "GET"
-    timeout = "5s"
-    path = "/health"
+    timeout = "10s"
+    path = "/nginx-health"
 
 # VM configuration
 [[vm]]


### PR DESCRIPTION
Add CSS rule to ensure main content padding-top is 64px instead of 32px.
This fixes the issue where dive titles were positioned at 32px from top,
placing them within the navbar's coverage area (0-64px) and making
them appear hidden behind the fixed navbar.

the title appears properly below the navbar on all screen sizes.

Enhance dive and dive-sites pages with multiple UX improvements
This commit implements several key user experience enhancements:
    
**Quick Filter Functionality:**
- Fix quick filters in dives page desktop view that were previously non-functional
- Implement proper handleQuickFilter logic with toggle functionality
- Add support for wreck, reef, boat dive, shore dive, and my dives filters
- Ensure proper tag ID mapping and filter state management

**Clickable Tags:**
- Make tags clickable in both dives and dive-sites list/grid views
- Add hover effects and tooltips for better user interaction
- Implement tag click handlers that add quick filters in format 'Tags: <tag name>'
- Support multiple tag selection and proper filter management

**Private Dive Indicators:**
- Add visual distinction for private dives in dives page
- Implement lock icon and 'Private' badge for private dive entries
- Use subtle purple background (bg-purple-50) for private dive cards
- Ensure consistent styling across list and grid views

**Tag Click Error Fix:**
- Resolve JavaScript error when clicking tags in filter section
- Fix handleSearchChange function expecting event object vs direct parameters
- Add proper handleFilterChange function for tag filter interactions

**Technical Improvements:**
- Update nginx configuration for better deployment handling
- Improve code maintainability and user interaction patterns
- Ensure consistent filter behavior across different page views

All changes maintain backward compatibility and follow existing code patterns.