### PR TITLE
Migrate MiniMap and DiveSiteMap to Leaflet

### DIFF
--- a/docs/development/work/2025-09-13-23-09-03-migrate-tripmap-to-leaflet/task.md
+++ b/docs/development/work/2025-09-13-23-09-03-migrate-tripmap-to-leaflet/task.md
@@ -378,3 +378,33 @@ This represents a significant improvement in user experience and system performa
 - **Error Handling**: Comprehensive error handling for all rate limiting scenarios
 
 **Result**: Rate limiting system now works correctly with proper request counting, accurate rate limits, and clean logging. All 250 requests per minute are allowed before rate limiting kicks in, exactly as configured.
+
+## OpenLayers → Leaflet Migration Status
+
+The goal is to completely remove OpenLayers from the frontend and standardize on Leaflet/react-leaflet.
+
+### Completed (migrated to Leaflet)
+
+- [x] `frontend/src/components/MiniMap.js` → Leaflet with `MapContainer`, `TileLayer`, `Marker`, modal maximize, responsive height tweaks
+- [x] `frontend/src/pages/DiveSiteMap.js` → Leaflet full-screen map with popups, default zoom 16, defensive coordinate handling, close button overlay, distinct main-site marker styling
+
+### Pending (still using OpenLayers)
+
+- [ ] `frontend/src/components/DiveSitesMap.js` (OL)
+- [ ] `frontend/src/components/DivingCentersMap.js` (OL)
+- [ ] `frontend/src/components/DivesMap.js` (OL)
+- [ ] `frontend/src/components/DiveTripsMap.js` (OL)
+- [ ] `frontend/src/components/DiveMap.js` (OL)
+- [ ] `frontend/src/components/UnifiedMapView.js` (OL; candidate for replacement with `LeafletMapView` or consolidation)
+
+### Cleanup
+
+- [ ] Verify no remaining `ol/*` imports after the above migrations
+- [ ] Remove OpenLayers from `package.json` dependencies once code is clean
+- [ ] Remove any dead OL-specific utilities/styles
+
+### Notes on Implementation
+
+- Leaflet default marker icons are configured via CDN URLs to avoid bundler asset issues
+- Popups provide clickable links to entity detail pages and display coordinates
+- Defensive guards ensure maps render even when coordinates are missing (fall back to Athens center)

--- a/frontend/src/components/MiniMap.js
+++ b/frontend/src/components/MiniMap.js
@@ -1,82 +1,30 @@
+import L, { Icon } from 'leaflet';
+import 'leaflet/dist/leaflet.css';
 import { Maximize2, X } from 'lucide-react';
