### PR TITLE
Refine Dives and Diving Centers UI, fix time display, remove thumbnails, and add location-based filtering

### DIFF
--- a/docs/development/api.md
+++ b/docs/development/api.md
@@ -1252,7 +1252,7 @@ Remove tag from dive site (admin/moderator only).
   "url": "string",
   "description": "string (optional)",
   "title": "string (optional)",
-  "thumbnail_url": "string (optional)",
+  "thumbnail_url": "string (optional)", // UI thumbnail toggle removed; field remains for image references
   "created_at": "datetime"
 }
 ```text

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -642,7 +642,7 @@ The application will follow a microservices-oriented or a well-separated monolit
     * url (link to stored media or external URL)
     * description (optional)
     * title (optional, for external links)
-    * thumbnail\_url (optional, for external links)
+    * thumbnail\_url (optional, for external links). Note: UI no longer exposes a thumbnail display toggle; images are handled contextually per page.
   * dive\_tags table: - NEW TABLE
     * id (PK)
     * dive\_id (FK to dives)

--- a/docs/development/css-and-sticky-positioning-guide.md
+++ b/docs/development/css-and-sticky-positioning-guide.md
@@ -710,7 +710,6 @@ A comprehensive filter bar component with responsive behavior and advanced featu
 | `onReset` | function | `() => {}` | Reset handler |
 | `viewMode` | string | `'list'` | View mode: 'list' or 'map' |
 | `onViewModeChange` | function | `() => {}` | View mode change handler |
-| `showThumbnails` | boolean | `false` | Whether to show thumbnails |
 | `compactLayout` | boolean | `false` | Whether to use compact layout |
 | `onDisplayOptionChange` | function | `() => {}` | Display option change handler |
 | `pageType` | string | `'dive-sites'` | Page type for quick filters |
@@ -921,7 +920,6 @@ Main page implementations using the `.sticky-below-navbar` class for consistent 
     onReset={handleReset}
     viewMode={viewMode}
     onViewModeChange={setViewMode}
-    showThumbnails={showThumbnails}
     compactLayout={compactLayout}
     onDisplayOptionChange={handleDisplayOptionChange}
     pageType='dive-sites'

--- a/docs/development/done/2025-08-30-22-14-23-dives-page-mobile-desktop-enhancement.md
+++ b/docs/development/done/2025-08-30-22-14-23-dives-page-mobile-desktop-enhancement.md
@@ -96,7 +96,7 @@ The current `/dives` page has basic mobile responsiveness but lacks the modern, 
 5. ✅ **View Mode Switching**: List/Map view switching working (tested Map view successfully)
 6. ✅ **Mobile Responsiveness**: Component adapts correctly to both desktop (1920x1080) and mobile (375x667) viewports
 7. ✅ **Touch Targets**: All interactive elements properly sized for mobile touch interaction
-8. ✅ **Sorting & Display Options**: Sort field, sort order, and display options (thumbnails, compact) all functional
+8. ✅ **Sorting & Display Options**: Sort field, sort order, and display options (compact) are functional; thumbnails option has been removed in favor of simplified UI
 
 **Key Finding**: The ResponsiveFilterBar is designed to appear on scroll, not by default, which provides an excellent user experience by keeping the hero section clean while making filters easily accessible when needed.
 

--- a/docs/development/done/newsletter-parsing-implementation-plan.md
+++ b/docs/development/done/newsletter-parsing-implementation-plan.md
@@ -77,7 +77,7 @@
 
 - [x] **Improve trip display layout**
   - ✅ Enhance trip card design with better visual hierarchy
-  - ✅ Add trip images/thumbnails support (placeholder implemented)
+  - ✅ Add trip images support (placeholder implemented); thumbnails option removed globally
   - ✅ Improve responsive design for mobile devices
   - ✅ Add trip duration and pricing display
 

--- a/docs/development/floating-search-filters-guide.md
+++ b/docs/development/floating-search-filters-guide.md
@@ -97,7 +97,6 @@ The current implementation uses this structure across all pages:
     onReset={resetSorting}
     viewMode={viewMode}
     onViewModeChange={handleViewModeChange}
-    showThumbnails={showThumbnails}
     compactLayout={compactLayout}
     onDisplayOptionChange={handleDisplayOptionChange}
   />
@@ -174,7 +173,6 @@ The current implementation uses this structure across all pages:
     onReset={resetSorting}
     viewMode={viewMode}
     onViewModeChange={handleViewModeChange}
-    showThumbnails={showThumbnails}
     compactLayout={compactLayout}
     onDisplayOptionChange={handleDisplayOptionChange}
   />
@@ -222,7 +220,6 @@ The current implementation uses this structure across all pages:
     onReset={resetSorting}
     viewMode={viewMode}
     onViewModeChange={handleViewModeChange}
-    showThumbnails={showThumbnails}
     compactLayout={compactLayout}
     onDisplayOptionChange={handleDisplayOptionChange}
   />
@@ -286,7 +283,6 @@ The current implementation uses this structure across all pages:
       onReset={resetSorting}
       viewMode={viewMode}
       onViewModeChange={handleViewModeChange}
-      showThumbnails={showThumbnails}
       compactLayout={compactLayout}
       onDisplayOptionChange={handleDisplayOptionChange}
     />
@@ -402,7 +398,7 @@ z-index: 200  /* Modal dialogs, full-screen overlays */
 - `onSearchChange`: Function to handle search input changes
 - `sortBy`, `sortOrder`, `sortOptions`: Sorting configuration
 - `viewMode`, `onViewModeChange`: View mode controls
-- `showThumbnails`, `compactLayout`: Display options
+- `compactLayout`: Display option (thumbnails removed)
 
 **Usage Pattern**:
 

--- a/frontend/src/components/DivingCentersResponsiveFilterBar.js
+++ b/frontend/src/components/DivingCentersResponsiveFilterBar.js
@@ -45,7 +45,6 @@ const DivingCentersResponsiveFilterBar = ({
   onReset = () => {},
   viewMode = 'list',
   onViewModeChange = () => {},
-  showThumbnails = false,
   compactLayout = false,
   onDisplayOptionChange = () => {},
 }) => {
@@ -314,17 +313,8 @@ const DivingCentersResponsiveFilterBar = ({
                   <label className='flex items-center gap-1 text-sm text-gray-700'>
                     <input
                       type='checkbox'
-                      checked={showThumbnails}
-                      onChange={e => onDisplayOptionChange('showThumbnails', e.target.checked)}
-                      className='rounded border-gray-300 text-blue-600 focus:ring-blue-500'
-                    />
-                    Thumbnails
-                  </label>
-                  <label className='flex items-center gap-1 text-sm text-gray-700'>
-                    <input
-                      type='checkbox'
                       checked={compactLayout}
-                      onChange={e => onDisplayOptionChange('compactLayout', e.target.checked)}
+                      onChange={() => onDisplayOptionChange('compact')}
                       className='rounded border-gray-300 text-blue-600 focus:ring-blue-500'
                     />
                     Compact
@@ -648,20 +638,10 @@ const DivingCentersResponsiveFilterBar = ({
                     </div>
                   </div>
 
-                  {/* Display Options - Compact Checkboxes */}
+                  {/* Display Options - Compact Checkbox */}
                   <div>
                     <h4 className='text-sm font-medium text-gray-700 mb-3'>Display Options</h4>
                     <div className='space-y-2'>
-                      <label className='flex items-center gap-3 p-3 bg-gray-50 border border-gray-200 rounded-lg cursor-pointer hover:bg-gray-100 transition-colors'>
-                        <input
-                          type='checkbox'
-                          className='w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500'
-                          checked={showThumbnails}
-                          onChange={() => onDisplayOptionChange('thumbnails')}
-                        />
-                        <span className='text-sm font-medium'>Thumbnails</span>
-                      </label>
-
                       <label className='flex items-center gap-3 p-3 bg-gray-50 border border-gray-200 rounded-lg cursor-pointer hover:bg-gray-100 transition-colors'>
                         <input
                           type='checkbox'
@@ -742,7 +722,6 @@ DivingCentersResponsiveFilterBar.propTypes = {
   onReset: PropTypes.func,
   viewMode: PropTypes.oneOf(['list', 'map']),
   onViewModeChange: PropTypes.func,
-  showThumbnails: PropTypes.bool,
   compactLayout: PropTypes.bool,
   onDisplayOptionChange: PropTypes.func,
 };

--- a/frontend/src/components/ResponsiveFilterBar.js
+++ b/frontend/src/components/ResponsiveFilterBar.js
@@ -41,7 +41,6 @@ const ResponsiveFilterBar = ({
   onReset = () => {},
   viewMode = 'list',
   onViewModeChange = () => {},
-  showThumbnails = false,
   compactLayout = false,
   onDisplayOptionChange = () => {},
   // New prop for page-specific quick filters
@@ -488,15 +487,6 @@ const ResponsiveFilterBar = ({
               <div className='flex items-center gap-2'>
                 <label className='text-sm font-medium text-gray-700'>Display:</label>
                 <div className='flex items-center gap-2'>
-                  <label className='flex items-center gap-1 text-sm text-gray-700'>
-                    <input
-                      type='checkbox'
-                      checked={showThumbnails}
-                      onChange={e => onDisplayOptionChange('showThumbnails', e.target.checked)}
-                      className='rounded border-gray-300 text-blue-600 focus:ring-blue-500'
-                    />
-                    Thumbnails
-                  </label>
                   <label className='flex items-center gap-1 text-sm text-gray-700'>
                     <input
                       type='checkbox'
@@ -1010,20 +1000,10 @@ const ResponsiveFilterBar = ({
                     </div>
                   </div>
 
-                  {/* Display Options - Compact Checkboxes */}
+                  {/* Display Options - Compact Checkbox */}
                   <div>
                     <h4 className='text-sm font-medium text-gray-700 mb-3'>Display Options</h4>
                     <div className='space-y-2'>
-                      <label className='flex items-center gap-3 p-3 bg-gray-50 border border-gray-200 rounded-lg cursor-pointer hover:bg-gray-100 transition-colors'>
-                        <input
-                          type='checkbox'
-                          className='w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500'
-                          checked={showThumbnails}
-                          onChange={() => onDisplayOptionChange('thumbnails')}
-                        />
-                        <span className='text-sm text-gray-700'>Show thumbnails</span>
-                      </label>
-
                       <label className='flex items-center gap-3 p-3 bg-gray-50 border border-gray-200 rounded-lg cursor-pointer hover:bg-gray-100 transition-colors'>
                         <input
                           type='checkbox'
@@ -1103,7 +1083,6 @@ ResponsiveFilterBar.propTypes = {
   onReset: PropTypes.func,
   viewMode: PropTypes.oneOf(['list', 'map']),
   onViewModeChange: PropTypes.func,
-  showThumbnails: PropTypes.bool,
   compactLayout: PropTypes.bool,
   onDisplayOptionChange: PropTypes.func,
   // New prop for page-specific quick filters

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1030,44 +1030,7 @@ div[class*="fixed top-16 left-0 right-0 bg-blue-700"] {
   margin-bottom: 0.25rem;
 }
 
-.view-mode-thumbnails .dive-item {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-  padding: 1rem;
-  border: 1px solid #e5e7eb;
-  border-radius: 0.5rem;
-  margin-bottom: 0.75rem;
-}
-
-.view-mode-thumbnails .dive-thumbnail {
-  width: 80px;
-  height: 80px;
-  background-color: #f3f4f6;
-  border-radius: 0.375rem;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: #6b7280;
-  font-size: 0.75rem;
-}
-
-/* Responsive adjustments */
-@media (max-width: 640px) {
-  .view-mode-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .view-mode-thumbnails .dive-item {
-    flex-direction: column;
-    text-align: center;
-  }
-
-  .view-mode-thumbnails .dive-thumbnail {
-    width: 100px;
-    height: 100px;
-  }
-}
+/* Removed thumbnail-specific styles */
 
 /* Enhanced Grid View Styling */
 .line-clamp-2 {
@@ -1094,27 +1057,7 @@ div[class*="fixed top-16 left-0 right-0 bg-blue-700"] {
   box-shadow: 0 10px 25px rgba(0, 0, 0, 0.1);
 }
 
-/* Enhanced Thumbnail Styling */
-.dive-thumbnail {
-  position: relative;
-  overflow: hidden;
-}
-
-.dive-thumbnail::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: linear-gradient(135deg, rgba(59, 130, 246, 0.1) 0%, rgba(6, 182, 212, 0.1) 100%);
-  opacity: 0;
-  transition: opacity 0.3s ease;
-}
-
-.dive-item:hover .dive-thumbnail::before {
-  opacity: 1;
-}
+/* Removed .dive-thumbnail effects */
 
 /* Enhanced Badge Styling */
 .badge-service {

--- a/frontend/src/pages/DiveSites.js
+++ b/frontend/src/pages/DiveSites.js
@@ -52,11 +52,7 @@ const DiveSites = () => {
   const [showAdvancedFilters, setShowAdvancedFilters] = useState(false);
   const [quickFilter, setQuickFilter] = useState('');
 
-  // View mode state
-  const [showThumbnails, setShowThumbnails] = useState(() => {
-    const params = new URLSearchParams(window.location.search);
-    return params.get('show_thumbnails') === 'true';
-  });
+  // Thumbnails feature removed
   const [compactLayout, setCompactLayout] = useState(() => {
     const params = new URLSearchParams(window.location.search);
     return params.get('compact_layout') !== 'false'; // Default to true (compact)
@@ -474,19 +470,7 @@ const DiveSites = () => {
   };
 
   const handleDisplayOptionChange = option => {
-    if (option === 'thumbnails') {
-      const newShowThumbnails = !showThumbnails;
-      setShowThumbnails(newShowThumbnails);
-
-      // Update URL
-      const urlParams = new URLSearchParams(window.location.search);
-      if (newShowThumbnails) {
-        urlParams.set('show_thumbnails', 'true');
-      } else {
-        urlParams.delete('show_thumbnails');
-      }
-      navigate(`?${urlParams.toString()}`, { replace: true });
-    } else if (option === 'compact') {
+    if (option === 'compact') {
       const newCompactLayout = !compactLayout;
       setCompactLayout(newCompactLayout);
 
@@ -714,7 +698,6 @@ const DiveSites = () => {
             onReset={resetSorting}
             viewMode={viewMode}
             onViewModeChange={handleViewModeChange}
-            showThumbnails={showThumbnails}
             compactLayout={compactLayout}
             onDisplayOptionChange={handleDisplayOptionChange}
           />
@@ -807,11 +790,7 @@ const DiveSites = () => {
 
                     <div className='flex-1 min-w-0'>
                       <div className='flex items-start gap-2 mb-2'>
-                        {showThumbnails && (
-                          <div className='dive-thumbnail flex-shrink-0 mt-0.5'>
-                            <MapPin className='w-5 h-5 sm:w-6 sm:h-6 text-gray-400' />
-                          </div>
-                        )}
+                        {/* Thumbnail removed */}
                         <div className='min-w-0 flex-1'>
                           <div className='flex flex-col gap-0'>
                             <h3
@@ -962,11 +941,7 @@ const DiveSites = () => {
                     compactLayout ? 'p-3' : 'p-4'
                   }`}
                 >
