### PR TITLE
Implement additive quick filters for dive sites

### DIFF
--- a/frontend/src/components/ResponsiveFilterBar.js
+++ b/frontend/src/components/ResponsiveFilterBar.js
@@ -26,7 +26,7 @@ const ResponsiveFilterBar = ({
   filters = {},
   onFilterChange = () => {},
   onQuickFilter = () => {},
-  quickFilter = '',
+  quickFilters = [],
   className = '',
   variant = 'sticky',
   showQuickFilters = true,
@@ -228,7 +228,7 @@ const ResponsiveFilterBar = ({
                     <button
                       onClick={() => onQuickFilter('my_dives')}
                       className={`flex items-center gap-1 px-3 py-2 text-sm rounded-md transition-colors ${
-                        quickFilter === 'my_dives'
+                        quickFilters.includes('my_dives')
                           ? 'bg-blue-100 text-blue-700 border border-blue-300 shadow-sm'
                           : 'bg-gray-50 text-gray-600 border border-gray-200 hover:bg-gray-100 active:bg-gray-200'
                       }`}
@@ -240,7 +240,7 @@ const ResponsiveFilterBar = ({
                   <button
                     onClick={() => onQuickFilter('wrecks')}
                     className={`flex items-center gap-1 px-3 py-2 text-sm rounded-md transition-colors ${
-                      quickFilter === 'wrecks'
+                      quickFilters.includes('wrecks')
                         ? 'bg-blue-100 text-blue-700 border border-blue-300 shadow-sm'
                         : 'bg-gray-50 text-gray-600 border border-gray-200 hover:bg-gray-100 active:bg-gray-200'
                     }`}
@@ -251,7 +251,7 @@ const ResponsiveFilterBar = ({
                   <button
                     onClick={() => onQuickFilter('reefs')}
                     className={`flex items-center gap-1 px-3 py-2 text-sm rounded-md transition-colors ${
-                      quickFilter === 'reefs'
+                      quickFilters.includes('reefs')
                         ? 'bg-blue-100 text-blue-700 border border-blue-300 shadow-sm'
                         : 'bg-gray-50 text-gray-600 border border-gray-200 hover:bg-gray-100 active:bg-gray-200'
                     }`}
@@ -262,7 +262,7 @@ const ResponsiveFilterBar = ({
                   <button
                     onClick={() => onQuickFilter('boat_dive')}
                     className={`flex items-center gap-1 px-3 py-2 text-sm rounded-md transition-colors ${
-                      quickFilter === 'boat_dive'
+                      quickFilters.includes('boat_dive')
                         ? 'bg-blue-100 text-blue-700 border border-blue-300 shadow-sm'
                         : 'bg-gray-50 text-gray-600 border border-gray-200 hover:bg-gray-100 active:bg-gray-200'
                     }`}
@@ -273,7 +273,7 @@ const ResponsiveFilterBar = ({
                   <button
                     onClick={() => onQuickFilter('shore_dive')}
                     className={`flex items-center gap-1 px-3 py-2 text-sm rounded-md transition-colors ${
-                      quickFilter === 'shore_dive'
+                      quickFilters.includes('shore_dive')
                         ? 'bg-blue-100 text-blue-700 border border-blue-300 shadow-sm'
                         : 'bg-gray-50 text-gray-600 border border-gray-200 hover:bg-gray-100 active:bg-gray-200'
                     }`}
@@ -288,7 +288,7 @@ const ResponsiveFilterBar = ({
                   <button
                     onClick={() => onQuickFilter('wrecks')}
                     className={`flex items-center gap-1 px-3 py-2 text-sm rounded-md transition-colors ${
-                      quickFilter === 'wrecks'
+                      quickFilters.includes('wrecks')
                         ? 'bg-blue-100 text-blue-700 border border-blue-300 shadow-sm'
                         : 'bg-gray-50 text-gray-600 border border-gray-200 hover:bg-gray-100 active:bg-gray-200'
                     }`}
@@ -299,7 +299,7 @@ const ResponsiveFilterBar = ({
                   <button
                     onClick={() => onQuickFilter('reefs')}
                     className={`flex items-center gap-1 px-3 py-2 text-sm rounded-md transition-colors ${
-                      quickFilter === 'reefs'
+                      quickFilters.includes('reefs')
                         ? 'bg-blue-100 text-blue-700 border border-blue-300 shadow-sm'
                         : 'bg-gray-50 text-gray-600 border border-gray-200 hover:bg-gray-100 active:bg-gray-200'
                     }`}
@@ -310,7 +310,7 @@ const ResponsiveFilterBar = ({
                   <button
                     onClick={() => onQuickFilter('boat_dive')}
                     className={`flex items-center gap-1 px-3 py-2 text-sm rounded-md transition-colors ${
-                      quickFilter === 'boat_dive'
+                      quickFilters.includes('boat_dive')
                         ? 'bg-blue-100 text-blue-700 border border-blue-300 shadow-sm'
                         : 'bg-gray-50 text-gray-600 border border-gray-200 hover:bg-gray-100 active:bg-gray-200'
                     }`}
@@ -321,7 +321,7 @@ const ResponsiveFilterBar = ({
                   <button
                     onClick={() => onQuickFilter('shore_dive')}
                     className={`flex items-center gap-1 px-3 py-2 text-sm rounded-md transition-colors ${
-                      quickFilter === 'shore_dive'
+                      quickFilters.includes('shore_dive')
                         ? 'bg-blue-100 text-blue-700 border border-blue-300 shadow-sm'
                         : 'bg-gray-50 text-gray-600 border border-gray-200 hover:bg-gray-100 active:bg-gray-200'
                     }`}
@@ -665,7 +665,7 @@ const ResponsiveFilterBar = ({
                     <button
                       onClick={() => onQuickFilter('my_dives')}
                       className={`flex-shrink-0 px-3 py-2 text-sm rounded-lg transition-colors min-h-[44px] ${
-                        quickFilter === 'my_dives'
+                        quickFilters.includes('my_dives')
                           ? 'bg-blue-100 text-blue-700 border border-blue-300'
                           : 'bg-gray-100 text-gray-600 border border-gray-200 hover:bg-gray-200'
                       }`}
@@ -677,7 +677,7 @@ const ResponsiveFilterBar = ({
                   <button
                     onClick={() => onQuickFilter('wrecks')}
                     className={`flex-shrink-0 px-3 py-2 text-sm rounded-lg transition-colors min-h-[44px] ${
-                      quickFilter === 'wrecks'
+                      quickFilters.includes('wrecks')
                         ? 'bg-blue-100 text-blue-700 border border-blue-300'
                         : 'bg-gray-100 text-gray-600 border border-gray-200 hover:bg-gray-200'
                     }`}
@@ -688,7 +688,7 @@ const ResponsiveFilterBar = ({
                   <button
                     onClick={() => onQuickFilter('reefs')}
                     className={`flex-shrink-0 px-3 py-2 text-sm rounded-lg transition-colors min-h-[44px] ${
-                      quickFilter === 'reefs'
+                      quickFilters.includes('reefs')
                         ? 'bg-blue-100 text-blue-700 border border-blue-300'
                         : 'bg-gray-100 text-gray-600 border border-gray-200 hover:bg-gray-200'
                     }`}
@@ -699,7 +699,7 @@ const ResponsiveFilterBar = ({
                   <button
                     onClick={() => onQuickFilter('boat_dive')}
                     className={`flex-shrink-0 px-3 py-2 text-sm rounded-lg transition-colors min-h-[44px] ${
-                      quickFilter === 'boat_dive'
+                      quickFilters.includes('boat_dive')
                         ? 'bg-blue-100 text-blue-700 border border-blue-300'
                         : 'bg-gray-100 text-gray-600 border border-gray-200 hover:bg-gray-200'
                     }`}
@@ -710,7 +710,7 @@ const ResponsiveFilterBar = ({
                   <button
                     onClick={() => onQuickFilter('shore_dive')}
                     className={`flex-shrink-0 px-3 py-2 text-sm rounded-lg transition-colors min-h-[44px] ${
-                      quickFilter === 'shore_dive'
+                      quickFilters.includes('shore_dive')
                         ? 'bg-blue-100 text-blue-700 border border-blue-300'
                         : 'bg-gray-100 text-gray-600 border border-gray-200 hover:bg-gray-200'
                     }`}
@@ -725,7 +725,7 @@ const ResponsiveFilterBar = ({
                   <button
                     onClick={() => onQuickFilter('wrecks')}
                     className={`flex-shrink-0 px-3 py-2 text-sm rounded-lg transition-colors min-h-[44px] ${
-                      quickFilter === 'wrecks'
+                      quickFilters.includes('wrecks')
                         ? 'bg-blue-100 text-blue-700 border border-blue-300'
                         : 'bg-gray-100 text-gray-600 border border-gray-200 hover:bg-gray-200'
                     }`}
@@ -736,7 +736,7 @@ const ResponsiveFilterBar = ({
                   <button
                     onClick={() => onQuickFilter('reefs')}
                     className={`flex-shrink-0 px-3 py-2 text-sm rounded-lg transition-colors min-h-[44px] ${
-                      quickFilter === 'reefs'
+                      quickFilters.includes('reefs')
                         ? 'bg-blue-100 text-blue-700 border border-blue-300'
                         : 'bg-gray-100 text-gray-600 border border-gray-200 hover:bg-gray-200'
                     }`}
@@ -747,7 +747,7 @@ const ResponsiveFilterBar = ({
                   <button
                     onClick={() => onQuickFilter('boat_dive')}
                     className={`flex-shrink-0 px-3 py-2 text-sm rounded-lg transition-colors min-h-[44px] ${
-                      quickFilter === 'boat_dive'
+                      quickFilters.includes('boat_dive')
                         ? 'bg-blue-100 text-blue-700 border border-blue-300'
                         : 'bg-gray-100 text-gray-600 border border-gray-200 hover:bg-gray-200'
                     }`}
@@ -758,7 +758,7 @@ const ResponsiveFilterBar = ({
                   <button
                     onClick={() => onQuickFilter('shore_dive')}
                     className={`flex-shrink-0 px-3 py-2 text-sm rounded-lg transition-colors min-h-[44px] ${
-                      quickFilter === 'shore_dive'
+                      quickFilters.includes('shore_dive')
                         ? 'bg-blue-100 text-blue-700 border border-blue-300'
                         : 'bg-gray-100 text-gray-600 border border-gray-200 hover:bg-gray-200'
                     }`}
@@ -1061,7 +1061,7 @@ ResponsiveFilterBar.propTypes = {
   filters: PropTypes.object,
   onFilterChange: PropTypes.func,
   onQuickFilter: PropTypes.func,
-  quickFilter: PropTypes.string,
+  quickFilters: PropTypes.array,
   className: PropTypes.string,
   variant: PropTypes.oneOf(['sticky', 'floating', 'inline']),
   showQuickFilters: PropTypes.bool,

--- a/frontend/src/pages/DiveSites.js
+++ b/frontend/src/pages/DiveSites.js
@@ -50,7 +50,7 @@ const DiveSites = () => {
   });
   const [showFilters, setShowFilters] = useState(false);
   const [showAdvancedFilters, setShowAdvancedFilters] = useState(false);
-  const [quickFilter, setQuickFilter] = useState('');
+  const [quickFilters, setQuickFilters] = useState([]);
 
   // Thumbnails feature removed
   const [compactLayout, setCompactLayout] = useState(() => {
@@ -486,74 +486,62 @@ const DiveSites = () => {
   };
 
   const handleQuickFilter = filterType => {
-    setQuickFilter(filterType);
+    // Toggle the filter in the quickFilters array
+    setQuickFilters(prev => {
+      if (prev.includes(filterType)) {
+        // Remove filter if already selected
+        return prev.filter(f => f !== filterType);
+      } else {
+        // Add filter if not selected
+        return [...prev, filterType];
+      }
+    });
 
-    // Apply the quick filter
-    switch (filterType) {
-      case 'beginner':
-        setFilters(prev => ({
-          ...prev,
-          difficulty_level: 'beginner',
-          search_query: '',
-        }));
-        break;
-      case 'intermediate':
-        setFilters(prev => ({
-          ...prev,
-          difficulty_level: 'intermediate',
-          search_query: '',
-        }));
-        break;
-      case 'advanced':
-        setFilters(prev => ({
-          ...prev,
-          difficulty_level: 'advanced',
-          search_query: '',
-        }));
-        break;
-      case 'wrecks':
-        setFilters(prev => ({
-          ...prev,
-          tag_ids: [8], // Wreck tag ID
-          search_query: '',
-          difficulty_level: '',
-        }));
-        break;
-      case 'reefs':
-        setFilters(prev => ({
-          ...prev,
-          tag_ids: [14], // Reef tag ID
-          search_query: '',
-          difficulty_level: '',
-        }));
-        break;
-      case 'boat_dive':
-        setFilters(prev => ({
-          ...prev,
-          tag_ids: [4], // Boat Dive tag ID
-          search_query: '',
-          difficulty_level: '',
-        }));
-        break;
-      case 'shore_dive':
-        setFilters(prev => ({
-          ...prev,
-          tag_ids: [13], // Shore Dive tag ID
-          search_query: '',
-          difficulty_level: '',
-        }));
-        break;
-      case 'clear':
-        setQuickFilter('');
-        setFilters(prev => ({
-          ...prev,
-          difficulty_level: '',
-          search_query: '',
-          tag_ids: [],
-        }));
-        break;
-      default:
-        break;
+    // Apply the quick filter changes
+    if (filterType === 'clear') {
+      setQuickFilters([]);
+      setFilters(prev => ({
+        ...prev,
+        difficulty_level: '',
+        search_query: '',
+        tag_ids: [],
+      }));
+    } else {
+      // Handle additive tag filters
+      const tagIdMap = {
+        wrecks: 8,
+        reefs: 14,
+        boat_dive: 4,
+        shore_dive: 13,
+      };
+
+      // Handle difficulty filters (these are mutually exclusive)
+      const difficultyFilters = ['beginner', 'intermediate', 'advanced'];
+
+      setFilters(prev => {
+        const newFilters = { ...prev };
+
+        if (difficultyFilters.includes(filterType)) {
+          // For difficulty, replace any existing difficulty
+          newFilters.difficulty_level = filterType;
+          newFilters.search_query = '';
+        } else if (tagIdMap[filterType]) {
+          // For tag filters, add/remove from existing tags
+          const currentTagIds = prev.tag_ids || [];
+          const tagId = tagIdMap[filterType];
+
+          if (currentTagIds.includes(tagId)) {
+            // Remove tag if already selected
+            newFilters.tag_ids = currentTagIds.filter(id => id !== tagId);
+          } else {
+            // Add tag if not selected
+            newFilters.tag_ids = [...currentTagIds, tagId];
+          }
+          newFilters.search_query = '';
+        }
+
+        return newFilters;
+      });
     }
 
     // Reset to first page
@@ -683,7 +671,7 @@ const DiveSites = () => {
             filters={{ ...filters, availableTags, user }}
             onFilterChange={handleFilterChange}
             onQuickFilter={handleQuickFilter}
-            quickFilter={quickFilter}
+            quickFilters={quickFilters}
             variant='inline'
             showQuickFilters={true}
             showAdvancedToggle={true}


### PR DESCRIPTION
Replace single quickFilter state with quickFilters array to enable multiple simultaneous tag filters. Users can now select Wreck AND Reef filters instead of being limited to one at a time.

- Change quickFilter string to quickFilters array in DiveSites.js
- Update handleQuickFilter to toggle filters in/out of array
- Modify ResponsiveFilterBar to check array membership for active state
- Maintain mutually exclusive behavior for difficulty filters
- Update PropTypes and mobile/desktop UI components

Fixes additive filtering behavior where clicking multiple quick filter buttons now applies AND logic instead of replacing previous selection.