-import { Feature } from 'ol';
-import { Point } from 'ol/geom';
-import TileLayer from 'ol/layer/Tile';
-import VectorLayer from 'ol/layer/Vector';
-import Map from 'ol/Map';
-import { fromLonLat } from 'ol/proj';
-import OSM from 'ol/source/OSM';
-import VectorSource from 'ol/source/Vector';
-import { Style, Circle as CircleStyle, Fill, Stroke } from 'ol/style';
-import View from 'ol/View';
 import PropTypes from 'prop-types';
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 import { createPortal } from 'react-dom';
+import { MapContainer, TileLayer, Marker, useMap } from 'react-leaflet';
+
+// Fix default marker icons (so they appear without bundler asset config)
+delete L.Icon.Default.prototype._getIconUrl;
+L.Icon.Default.mergeOptions({
+  iconRetinaUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.7.1/images/marker-icon-2x.png',
+  iconUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.7.1/images/marker-icon.png',
+  shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.7.1/images/marker-shadow.png',
+});
+
+const Recenter = ({ lat, lng, zoom }) => {
+  const map = useMap();
+  useEffect(() => {
+    if (!map) return;
+    map.setView([lat, lng], zoom, { animate: false });
+  }, [map, lat, lng, zoom]);
+  return null;
+};
 
 const MiniMap = ({ latitude, longitude, name, onMaximize, isMaximized = false, onClose }) => {
   const [isExpanded, setIsExpanded] = useState(false);
-  const mapRef = useRef();
-  const mapInstance = useRef();
-
-  const position = [longitude, latitude];
-
-  useEffect(() => {
-    if (!mapRef.current) return;
-
-    try {
-      // Create map
-      const map = new Map({
-        target: mapRef.current,
-        layers: [
-          new TileLayer({
-            source: new OSM(),
-          }),
-        ],
-        view: new View({
-          center: fromLonLat(position),
-          zoom: isExpanded ? 12 : 10,
-        }),
-      });
-
-      mapInstance.current = map;
-
-      // Create and add marker
-      const feature = new Feature({
-        geometry: new Point(fromLonLat(position)),
-      });
-
-      const vectorSource = new VectorSource({
-        features: [feature],
-      });
-
-      const vectorLayer = new VectorLayer({
-        source: vectorSource,
-        style: new Style({
-          image: new CircleStyle({
-            radius: 8,
-            fill: new Fill({
-              color: '#2563ea',
-            }),
-            stroke: new Stroke({
-              color: 'white',
-              width: 2,
-            }),
-          }),
-        }),
-      });
-
-      map.addLayer(vectorLayer);
-    } catch (error) {
-      // Error creating map
-    }
-
-    // Cleanup
-    return () => {
-      if (mapInstance.current) {
-        mapInstance.current.setTarget(undefined);
-      }
-    };
-  }, [longitude, latitude, isExpanded]);
 
   const handleMaximize = () => {
     if (onMaximize) {
@@ -107,7 +55,21 @@ const MiniMap = ({ latitude, longitude, name, onMaximize, isMaximized = false, o
             </button>
           </div>
           <div className='h-full'>
-            <div ref={mapRef} className='w-full h-full rounded-b-lg' />
+            <div className='w-full h-full rounded-b-lg'>
+              <MapContainer
+                center={[latitude, longitude]}
+                zoom={12}
+                className='w-full h-full rounded-b-lg'
+                style={{ zIndex: 1 }}
+              >
+                <TileLayer
+                  attribution=''
+                  url='https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'
+                />
+                <Recenter lat={latitude} lng={longitude} zoom={12} />
+                <Marker position={[latitude, longitude]} />
+              </MapContainer>
+            </div>
           </div>
         </div>
       </div>,
@@ -116,7 +78,11 @@ const MiniMap = ({ latitude, longitude, name, onMaximize, isMaximized = false, o
   }
 
   return (
-    <div className={`relative ${isExpanded ? 'h-64' : 'h-32'} transition-all duration-300`}>
+    <div
+      className={`relative ${
+        isExpanded ? 'h-64 md:h-96' : 'h-32 md:h-48'
+      } transition-all duration-300`}
+    >
       <div className='absolute top-2 right-2 z-10'>
         <button
           onClick={handleMaximize}
@@ -126,7 +92,18 @@ const MiniMap = ({ latitude, longitude, name, onMaximize, isMaximized = false, o
           <Maximize2 className='w-4 h-4' />
         </button>
       </div>
-      <div ref={mapRef} className='w-full h-full rounded-lg' />
+      <div className='w-full h-full rounded-lg'>
+        <MapContainer
+          center={[latitude, longitude]}
+          zoom={isExpanded ? 12 : 10}
+          className='w-full h-full rounded-lg'
+          style={{ zIndex: 1 }}
+        >
+          <TileLayer attribution='' url='https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png' />
+          <Recenter lat={latitude} lng={longitude} zoom={isExpanded ? 12 : 10} />
+          <Marker position={[latitude, longitude]} />
+        </MapContainer>
+      </div>
     </div>
   );
 };

--- a/frontend/src/pages/DiveSiteMap.js
+++ b/frontend/src/pages/DiveSiteMap.js
@@ -1,31 +1,38 @@
+import L, { Icon } from 'leaflet';
+import 'leaflet/dist/leaflet.css';
 import { ArrowLeft } from 'lucide-react';
-import { Feature } from 'ol';
-import { Point } from 'ol/geom';
-import TileLayer from 'ol/layer/Tile';
-import VectorLayer from 'ol/layer/Vector';
-import Map from 'ol/Map';
-import { fromLonLat } from 'ol/proj';
-import ClusterSource from 'ol/source/Cluster';
-import OSM from 'ol/source/OSM';
-import VectorSource from 'ol/source/Vector';
-import { Style, Icon, Text, Fill, Stroke, Circle } from 'ol/style';
-import View from 'ol/View';
-import { useState, useEffect, useRef } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
+import { MapContainer, TileLayer, Marker, Popup, useMap } from 'react-leaflet';
 import { useQuery } from 'react-query';
 import { useParams, useNavigate } from 'react-router-dom';
 
 import api from '../api';
 
+// Fix default marker icons
+delete L.Icon.Default.prototype._getIconUrl;
+L.Icon.Default.mergeOptions({
+  iconRetinaUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.7.1/images/marker-icon-2x.png',
+  iconUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.7.1/images/marker-icon.png',
+  shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.7.1/images/marker-shadow.png',
+});
+
+const Recenter = ({ lat, lng, zoom }) => {
+  const map = useMap();
+  useEffect(() => {
+    if (!map) return;
+    map.setView([lat, lng], zoom, { animate: false });
+  }, [map, lat, lng, zoom]);
+  return null;
+};
+
 const DiveSiteMap = () => {
   const { id } = useParams();
   const navigate = useNavigate();
-  const mapRef = useRef();
-  const mapInstance = useRef();
-  const [selectedSite, setSelectedSite] = useState(null);
-  const [currentZoom, setCurrentZoom] = useState(13);
-  const [popupPosition, setPopupPosition] = useState({ top: 20, left: 16 });
-  const [_useClustering, setUseClustering] = useState(false);
+  const [currentZoom, setCurrentZoom] = useState(16);
+  const mapContainerRef = useRef();
+
+  const isFiniteNumber = value => typeof value === 'number' && Number.isFinite(value);
 
   // Fetch current dive site
   const { data: diveSite, isLoading: isLoadingDiveSite } = useQuery(
@@ -45,307 +52,75 @@ const DiveSiteMap = () => {
     }
   );
 
-  // Create custom dive site icon
+  // Create custom Leaflet icon (SVG diver flag)
   const createDiveSiteIcon = (isMain = false) => {
     const size = isMain ? 32 : 24;
-
-    // Create SVG scuba flag (diver down flag) - red rectangle with white diagonal stripe
+    const border = isMain
+      ? '<rect x="1.5" y="1.5" width="21" height="21" fill="none" stroke="#f59e0b" stroke-width="3" rx="3" ry="3"/>'
+      : '';
     const svg = `
       <svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <!-- Red rectangle background -->
-        <rect x="2" y="2" width="20" height="20" fill="#dc2626" stroke="white" stroke-width="1"/>
-        <!-- White diagonal stripe from top-left to bottom-right -->
+        ${border}
+        <rect x="2" y="2" width="20" height="20" fill="#dc2626" stroke="white" stroke-width="1.5" rx="2" ry="2"/>
         <path d="M2 2 L22 22" stroke="white" stroke-width="3" stroke-linecap="round"/>
-        <!-- Optional: Add small white dots for bubbles -->
         <circle cx="6" cy="6" r="1" fill="white"/>
         <circle cx="18" cy="18" r="1" fill="white"/>
       </svg>
     `;
-
     const dataUrl = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
-
     return new Icon({
-      src: dataUrl,
-      scale: 1,
-      anchor: [0.5, 0.5],
-      anchorXUnits: 'fraction',
-      anchorYUnits: 'fraction',
+      iconUrl: dataUrl,
+      iconSize: [size, size],
+      iconAnchor: [size / 2, size / 2],
+      popupAnchor: [0, -size / 2],
     });
   };
 
-  // Create cluster style function
-  const createClusterStyle = feature => {
-    const features = feature.get('features');
-    const size = features.length;
+  // (Cluster styling removed; simple markers are used for main and nearby sites)
 
-    if (size === 1) {
-      // Single feature - show individual dive site icon
-      const isMain = features[0].get('isMain');
-      return new Style({
-        image: createDiveSiteIcon(isMain),
-      });
-    } else {
-      // Multiple features - show cluster circle
-      return new Style({
-        image: new Circle({
-          radius: Math.min(size * 3 + 10, 25),
-          fill: new Fill({
-            color: '#dc2626',
-          }),
-          stroke: new Stroke({
-            color: 'white',
-            width: 2,
-          }),
-        }),
-        text: new Text({
-          text: size.toString(),
-          fill: new Fill({
-            color: 'white',
-          }),
-          font: 'bold 14px Arial',
-        }),
-      });
-    }
+  // Track zoom from Leaflet map
+  const MapZoomTracker = () => {
+    const map = useMap();
+    useEffect(() => {
+      if (!map) return;
+      const onZoom = () => setCurrentZoom(map.getZoom());
+      map.on('zoomend', onZoom);
+      onZoom();
+      return () => map.off('zoomend', onZoom);
+    }, [map]);
+    return null;
   };
 
-  // Create non-clustered style function
-  // const createNonClusteredStyle = feature => {
-  //   const isMain = feature.get('isMain');
-  //   return new Style({
-  //     image: createDiveSiteIcon(isMain),
-  //   });
-  // };
-
-  // Calculate optimal popup position based on click coordinates
-  const calculatePopupPosition = (clickX, clickY, mapWidth, mapHeight) => {
-    const popupWidth = 320; // Approximate popup width
-    const popupHeight = 200; // Approximate popup height
-    const margin = 16;
-
-    // Start with default position (below and to the right of click)
-    let left = clickX + margin;
-    let top = clickY + margin;
-
-    // Check if popup would go off the right edge
-    if (left + popupWidth > mapWidth - margin) {
-      left = clickX - popupWidth - margin;
-    }
-
-    // Check if popup would go off the bottom edge
-    if (top + popupHeight > mapHeight - margin) {
-      top = clickY - popupHeight - margin;
-    }
-
-    // If popup would go off the left edge, try positioning to the right
-    if (left < margin) {
-      left = margin;
-    }
-
-    // If popup would go off the top edge, try positioning below
-    if (top < margin) {
-      top = margin;
-    }
-
-    // Additional check: if the popup is still too close to edges, adjust further
-    // This handles cases where the click is very close to borders
-    if (clickY < popupHeight + margin * 2) {
-      // Click is very close to top, position popup below
-      top = clickY + margin;
-    }
-
-    if (clickX < popupWidth / 2) {
-      // Click is very close to left edge, center the popup
-      left = margin;
-    }
-
-    if (clickX > mapWidth - popupWidth / 2) {
-      // Click is very close to right edge, position popup to the left
-      left = mapWidth - popupWidth - margin;
-    }
-
-    return { top, left };
-  };
-
-  useEffect(() => {
-    if (!mapRef.current || !diveSite) return;
-
-    try {
-      // Create map
-      const map = new Map({
-        target: mapRef.current,
-        layers: [
-          new TileLayer({
-            source: new OSM(),
-          }),
-        ],
-        view: new View({
-          center: fromLonLat([diveSite.longitude, diveSite.latitude]),
-          zoom: 13,
-        }),
-      });
-
-      mapInstance.current = map;
-
-      // Set up zoom level tracking
-      setCurrentZoom(map.getView().getZoom());
-
-      // Listen for zoom changes
-      map.getView().on('change:resolution', () => {
-        const newZoom = map.getView().getZoom();
-
-        setCurrentZoom(newZoom);
-        const newClusteringState = newZoom <= 11;
-
-        setUseClustering(newClusteringState);
-      });
-
-      // Create features for all sites
-      const features = [];
-
-      // Main dive site (larger, different color)
-      const mainFeature = new Feature({
-        geometry: new Point(fromLonLat([diveSite.longitude, diveSite.latitude])),
-        site: diveSite,
+  // Compute markers
+  const markers = useMemo(() => {
+    if (!diveSite) return [];
+    const list = [];
+    if (isFiniteNumber(diveSite.latitude) && isFiniteNumber(diveSite.longitude)) {
+      list.push({
+        id: `site-${diveSite.id}`,
+        position: [diveSite.latitude, diveSite.longitude],
+        data: diveSite,
         isMain: true,
       });
-      features.push(mainFeature);
-
-      // Nearby dive sites
-      if (nearbyDiveSites) {
-        nearbyDiveSites.forEach(site => {
-          const feature = new Feature({
-            geometry: new Point(fromLonLat([site.longitude, site.latitude])),
-            site: site,
-            isMain: false,
-          });
-          features.push(feature);
-        });
-      }
-
-      // Create source based on zoom level
-      const currentZoom = map.getView().getZoom();
-      const shouldUseClustering = currentZoom <= 11;
-      const clusterDistance = shouldUseClustering ? 50 : 0; // 0 = no clustering
-
-      setUseClustering(shouldUseClustering);
-
-      // Always use ClusterSource with dynamic distance
-      const source = new ClusterSource({
-        distance: clusterDistance,
-        source: new VectorSource({
-          features: features,
-        }),
-      });
-
-      const vectorLayer = new VectorLayer({
-        source: source,
-        style: createClusterStyle, // Always use cluster style, it handles single features
-      });
-
-      map.addLayer(vectorLayer);
-
-      // Add click handler
-      map.on('click', event => {
-        const feature = map.forEachFeatureAtPixel(event.pixel, feature => {
-          return feature;
-        });
-
-        if (feature) {
-          // Always handle as cluster feature since we always use ClusterSource
-          const features = feature.get('features');
-
-          if (features && features.length === 1) {
-            // Single dive site
-            const site = features[0].get('site');
-
-            setSelectedSite(site);
-          } else if (features && features.length > 1) {
-            // Cluster - zoom in to show individual sites
-
-            try {
-              const extent = source.getClusterExtent(feature);
-              // Check if extent is valid (not empty)
-              if (
-                extent &&
-                extent.getWidth &&
-                extent.getWidth() > 0 &&
-                extent.getHeight &&
-                extent.getHeight() > 0
-              ) {
-                map.getView().fit(extent, {
-                  duration: 500,
-                  padding: [50, 50, 50, 50],
-                });
-              } else {
-                // Fallback: zoom in by one level
-                const view = map.getView();
-                const currentZoom = view.getZoom();
-                view.animate({
-                  zoom: currentZoom + 1,
-                  duration: 500,
-                });
-              }
-            } catch (error) {
-              // Fallback: zoom in by one level
-              const view = map.getView();
-              const currentZoom = view.getZoom();
-              view.animate({
-                zoom: currentZoom + 1,
-                duration: 500,
-              });
-            }
-            return; // Don't show popup for clusters
-          }
-
-          // Calculate optimal popup position
-          const mapElement = mapRef.current;
-          const mapRect = mapElement.getBoundingClientRect();
-          const clickX = event.pixel[0];
-          const clickY = event.pixel[1];
-
-          const position = calculatePopupPosition(clickX, clickY, mapRect.width, mapRect.height);
-
-          setPopupPosition(position);
-        } else {
-          setSelectedSite(null);
-        }
-      });
-    } catch (error) {}
-
-    // Cleanup
-    return () => {
-      if (mapInstance.current) {
-        mapInstance.current.setTarget(undefined);
-      }
-    };
-  }, [diveSite, nearbyDiveSites]);
-
-  // Update clustering distance when zoom changes
-  useEffect(() => {
-    if (!mapInstance.current || !diveSite) return;
-
-    // Get current vector layer
-    const layers = mapInstance.current.getLayers();
-    const existingVectorLayer = layers.getArray().find(layer => layer instanceof VectorLayer);
-    if (!existingVectorLayer) return;
-
-    const currentSource = existingVectorLayer.getSource();
-    if (!(currentSource instanceof ClusterSource)) return;
-
-    // Get current zoom and determine new distance
-    const currentZoom = mapInstance.current.getView().getZoom();
-    const shouldUseClustering = currentZoom <= 11;
-    const newDistance = shouldUseClustering ? 50 : 0;
-
-    if (currentSource.getDistance() !== newDistance) {
-      // Update the cluster distance
-      currentSource.setDistance(newDistance);
-      setUseClustering(shouldUseClustering);
-
-      // Force a refresh of the source
-      currentSource.refresh();
     }
-  }, [currentZoom, diveSite, nearbyDiveSites]);
+    const nearbyArray = Array.isArray(nearbyDiveSites)
+      ? nearbyDiveSites
+      : nearbyDiveSites?.results ||
+        nearbyDiveSites?.items ||
+        nearbyDiveSites?.data ||
+        nearbyDiveSites?.nearby_sites ||
+        [];
+    nearbyArray.forEach(site => {
+      if (site && site.latitude && site.longitude) {
+        list.push({
+          id: `nearby-${site.id}`,
+          position: [site.latitude, site.longitude],
+          data: site,
+        });
+      }
+    });
+    return list;
+  }, [diveSite, nearbyDiveSites]);
 
   if (isLoadingDiveSite || isLoadingNearby || !diveSite) {
     return (
@@ -370,66 +145,81 @@ const DiveSiteMap = () => {
             <h1 className='text-xl font-semibold'>
               {diveSite?.name || 'Loading...'} - Full Map View
             </h1>
-            <p className='text-sm text-gray-600'>
-              {diveSite?.latitude?.toFixed(4) || 'Loading...'},{' '}
-              {diveSite?.longitude?.toFixed(4) || 'Loading...'}
-            </p>
+            {isFiniteNumber(diveSite?.latitude) && isFiniteNumber(diveSite?.longitude) ? (
+              <p className='text-sm text-gray-600'>
+                {Number(diveSite.latitude).toFixed(4)}, {Number(diveSite.longitude).toFixed(4)}
+              </p>
+            ) : (
+              <p className='text-sm text-gray-600'>No coordinates</p>
+            )}
           </div>
         </div>
-        <div className='flex items-center space-x-2'>
+        <div className='flex items-center space-x-3'>
           <span className='text-sm text-gray-600'>Zoom: {currentZoom.toFixed(1)}</span>
+          <button
+            onClick={() => navigate(`/dive-sites/${id}`)}
+            className='p-2 hover:bg-gray-100 rounded-md transition-colors'
+            aria-label='Close full map view'
+            title='Close'
+          >
+            ×
+          </button>
         </div>
       </div>
 
       {/* Map */}
-      <div className='h-full'>
-        <div ref={mapRef} className='w-full h-full' />
+      <div ref={mapContainerRef} className='h-full relative'>
+        <div className='absolute top-4 right-4 z-50'>
+          <button
+            onClick={() => navigate(`/dive-sites/${id}`)}
+            className='bg-white text-gray-700 hover:text-gray-900 rounded-full w-9 h-9 shadow-md flex items-center justify-center border border-gray-200'
+            aria-label='Close full map view'
+            title='Close'
+          >
+            ×
+          </button>
+        </div>
+        <MapContainer
+          center={
+            isFiniteNumber(diveSite.latitude) && isFiniteNumber(diveSite.longitude)
+              ? [diveSite.latitude, diveSite.longitude]
+              : [37.9838, 23.7275]
+          }
+          zoom={16}
+          className='w-full h-full'
+          style={{ zIndex: 1 }}
+        >
+          <TileLayer attribution='' url='https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png' />
+          <MapZoomTracker />
+          {isFiniteNumber(diveSite.latitude) && isFiniteNumber(diveSite.longitude) && (
+            <Recenter lat={diveSite.latitude} lng={diveSite.longitude} zoom={16} />
+          )}
+          {markers.map(m => (
+            <Marker key={m.id} position={m.position} icon={createDiveSiteIcon(m.isMain)}>
+              <Popup>
+                <div className='p-1'>
+                  <a
+                    href={`/dive-sites/${m.data.id}`}
+                    className='text-blue-600 hover:text-blue-800 hover:underline font-medium'
+                  >
+                    {m.data.name || `Dive Site #${m.data.id}`}
+                  </a>
+                  <div className='text-xs text-gray-600 mt-1'>
+                    {Array.isArray(m.position) && m.position.length === 2
+                      ? `${Number(m.position[0]).toFixed(4)}, ${Number(m.position[1]).toFixed(4)}`
+                      : 'N/A'}
+                  </div>
+                </div>
+              </Popup>
+            </Marker>
+          ))}
+        </MapContainer>
+        <div className='absolute top-4 left-16 z-50 bg-white/90 text-gray-800 text-xs px-2 py-1 rounded shadow border border-gray-200'>
+          Zoom: {currentZoom.toFixed(1)}
+        </div>
       </div>
 
-      {/* Popup for selected site */}
-      {selectedSite && (
-        <div
-          className='absolute bg-white rounded-lg shadow-lg p-4 max-w-sm z-10 border border-gray-200'
-          style={{
-            top: `${popupPosition.top}px`,
-            left: `${popupPosition.left}px`,
-            maxWidth: '320px',
-          }}
-        >
-          <div className='flex items-center justify-between mb-2'>
-            <h3 className='font-semibold text-lg'>{selectedSite.name}</h3>
-            <button
-              onClick={() => setSelectedSite(null)}
-              className='text-gray-500 hover:text-gray-700 text-xl font-bold'
-            >
-              ×
-            </button>
-          </div>
-          <p className='text-sm text-gray-600 mb-3'>
-            {selectedSite?.latitude?.toFixed(4) || 'N/A'},{' '}
-            {selectedSite?.longitude?.toFixed(4) || 'N/A'}
-          </p>
-          {selectedSite?.distance_km && (
-            <p className='text-sm text-gray-600 mb-3'>
-              Distance: {selectedSite.distance_km.toFixed(1)} km
-            </p>
-          )}
-          <div className='flex space-x-2'>
-            <button
-              onClick={() => navigate(`/dive-sites/${selectedSite.id}`)}
-              className='bg-blue-600 text-white px-4 py-2 rounded-md text-sm hover:bg-blue-700 transition-colors'
-            >
-              View Details
-            </button>
-            <button
-              onClick={() => navigate(`/dive-sites/${selectedSite.id}/map`)}
-              className='bg-gray-600 text-white px-4 py-2 rounded-md text-sm hover:bg-gray-700 transition-colors'
-            >
-              Full Map
-            </button>
-          </div>
-        </div>
-      )}
+      {/* Popup replaced by native Leaflet popups when needed in future */}
     </div>,
     document.body
   );


### PR DESCRIPTION
Replace OpenLayers with react-leaflet for MiniMap and the full dive site map. Add popups with links, zoom indicator, overlay close button, and default zoom 16. Increase MiniMap desktop height and fix missing-icon error. Update task.md with migration status and pending OL components.