-                  {showThumbnails && (
-                    <div className='dive-thumbnail bg-gray-100 p-3 flex items-center justify-center'>
-                      <MapPin className='w-10 h-10 text-gray-400' />
-                    </div>
-                  )}
+          {/* Thumbnail removed */}
 
                   <div className='p-3'>
                     <div className='flex items-center gap-3 mb-2'>

--- a/frontend/src/pages/DiveTrips.js
+++ b/frontend/src/pages/DiveTrips.js
@@ -65,10 +65,7 @@ const DiveTrips = () => {
     const viewMode = params.get('view');
     return viewMode === 'map' ? 'map' : viewMode === 'grid' ? 'grid' : 'list';
   });
-  const [showThumbnails, setShowThumbnails] = useState(() => {
-    const params = new URLSearchParams(window.location.search);
-    return params.get('show_thumbnails') === 'true';
-  });
+  // Thumbnails feature removed
   const [compactLayout, setCompactLayout] = useState(() => {
     const params = new URLSearchParams(window.location.search);
     return params.get('compact_layout') !== 'false'; // Default to true (compact)
@@ -153,19 +150,7 @@ const DiveTrips = () => {
   };
 
   const handleDisplayOptionChange = option => {
-    if (option === 'thumbnails') {
-      const newShowThumbnails = !showThumbnails;
-      setShowThumbnails(newShowThumbnails);
-
-      // Update URL
-      const urlParams = new URLSearchParams(window.location.search);
-      if (newShowThumbnails) {
-        urlParams.set('show_thumbnails', 'true');
-      } else {
-        urlParams.delete('show_thumbnails');
-      }
-      navigate(`?${urlParams.toString()}`, { replace: true });
-    } else if (option === 'compact') {
+    if (option === 'compact') {
       const newCompactLayout = !compactLayout;
       setCompactLayout(newCompactLayout);
 
@@ -1044,11 +1029,7 @@ const DiveTrips = () => {
                 <div className='flex items-start justify-between mb-4'>
                   <div className='flex-1'>
                     <div className='flex items-center gap-3 mb-2'>
-                      {showThumbnails && (
-                        <div className='dive-thumbnail'>
-                          <Calendar className='w-8 h-8' />
-                        </div>
-                      )}
+                      {/* Thumbnail removed */}
                       <div>
                         <h3
                           className={`font-semibold text-gray-900 ${compactLayout ? 'text-base' : 'text-lg'}`}
@@ -1325,11 +1306,7 @@ const DiveTrips = () => {
                   compactLayout ? 'p-4' : 'p-6'
                 }`}
               >
-                {showThumbnails && (
-                  <div className='dive-thumbnail bg-gray-100 p-4 flex items-center justify-center'>
-                    <Calendar className='w-12 h-12 text-gray-400' />
-                  </div>
-                )}
+                {/* Thumbnail removed */}
 
                 <div className='p-4'>
                   <h3

--- a/frontend/src/pages/Dives.js
+++ b/frontend/src/pages/Dives.js
@@ -85,10 +85,6 @@ const Dives = () => {
     const params = new URLSearchParams(window.location.search);
     return params.get('view') || 'list';
   });
-  const [showThumbnails, setShowThumbnails] = useState(() => {
-    const params = new URLSearchParams(window.location.search);
-    return params.get('show_thumbnails') === 'true';
-  });
   const [compactLayout, setCompactLayout] = useState(() => {
     const params = new URLSearchParams(window.location.search);
     return params.get('compact_layout') !== 'false'; // Default to true (compact)
@@ -753,19 +749,7 @@ const Dives = () => {
   };
 
   const handleDisplayOptionChange = option => {
-    if (option === 'thumbnails') {
-      const newShowThumbnails = !showThumbnails;
-      setShowThumbnails(newShowThumbnails);
-
-      // Update URL
-      const urlParams = new URLSearchParams(window.location.search);
-      if (newShowThumbnails) {
-        urlParams.set('show_thumbnails', 'true');
-      } else {
-        urlParams.delete('show_thumbnails');
-      }
-      navigate(`?${urlParams.toString()}`, { replace: true });
-    } else if (option === 'compact') {
+    if (option === 'compact') {
       const newCompactLayout = !compactLayout;
       setCompactLayout(newCompactLayout);
 
@@ -947,10 +931,8 @@ const Dives = () => {
         onReset={resetSorting}
         viewMode={viewMode}
         onViewModeChange={handleViewModeChange}
-        showThumbnails={showThumbnails}
         compactLayout={compactLayout}
         onDisplayOptionChange={(option, value) => {
-          if (option === 'showThumbnails') setShowThumbnails(value);
           if (option === 'compactLayout') setCompactLayout(value);
         }}
         pageType='dives'
@@ -1056,11 +1038,6 @@ const Dives = () => {
                   <div className='flex items-start justify-between mb-4 relative'>
                     <div className='flex-1'>
                       <div className='flex items-center gap-3 mb-2'>
-                        {showThumbnails && (
-                          <div className='dive-thumbnail'>
-                            <Calendar className='w-8 h-8' />
-                          </div>
-                        )}
                         <div>
                           <div className='flex flex-wrap items-center gap-2 mb-1'>
                             <div className='flex items-center gap-2 flex-1 min-w-0'>
@@ -1214,12 +1191,6 @@ const Dives = () => {
                     dive.is_private ? 'bg-purple-50 border-purple-200' : 'bg-white border-gray-200'
                   } ${compactLayout ? 'p-4' : 'p-6'}`}
                 >
-                  {showThumbnails && (
-                    <div className='dive-thumbnail bg-gray-100 p-4 flex items-center justify-center'>
-                      <Calendar className='w-12 h-12 text-gray-400' />
-                    </div>
-                  )}
-
                   <div className='p-4'>
                     <div className='flex items-center gap-2 mb-2'>
                       <div className='flex items-center gap-2 flex-1 min-w-0'>

--- a/frontend/src/pages/Dives.js
+++ b/frontend/src/pages/Dives.js
@@ -1091,11 +1091,8 @@ const Dives = () => {
                             )}
                           </div>
                           <p className={`text-gray-600 ${compactLayout ? 'text-sm' : 'text-base'}`}>
-                            {new Date(dive.dive_date).toLocaleDateString('en-GB')} at{' '}
-                            {new Date(dive.dive_date).toLocaleTimeString('en-GB', {
-                              hour: '2-digit',
-                              minute: '2-digit',
-                            })}
+                            {new Date(dive.dive_date).toLocaleDateString('en-GB')}
+                            {dive.dive_time && ` at ${formatTime(dive.dive_time)}`}
                           </p>
                         </div>
                       </div>

--- a/frontend/src/pages/Dives.js
+++ b/frontend/src/pages/Dives.js
@@ -1053,7 +1053,7 @@ const Dives = () => {
                     dive.is_private ? 'bg-purple-50 border-purple-200' : 'bg-white border-gray-200'
                   } ${compactLayout ? 'p-4' : 'p-6'}`}
                 >
-                  <div className='flex items-start justify-between mb-4'>
+                  <div className='flex items-start justify-between mb-4 relative'>
                     <div className='flex-1'>
                       <div className='flex items-center gap-3 mb-2'>
                         {showThumbnails && (
@@ -1062,14 +1062,14 @@ const Dives = () => {
                           </div>
                         )}
                         <div>
-                          <div className='flex items-center gap-2 mb-1'>
+                          <div className='flex flex-wrap items-center gap-2 mb-1'>
                             <div className='flex items-center gap-2 flex-1 min-w-0'>
                               <h3
                                 className={`font-semibold text-gray-900 flex-1 min-w-0 ${compactLayout ? 'text-base' : 'text-lg'}`}
                               >
                                 <Link
                                   to={`/dives/${dive.id}`}
-                                  className='hover:text-blue-600 transition-colors block truncate'
+                                  className='hover:text-blue-600 transition-colors block whitespace-normal break-words'
                                 >
                                   {dive.name || `Dive #${dive.id}`}
                                 </Link>
@@ -1102,7 +1102,7 @@ const Dives = () => {
                     </div>
                     <Link
                       to={`/dives/${dive.id}`}
-                      className='inline-flex items-center gap-2 px-4 py-2 text-sm text-blue-600 hover:text-blue-700 hover:bg-blue-50 rounded-lg transition-colors'
+                      className='hidden sm:inline-flex items-center gap-2 px-4 py-2 text-sm text-blue-600 hover:text-blue-700 hover:bg-blue-50 rounded-lg transition-colors'
                     >
                       <Eye className='w-4 h-4' />
                       View Dive
@@ -1231,7 +1231,7 @@ const Dives = () => {
                         >
                           <Link
                             to={`/dives/${dive.id}`}
-                            className='hover:text-blue-600 transition-colors block truncate'
+                            className='hover:text-blue-600 transition-colors block whitespace-normal break-words'
                           >
                             {dive.name || `Dive #${dive.id}`}
                           </Link>

--- a/frontend/src/pages/DivingCenters.js
+++ b/frontend/src/pages/DivingCenters.js
@@ -67,6 +67,8 @@ const DivingCenters = () => {
 
   // Quick filter state
   const [quickFilter, setQuickFilter] = useState('');
+  // Track which center emails are revealed in grid view
+  const [revealedEmails, setRevealedEmails] = useState({});
 
   // Responsive detection using custom hook
   const { isMobile } = useResponsive();
@@ -931,13 +933,24 @@ const DivingCenters = () => {
                     {/* Show email if available, otherwise rating */}
                     {center.email ? (
                       <div className='flex items-center justify-center bg-blue-50 rounded-lg px-3 py-2'>
-                        <a
-                          href={`mailto:${center.email}`}
-                          className='text-blue-500 hover:text-blue-700 transition-colors'
-                          title={`Send email to ${center.email}`}
-                        >
-                          <Mail className='w-5 h-5' />
-                        </a>
+                        {revealedEmails[center.id] ? (
+                          <span className='text-blue-600 text-sm'>
+                            {/* Use MaskedEmail to keep consistent behavior with list view */}
+                            <MaskedEmail email={center.email} className='font-medium' showMailto={true} />
+                          </span>
+                        ) : (
+                          <button
+                            type='button'
+                            onClick={() =>
+                              setRevealedEmails(prev => ({ ...prev, [center.id]: true }))
+                            }
+                            className='text-blue-500 hover:text-blue-700 transition-colors'
+                            aria-label='Reveal email'
+                            title='Click to reveal email'
+                          >
+                            <Mail className='w-5 h-5' />
+                          </button>
+                        )}
                       </div>
                     ) : center.average_rating ? (
                       <div className='flex items-center justify-center bg-yellow-50 rounded-lg px-3 py-2'>

--- a/frontend/src/pages/DivingCenters.js
+++ b/frontend/src/pages/DivingCenters.js
@@ -497,6 +497,16 @@ const DivingCenters = () => {
     setPagination(prev => ({ ...prev, page: 1 }));
   };
 
+  // Apply a filter when clicking a badge (country, region, city)
+  const applyFilterTag = (key, value) => {
+    if (!value) return;
+    const newFilters = { ...filters, [key]: value };
+    const newPagination = { ...pagination, page: 1 };
+    setFilters(newFilters);
+    setPagination(newPagination);
+    immediateUpdateURL(newFilters, newPagination, viewMode);
+  };
+
   if (isLoading) {
     return (
       <div className='flex justify-center items-center h-64'>
@@ -783,26 +793,41 @@ const DivingCenters = () => {
 
                       {/* Coordinates removed to save space */}
 
-                      {/* Geographic fields */}
+                      {/* Geographic fields (clickable badges) */}
                       {center.country && (
-                        <div className='flex items-center gap-1 text-xs text-gray-600'>
-                          <Globe className='w-3 h-3 text-gray-400' />
+                        <button
+                          type='button'
+                          onClick={() => applyFilterTag('country', center.country)}
+                          className='flex items-center gap-1 text-xs text-blue-700 bg-blue-50 hover:bg-blue-100 px-2 py-1 rounded'
+                          title={`Filter by country: ${center.country}`}
+                        >
+                          <Globe className='w-3 h-3 text-blue-600' />
                           <span className='truncate'>{center.country}</span>
-                        </div>
+                        </button>
                       )}
 
                       {center.region && (
-                        <div className='flex items-center gap-1 text-xs text-gray-600'>
-                          <MapPin className='w-3 h-3 text-gray-400' />
+                        <button
+                          type='button'
+                          onClick={() => applyFilterTag('region', center.region)}
+                          className='flex items-center gap-1 text-xs text-green-700 bg-green-50 hover:bg-green-100 px-2 py-1 rounded'
+                          title={`Filter by region: ${center.region}`}
+                        >
+                          <MapPin className='w-3 h-3 text-green-600' />
                           <span className='truncate'>{center.region}</span>
-                        </div>
+                        </button>
                       )}
 
                       {center.city && (
-                        <div className='flex items-center gap-1 text-xs text-gray-600'>
-                          <Building className='w-3 h-3 text-gray-400' />
+                        <button
+                          type='button'
+                          onClick={() => applyFilterTag('city', center.city)}
+                          className='flex items-center gap-1 text-xs text-purple-700 bg-purple-50 hover:bg-purple-100 px-2 py-1 rounded'
+                          title={`Filter by city: ${center.city}`}
+                        >
+                          <Building className='w-3 h-3 text-purple-600' />
                           <span className='truncate'>{center.city}</span>
-                        </div>
+                        </button>
                       )}
                     </div>
 
@@ -903,26 +928,41 @@ const DivingCenters = () => {
                   {(center.country || center.region || center.city) && (
                     <div className='flex flex-wrap gap-2 mb-4'>
                       {center.country && (
-                        <div className='flex items-center gap-1 bg-blue-50 px-2 py-1 rounded-full'>
+                        <button
+                          type='button'
+                          onClick={() => applyFilterTag('country', center.country)}
+                          className='flex items-center gap-1 bg-blue-50 px-2 py-1 rounded-full hover:bg-blue-100'
+                          title={`Filter by country: ${center.country}`}
+                        >
                           <Globe className='w-3 h-3 text-blue-600' />
                           <span className='text-xs font-medium text-blue-700'>
                             {center.country}
                           </span>
-                        </div>
+                        </button>
                       )}
                       {center.region && (
-                        <div className='flex items-center gap-1 bg-green-50 px-2 py-1 rounded-full'>
+                        <button
+                          type='button'
+                          onClick={() => applyFilterTag('region', center.region)}
+                          className='flex items-center gap-1 bg-green-50 px-2 py-1 rounded-full hover:bg-green-100'
+                          title={`Filter by region: ${center.region}`}
+                        >
                           <MapPin className='w-3 h-3 text-green-600' />
                           <span className='text-xs font-medium text-green-700'>
                             {center.region}
                           </span>
-                        </div>
+                        </button>
                       )}
                       {center.city && (
-                        <div className='flex items-center gap-1 bg-purple-50 px-2 py-1 rounded-full'>
+                        <button
+                          type='button'
+                          onClick={() => applyFilterTag('city', center.city)}
+                          className='flex items-center gap-1 bg-purple-50 px-2 py-1 rounded-full hover:bg-purple-100'
+                          title={`Filter by city: ${center.city}`}
+                        >
                           <Building className='w-3 h-3 text-purple-600' />
                           <span className='text-xs font-medium text-purple-700'>{center.city}</span>
-                        </div>
+                        </button>
                       )}
                     </div>
                   )}

--- a/frontend/src/pages/DivingCenters.js
+++ b/frontend/src/pages/DivingCenters.js
@@ -56,10 +56,7 @@ const DivingCenters = () => {
     const params = new URLSearchParams(window.location.search);
     return params.get('view') || 'list';
   });
-  const [showThumbnails, setShowThumbnails] = useState(() => {
-    const params = new URLSearchParams(window.location.search);
-    return params.get('show_thumbnails') === 'true';
-  });
+  // Thumbnails feature removed
   const [compactLayout, setCompactLayout] = useState(() => {
     const params = new URLSearchParams(window.location.search);
     return params.get('compact_layout') !== 'false'; // Default to true (compact)
@@ -434,19 +431,7 @@ const DivingCenters = () => {
   };
 
   const handleDisplayOptionChange = option => {
-    if (option === 'thumbnails') {
-      const newShowThumbnails = !showThumbnails;
-      setShowThumbnails(newShowThumbnails);
-
-      // Update URL
-      const urlParams = new URLSearchParams(window.location.search);
-      if (newShowThumbnails) {
-        urlParams.set('show_thumbnails', 'true');
-      } else {
-        urlParams.delete('show_thumbnails');
-      }
-      navigate(`?${urlParams.toString()}`, { replace: true });
-    } else if (option === 'compact') {
+    if (option === 'compact') {
       const newCompactLayout = !compactLayout;
       setCompactLayout(newCompactLayout);
 
@@ -696,7 +681,6 @@ const DivingCenters = () => {
           onReset={resetSorting}
           viewMode={viewMode}
           onViewModeChange={handleViewModeChange}
-          showThumbnails={showThumbnails}
           compactLayout={compactLayout}
           onDisplayOptionChange={handleDisplayOptionChange}
         />
@@ -862,21 +846,7 @@ const DivingCenters = () => {
                   compactLayout ? 'p-4' : 'p-6'
                 }`}
               >
-                {/* Header with thumbnail and rating */}
-                <div className='relative'>
-                  {showThumbnails && (
-                    <div className='dive-thumbnail bg-gradient-to-br from-blue-50 to-cyan-50 p-6 flex items-center justify-center border-b border-gray-100'>
-                      <div className='relative'>
-                        <Building className='w-16 h-16 text-blue-600' />
-                        {center.average_rating && (
-                          <div className='absolute -top-2 -right-2 bg-yellow-400 text-white text-xs font-bold rounded-full w-6 h-6 flex items-center justify-center'>
-                            {Math.round(center.average_rating)}
-                          </div>
-                        )}
-                      </div>
-                    </div>
-                  )}
-                </div>
+                {/* Header thumbnail removed */}
 
                 <div className={`${compactLayout ? 'p-3' : 'p-5'}`}>
                   {/* Title and rating row */}


### PR DESCRIPTION
### Description
This PR delivers multiple UX and correctness improvements across Dives and Diving Centers, removes legacy thumbnail functionality, and introduces clickable location badges for quick filtering.

#### Highlights
- Accurate dive time in list view using `dive_time` (matches details/grid)
- Better mobile usability and multi-line title wrapping on Dives
- Diving Centers grid refinements (3-column layout on md+, expandable descriptions)
- Privacy-friendly email reveal flow in grid (icon remains; click-to-arm mailto)
- Clickable country/region/city badges that apply filters and update the URL
- Removal of obsolete “thumbnails” mode and related code/docs

---

### Commits Included (not in main)
- 6fd3f8f — Make location badges filter Diving Centers  
  - Convert country/region/city badges to buttons; apply filter, reset to page 1, update URL

- a2c4b9a — Refine Diving Centers grid and email behavior  
  - 3 columns on md+; grid descriptions More/Less toggle  
  - Email reveal: icon remains; first click arms mailto, second opens  
  - Remove coordinates from list/grid cards

- eb3cb22 — Mask emails in Diving Centers grid until revealed  
  - Initial grid behavior to hide email behind icon

- 9300ab1 — Remove thumbnail UI and wiring; validate pages desktop/mobile  
  - Remove “Thumbnails” toggle and `showThumbnails` state/URL/code/styles  
  - Fix compact toggle wiring in Diving Centers filter bar  
  - Update docs and validate main pages

- 7e94881 — Fix dive time in list view to use `dive_time`  
  - Replace timezone-shifted time derived from `dive_date` with `formatTime(dive_time)`

- 9387497 — Improve mobile dives header alignment and wrapping  
  - Remove mobile “View” button; title is tap target  
  - Enable multi-line title wrapping in list and grid

---

### Files/Areas Touched
- `frontend/src/pages/Dives.js`  
- `frontend/src/pages/DivingCenters.js`  
- `frontend/src/pages/DiveSites.js`  
- `frontend/src/pages/DiveTrips.js`  
- `frontend/src/components/ResponsiveFilterBar.js`  
- `frontend/src/components/DivingCentersResponsiveFilterBar.js`  
- `frontend/src/index.css`  
- Documentation under `docs/development/*`

### Testing & Validation
- Desktop/mobile manual validation:
  - Dives: time matches details; long titles wrap; mobile header OK
  - Diving Centers: grid is 3 columns on md+; description toggle works; email icon reveal flow works
  - Location badges (list and grid) apply filters and update URL
  - No remaining thumbnails UI/state; compact toggle working

### Rationale
- Fixes visible time inconsistencies  
- Improves small-screen readability and interaction  
- Simplifies UI by removing low-value thumbnails mode  
- Adds intuitive location-based filtering

### Migration/Compatibility
- No backend changes  
- Removes frontend thumbnails mode and related URL parameters