### PR TITLE
Add URL clickability to dive site descriptions

### DIFF
--- a/frontend/src/components/DiveSitesMap.js
+++ b/frontend/src/components/DiveSitesMap.js
@@ -8,6 +8,7 @@ import { MapContainer, TileLayer, Marker, Popup, useMap } from 'react-leaflet';
 import { Link } from 'react-router-dom';
 
 import { getDifficultyLabel, getDifficultyColorClasses } from '../utils/difficultyHelpers';
+import { renderTextWithLinks } from '../utils/textHelpers';
 
 // Fix default marker icons
 delete L.Icon.Default.prototype._getIconUrl;
@@ -322,7 +323,9 @@ const DiveSitesMap = ({ diveSites, onViewportChange }) => {
                 <div className='p-2'>
                   <h3 className='font-semibold text-gray-900 mb-1'>{site.name}</h3>
                   {site.description && (
-                    <p className='text-sm text-gray-600 mb-2 line-clamp-2'>{site.description}</p>
+                    <p className='text-sm text-gray-600 mb-2 line-clamp-2'>
+                      {renderTextWithLinks(site.description)}
+                    </p>
                   )}
                   <div className='flex items-center justify-between mb-2'>
                     <span

--- a/frontend/src/pages/DiveDetail.js
+++ b/frontend/src/pages/DiveDetail.js
@@ -26,6 +26,7 @@ import { useAuth } from '../contexts/AuthContext';
 import usePageTitle from '../hooks/usePageTitle';
 import { getDifficultyLabel, getDifficultyColorClasses } from '../utils/difficultyHelpers';
 import { handleRateLimitError } from '../utils/rateLimitHandler';
+import { renderTextWithLinks } from '../utils/textHelpers';
 
 const DiveDetail = () => {
   const { id } = useParams();
@@ -596,7 +597,9 @@ const DiveDetail = () => {
                   <span className='font-medium'>{dive.dive_site.name}</span>
                 </div>
                 {dive.dive_site.description && (
-                  <p className='text-sm text-gray-600'>{dive.dive_site.description}</p>
+                  <p className='text-sm text-gray-600'>
+                    {renderTextWithLinks(dive.dive_site.description)}
+                  </p>
                 )}
                 <RouterLink
                   to={`/dive-sites/${dive.dive_site.id}`}
@@ -618,7 +621,9 @@ const DiveDetail = () => {
                   <span className='font-medium'>{dive.diving_center.name}</span>
                 </div>
                 {dive.diving_center.description && (
-                  <p className='text-sm text-gray-600'>{dive.diving_center.description}</p>
+                  <p className='text-sm text-gray-600'>
+                    {renderTextWithLinks(dive.diving_center.description)}
+                  </p>
                 )}
                 <RouterLink
                   to={`/diving-centers/${dive.diving_center.id}`}

--- a/frontend/src/pages/DiveSiteDetail.js
+++ b/frontend/src/pages/DiveSiteDetail.js
@@ -24,6 +24,7 @@ import { formatCost, DEFAULT_CURRENCY } from '../utils/currency';
 import { getDifficultyLabel, getDifficultyColorClasses } from '../utils/difficultyHelpers';
 import { handleRateLimitError } from '../utils/rateLimitHandler';
 import { getTagColor } from '../utils/tagHelpers';
+import { renderTextWithLinks } from '../utils/textHelpers';
 
 // Helper function to safely extract error message
 const getErrorMessage = error => {
@@ -308,7 +309,9 @@ const DiveSiteDetail = () => {
               <h2 className='text-lg sm:text-xl font-semibold text-gray-900 mb-3 sm:mb-4'>
                 Description
               </h2>
-              <p className='text-gray-700 text-sm sm:text-base'>{diveSite.description}</p>
+              <p className='text-gray-700 text-sm sm:text-base'>
+                {renderTextWithLinks(diveSite.description)}
+              </p>
             </div>
           )}
 

--- a/frontend/src/pages/DiveSites.js
+++ b/frontend/src/pages/DiveSites.js
@@ -33,6 +33,7 @@ import { getDifficultyLabel, getDifficultyColorClasses } from '../utils/difficul
 import { handleRateLimitError } from '../utils/rateLimitHandler';
 import { getSortOptions } from '../utils/sortOptions';
 import { getTagColor } from '../utils/tagHelpers';
+import { renderTextWithLinks } from '../utils/textHelpers';
 
 const DiveSites = () => {
   const { user, isAdmin } = useAuth();
@@ -861,22 +862,7 @@ const DiveSites = () => {
                     <p
                       className={`text-gray-700 ${compactLayout ? 'text-xs' : 'text-sm'} mb-2 line-clamp-2`}
                     >
-                      {site.description.split(/(https?:\/\/[^\s]+)/).map((part, index) => {
-                        if (part.match(/^https?:\/\//)) {
-                          return (
-                            <a
-                              key={index}
-                              href={part}
-                              target='_blank'
-                              rel='noopener noreferrer'
-                              className='text-blue-600 hover:text-blue-800 underline break-all'
-                            >
-                              {part}
-                            </a>
-                          );
-                        }
-                        return part;
-                      })}
+                      {renderTextWithLinks(site.description)}
                     </p>
                   )}
 

--- a/frontend/src/pages/TripDetail.js
+++ b/frontend/src/pages/TripDetail.js
@@ -7,6 +7,7 @@ import { getParsedTrip, getDiveSite, getDivingCenter } from '../api';
 import MaskedEmail from '../components/MaskedEmail';
 import TripHeader from '../components/TripHeader';
 import usePageTitle from '../hooks/usePageTitle';
+import { renderTextWithLinks } from '../utils/textHelpers';
 import { generateTripName } from '../utils/tripNameGenerator';
 const TripDetail = () => {
   const { id } = useParams();
@@ -161,7 +162,9 @@ const TripDetail = () => {
                       {dive.dive_site_id && diveSite && (
                         <div className='text-sm text-gray-600'>
                           <p className='mb-2'>
-                            {diveSite.description || 'No description available'}
+                            {diveSite.description
+                              ? renderTextWithLinks(diveSite.description)
+                              : 'No description available'}
                           </p>
                           {dive.dive_description && (
                             <p className='mb-2 text-gray-700'>

--- a/frontend/src/utils/textHelpers.js
+++ b/frontend/src/utils/textHelpers.js
@@ -1,0 +1,74 @@
+/**
+ * Utility functions for text processing and formatting
+ */
+
+/**
+ * Converts URLs in text to clickable links
+ * @param {string} text - The text to process
+ * @param {Object} options - Configuration options
+ * @param {string} options.linkClassName - CSS classes for links
+ * @param {boolean} options.targetBlank - Whether to open links in new tab
+ * @returns {Array} Array of React elements and strings
+ */
+export const linkifyUrls = (text, options = {}) => {
+  const {
+    linkClassName = 'text-blue-600 hover:text-blue-800 underline break-all',
+    targetBlank = true,
+  } = options;
+
+  if (!text || typeof text !== 'string') {
+    return text;
+  }
+
+  // Split text by URLs (http/https)
+  const parts = text.split(/(https?:\/\/[^\s]+)/);
+
+  return parts.map((part, index) => {
+    // Check if this part is a URL
+    if (part.match(/^https?:\/\//)) {
+      return {
+        type: 'link',
+        key: index,
+        href: part,
+        text: part,
+        className: linkClassName,
+        target: targetBlank ? '_blank' : '_self',
+        rel: targetBlank ? 'noopener noreferrer' : undefined,
+      };
+    }
+    return {
+      type: 'text',
+      key: index,
+      text: part,
+    };
+  });
+};
+
+/**
+ * Renders text with clickable URLs as React elements
+ * @param {string} text - The text to process
+ * @param {Object} options - Configuration options
+ * @param {string} options.linkClassName - CSS classes for links
+ * @param {boolean} options.targetBlank - Whether to open links in new tab
+ * @returns {Array} Array of React elements and strings
+ */
+export const renderTextWithLinks = (text, options = {}) => {
+  const linkifiedParts = linkifyUrls(text, options);
+
+  return linkifiedParts.map(part => {
+    if (part.type === 'link') {
+      return (
+        <a
+          key={part.key}
+          href={part.href}
+          target={part.target}
+          rel={part.rel}
+          className={part.className}
+        >
+          {part.text}
+        </a>
+      );
+    }
+    return part.text;
+  });
+};


### PR DESCRIPTION
Implement automatic URL detection and link conversion for dive site descriptions across all pages. URLs are now clickable and open in new tabs with proper security attributes.

- Create textHelpers.js utility with linkifyUrls and renderTextWithLinks
- Update DiveDetail.js sidebar dive site description
- Update DiveSiteDetail.js main description section
- Update TripDetail.js dive site descriptions
- Update DiveSitesMap.js map popup descriptions
- Update DiveSites.js list/grid view descriptions
- Add proper styling with blue links and hover effects
- Ensure all links open in new tabs with security attributes

Fixes issue where URLs in dive site descriptions were not clickable.