### PR TITLE
Add nginx cold-start loading page and utilities

### DIFF
--- a/nginx/Dockerfile.prod
+++ b/nginx/Dockerfile.prod
@@ -9,6 +9,9 @@ RUN apk add --no-cache \
 # Copy production configuration
 COPY prod.conf /etc/nginx/nginx.conf
 
+# Copy static loading page used during auto-start warmup
+COPY loading.html /usr/share/nginx/html/loading.html
+
 # Set proper permissions (nginx user already exists in base image)
 RUN chown -R nginx:nginx /var/cache/nginx && \
     chown -R nginx:nginx /var/log/nginx && \

--- a/nginx/loading.html
+++ b/nginx/loading.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>Starting Divemap…</title>
+    <style>
+      html,body{height:100%;margin:0;font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu;}
+      .wrap{display:flex;align-items:center;justify-content:center;height:100%;color:#374151}
+      .box{max-width:32rem;text-align:center;padding:16px}
+      .spinner{width:48px;height:48px;border:4px solid #E5E7EB;border-top-color:#0072B2;border-radius:50%;margin:0 auto 16px;animation:spin 1s linear infinite}
+      @keyframes spin {to{transform:rotate(360deg)}}
+    </style>
+  </head>
+  <body>
+    <div class="wrap">
+      <div class="box">
+        <div class="spinner"></div>
+        <h1>Starting Divemap…</h1>
+        <p>Warming up services. This typically takes a few seconds.</p>
+        <p id="quip" style="margin-top:8px;opacity:.85">🤿 Finding the scuba gear…</p>
+      </div>
+    </div>
+    <script>
+      // Poll backend /health and reload when healthy (with debug logging and timeout)
+      async function poll() {
+        const startedAt = Date.now();
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort('timeout'), 1000);
+        try {
+          const res = await fetch('/health', { cache: 'no-store', signal: controller.signal });
+          console.log('[Divemap Loading] /health', new Date(startedAt).toISOString(), res.status);
+          if (res.ok) {
+            location.reload();
+            return;
+          }
+        } catch (e) {
+          console.log('[Divemap Loading] /health error', e);
+        } finally {
+          clearTimeout(timeoutId);
+        }
+        setTimeout(poll, 500);
+      }
+      poll();
+
+      // Lighthearted rotating messages while we wait for the ocean (services) to warm up
+      const quips = [
+        '🤿 Finding the scuba gear…',
+        '🐟 Counting fish… 1, 2, 3… so many fish!',
+        '🌊 Calibrating dive computer…',
+        '🧭 Checking currents and compass bearings…',
+        '🐠 Shoaling assets… I mean fish.',
+        '🦑 Negotiating with the squid for faster ink-ternet…',
+        '🐡 Inflating the BCD… gently.',
+        '🪸 Untangling lines from the coral (carefully)…',
+        '🦈 Asking the sharks for an ETA…',
+        '📡 Pinging the dive boat—almost there…'
+      ];
+      const quipEl = document.getElementById('quip');
+      let quipIdx = 0;
+      setInterval(() => {
+        quipIdx = (quipIdx + 1) % quips.length;
+        if (quipEl) quipEl.textContent = quips[quipIdx];
+      }, 1200);
+    </script>
+  </body>
+  </html>
+
+

--- a/nginx/prod.conf
+++ b/nginx/prod.conf
@@ -73,6 +73,12 @@ http {
 
         # Frontend routes
         location / {
+            # Intercept upstream errors here only (keep APIs returning real status codes)
+            proxy_intercept_errors on;
+            # Serve a loading page with HTTP 200 when upstream isn't ready yet
+            # Typical boot-time upstream errors from Fly auto-start: 502/503/504
+            error_page 502 503 504 =200 /loading.html;
+
             proxy_pass http://frontend;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
@@ -92,8 +98,16 @@ http {
             # Frontend specific settings
             proxy_buffering off;
             proxy_cache off;
-            proxy_read_timeout 300s;
-            proxy_connect_timeout 75s;
+            # Fail fast while upstream containers boot so we can show loading page
+            proxy_connect_timeout 250ms;
+            proxy_read_timeout 2s;
+            proxy_send_timeout 2s;
+        }
+
+        # Static loading page served directly by nginx while upstreams are starting
+        location = /loading.html {
+            root /usr/share/nginx/html;
+            add_header Cache-Control "no-store";
         }
 
         # Backend API routes with rate limiting

--- a/utils/stop_fly_machines.sh
+++ b/utils/stop_fly_machines.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Stop all Fly.io machines for the Divemap stack (nginx, frontend, backend, db).
+# Requires: flyctl installed and authenticated (fly auth login).
+# Usage:
+#   utils/stop_fly_machines.sh            # prompts for confirmation
+#   utils/stop_fly_machines.sh --yes      # non-interactive
+#   utils/stop_fly_machines.sh --dry-run  # show actions without executing
+#
+# It reads app names from component fly.toml files.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
+YES="false"
+DRY_RUN="false"
+
+for arg in "$@"; do
+  case "$arg" in
+    --yes|-y) YES="true" ;;
+    --dry-run) DRY_RUN="true" ;;
+    *) echo "Unknown argument: $arg" >&2; exit 2 ;;
+  esac
+done
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || { echo "Error: '$1' not found in PATH" >&2; exit 1; }
+}
+
+parse_app_from_toml() {
+  # Minimal parser: first non-comment line starting with app = '...'
+  awk -F"'" '/^app\s*=\s*\x27/ { print $2; exit }' "$1"
+}
+
+apps=()
+
+nginx_toml="$ROOT_DIR/nginx/fly.toml"
+frontend_toml="$ROOT_DIR/frontend/fly.toml"
+backend_toml="$ROOT_DIR/backend/fly.toml"
+db_toml="$ROOT_DIR/database/fly.toml"
+
+[[ -f "$nginx_toml" ]] && apps+=("$(parse_app_from_toml "$nginx_toml")")
+[[ -f "$frontend_toml" ]] && apps+=("$(parse_app_from_toml "$frontend_toml")")
+[[ -f "$backend_toml" ]] && apps+=("$(parse_app_from_toml "$backend_toml")")
+[[ -f "$db_toml" ]] && apps+=("$(parse_app_from_toml "$db_toml")")
+
+# Deduplicate while preserving order
+unique_apps=()
+for a in "${apps[@]}"; do
+  [[ -z "$a" ]] && continue
+  skip="false"
+  for ua in "${unique_apps[@]}"; do
+    [[ "$ua" == "$a" ]] && skip="true" && break
+  done
+  [[ "$skip" == "false" ]] && unique_apps+=("$a")
+done
+
+if [[ ${#unique_apps[@]} -eq 0 ]]; then
+  echo "No Fly apps found from fly.toml files." >&2
+  exit 1
+fi
+
+require_cmd fly
+
+echo "Will stop machines for the following Fly apps: ${unique_apps[*]}"
+
+if [[ "$YES" != "true" ]]; then
+  read -r -p "Proceed? [y/N] " reply
+  case "$reply" in
+    y|Y|yes|YES) ;;
+    *) echo "Aborted."; exit 0 ;;
+  esac
+fi
+
+stop_app_machines() {
+  local app="$1"
+  echo "Listing machines for app: $app"
+  # Using JSON output to be robust; fallback to non-JSON if needed
+  if ids_json=$(fly machines list -a "$app" --json 2>/dev/null); then
+    mapfile -t ids < <(printf '%s' "$ids_json" | awk -F'"' '/"id"\s*:\s*"/ {print $4}')
+  else
+    # Fallback: parse plain output, assuming ID is first column
+    mapfile -t ids < <(fly machines list -a "$app" 2>/dev/null | awk 'NR>1 {print $1}')
+  fi
+
+  if [[ ${#ids[@]} -eq 0 ]]; then
+    echo "No machines found for $app"
+    return 0
+  fi
+
+  for id in "${ids[@]}"; do
+    [[ -z "$id" ]] && continue
+    echo "Stopping machine $id in app $app ..."
+    if [[ "$DRY_RUN" == "true" ]]; then
+      echo "DRY-RUN: fly machine stop $id -a $app"
+    else
+      fly machine stop "$id" -a "$app"
+    fi
+  done
+}
+
+for app in "${unique_apps[@]}"; do
+  stop_app_machines "$app"
+done
+
+echo "Done."
+
+


### PR DESCRIPTION
Implement nginx fallback for Fly.io cold starts by serving a static loading page when the frontend upstream isn’t ready, with fast timeouts that trigger the fallback quickly. Scope the fallback to the root route so API endpoints continue returning real status codes. Add a playful rotating message set for better UX. The loading page polls the backend /health every 500ms with a 1s fetch timeout to avoid hangs and reloads instantly when the stack is ready. Remove meta refresh to prevent bouncing into Cloudflare’s 502 window. Copy the loading page into the nginx image.

Also add a utility script to stop Fly Machines across db/backend/ frontend/nginx by reading app names from their fly.toml files.

Changes:
- nginx/prod.conf: scope error_page to '/', enable fail-fast timeouts; keep APIs returning real error codes
- nginx/loading.html: spinner, humorous quips, /health polling, debug logs, AbortController timeout, no meta refresh
- nginx/Dockerfile.prod: COPY loading page into /usr/share/nginx/html
- utils/stop_fly_machines.sh: stop machines via flyctl for all apps

Note: Cloudflare 502 can occur before nginx is up; consider keeping one nginx machine warm or handling 502 at Cloudflare edge during cold-start.