### PR TITLE
Update brand identity to accessible True Blue

### DIFF
--- a/backend/app/templates/emails/admin_alert.html
+++ b/backend/app/templates/emails/admin_alert.html
@@ -73,7 +73,7 @@
                                 You're receiving this email because you have admin alerts enabled.
                             </p>
                             <p style="margin: 0 0 20px 0;">
-                                <a href="{{ site_url }}/profile/notifications" style="display: inline-block; color: #2d6b8a; text-decoration: none; font-weight: 600; font-size: 14px; padding: 10px 20px; border: 2px solid #2d6b8a; border-radius: 6px;">
+                                <a href="{{ site_url }}/profile/notifications" style="display: inline-block; color: #0072B2; text-decoration: none; font-weight: 600; font-size: 14px; padding: 10px 20px; border: 2px solid #0072B2; border-radius: 6px;">
                                     Manage Preferences
                                 </a>
                             </p>

--- a/backend/app/templates/emails/daily_digest.html
+++ b/backend/app/templates/emails/daily_digest.html
@@ -31,7 +31,7 @@
                     
                     <!-- Header -->
                     <tr>
-                        <td class="email-header" style="background: linear-gradient(135deg, #2d6b8a 0%, #1e4a63 100%); padding: 35px 30px; text-align: center;">
+                        <td class="email-header" style="background: linear-gradient(135deg, #0072B2 0%, #004d7a 100%); padding: 35px 30px; text-align: center;">
                             <div>
                                 <img src="https://raw.githubusercontent.com/kargig/divemap/refs/heads/main/frontend/public/divemap_navbar_logo.png" alt="{{ site_name }} Logo" class="logo-img" width="120" height="120" style="display: block; height: 120px; width: auto; margin: 0 auto 12px;">
                                 <h1 class="header-title" style="margin: 0; color: #ffffff; font-size: 28px; font-weight: 600; text-shadow: 0 1px 3px rgba(0,0,0,0.2); letter-spacing: 0.5px;">{{ site_name }}</h1>
@@ -49,18 +49,18 @@
                                 <div class="icon-circle" style="width: 60px; height: 60px; background: linear-gradient(135deg, #e0f2fe 0%, #bae6fd 100%); border-radius: 50%; margin: 0 auto 20px; display: table-cell; vertical-align: middle; text-align: center;">
                                     <span class="icon-emoji" style="font-size: 32px; line-height: 60px; display: inline-block; vertical-align: middle;">📬</span>
                                 </div>
-                                <h2 style="color: #2d6b8a; margin: 0 0 12px 0; font-size: 26px; font-weight: 700;">You have <span style="color: #1e4a63; font-size: 32px;">{{ count }}</span> new notification{{ 's' if count != 1 else '' }}</h2>
+                                <h2 style="color: #0072B2; margin: 0 0 12px 0; font-size: 26px; font-weight: 700;">You have <span style="color: #004d7a; font-size: 32px;">{{ count }}</span> new notification{{ 's' if count != 1 else '' }}</h2>
                                 <p style="color: #64748b; font-size: 15px; margin: 0;">Here's what's new on {{ site_name }} today</p>
                             </div>
                             
                             <!-- Notifications List -->
                             <div style="margin: 30px 0;">
                                 {% for notification in notifications %}
-                                <div class="notification-card" style="background-color: #ffffff; border: 2px solid #e5e7eb; border-left: 5px solid #2d6b8a; padding: 22px; margin-bottom: 18px; border-radius: 8px; box-shadow: 0 2px 6px rgba(0,0,0,0.06);">
-                                    <h3 style="margin: 0 0 12px 0; color: #2d6b8a; font-size: 18px; font-weight: 600; line-height: 1.4;">{{ notification.title }}</h3>
+                                <div class="notification-card" style="background-color: #ffffff; border: 2px solid #e5e7eb; border-left: 5px solid #0072B2; padding: 22px; margin-bottom: 18px; border-radius: 8px; box-shadow: 0 2px 6px rgba(0,0,0,0.06);">
+                                    <h3 style="margin: 0 0 12px 0; color: #0072B2; font-size: 18px; font-weight: 600; line-height: 1.4;">{{ notification.title }}</h3>
                                     <p style="margin: 0 0 16px 0; color: #475569; font-size: 15px; line-height: 1.6;">{{ notification.message }}</p>
                                     {% if notification.link_url %}
-                                    <a href="{{ site_url }}{{ notification.link_url }}" style="display: inline-flex; align-items: center; gap: 6px; color: #2d6b8a; text-decoration: none; font-weight: 600; font-size: 14px; padding: 8px 16px; background-color: #f0f9ff; border-radius: 6px;">
+                                    <a href="{{ site_url }}{{ notification.link_url }}" style="display: inline-flex; align-items: center; gap: 6px; color: #0072B2; text-decoration: none; font-weight: 600; font-size: 14px; padding: 8px 16px; background-color: #f0f9ff; border-radius: 6px;">
                                         View Details <span style="font-size: 16px;">→</span>
                                     </a>
                                     {% endif %}
@@ -70,7 +70,7 @@
                             
                             <!-- CTA Button -->
                             <div style="text-align: center; margin: 40px 0 30px 0;">
-                                <a href="{{ site_url }}/notifications" style="display: inline-block; background: linear-gradient(135deg, #2d6b8a 0%, #1e4a63 100%); color: #ffffff; padding: 18px 40px; text-decoration: none; border-radius: 8px; font-weight: 600; font-size: 17px; box-shadow: 0 4px 12px rgba(45, 107, 138, 0.35); letter-spacing: 0.3px;">
+                                <a href="{{ site_url }}/notifications" style="display: inline-block; background: linear-gradient(135deg, #0072B2 0%, #004d7a 100%); color: #ffffff; padding: 18px 40px; text-decoration: none; border-radius: 8px; font-weight: 600; font-size: 17px; box-shadow: 0 4px 12px rgba(0, 114, 178, 0.35); letter-spacing: 0.3px;">
                                     View All Notifications
                                 </a>
                             </div>
@@ -91,7 +91,7 @@
                             </p>
                             {% endif %}
                             <p style="margin: 0 0 20px 0;">
-                                <a href="{{ site_url }}/profile/notifications" style="display: inline-block; color: #2d6b8a; text-decoration: none; font-weight: 600; font-size: 14px; padding: 10px 20px; border: 2px solid #2d6b8a; border-radius: 6px;">
+                                <a href="{{ site_url }}/profile/notifications" style="display: inline-block; color: #0072B2; text-decoration: none; font-weight: 600; font-size: 14px; padding: 10px 20px; border: 2px solid #0072B2; border-radius: 6px;">
                                     Manage Preferences
                                 </a>
                             </p>

--- a/backend/app/templates/emails/email_verification.html
+++ b/backend/app/templates/emails/email_verification.html
@@ -39,7 +39,7 @@
                     
                     <!-- Header with Logo -->
                     <tr>
-                        <td class="email-header" style="background: linear-gradient(135deg, #2d6b8a 0%, #1e4a63 100%); padding: 35px 30px; text-align: center;">
+                        <td class="email-header" style="background: linear-gradient(135deg, #0072B2 0%, #004d7a 100%); padding: 35px 30px; text-align: center;">
                             <!-- Logo and Site Name -->
                             <div>
                                 <img src="https://raw.githubusercontent.com/kargig/divemap/refs/heads/main/frontend/public/divemap_navbar_logo.png" alt="{{ site_name }} Logo" class="logo-img" width="120" height="120" style="display: block; height: 120px; width: auto; margin: 0 auto 12px;">
@@ -57,7 +57,7 @@
                                 <div class="icon-circle" style="width: 60px; height: 60px; background: linear-gradient(135deg, #e0f2fe 0%, #bae6fd 100%); border-radius: 50%; margin: 0 auto 20px; display: table-cell; vertical-align: middle; text-align: center;">
                                     <span class="icon-emoji" style="font-size: 32px; line-height: 60px; display: inline-block; vertical-align: middle;">✉️</span>
                                 </div>
-                                <h2 class="content-title" style="color: #2d6b8a; margin: 0 0 15px 0; font-size: 26px; font-weight: 700; line-height: 1.3;">Verify your email address</h2>
+                                <h2 class="content-title" style="color: #0072B2; margin: 0 0 15px 0; font-size: 26px; font-weight: 700; line-height: 1.3;">Verify your email address</h2>
                                 <p style="color: #64748b; font-size: 16px; line-height: 1.6; margin: 0; max-width: 480px; margin-left: auto; margin-right: auto;">
                                     Welcome to {{ site_name }}! We're excited to have you on board. To get started, please verify your email address.
                                 </p>
@@ -65,7 +65,7 @@
                             
                             <!-- Main CTA Button -->
                             <div style="text-align: center; margin: 40px 0;">
-                                <a href="{{ verification_link }}" class="cta-button" style="display: inline-block; background: linear-gradient(135deg, #2d6b8a 0%, #1e4a63 100%); color: #ffffff; padding: 18px 40px; text-decoration: none; border-radius: 8px; font-weight: 600; font-size: 17px; box-shadow: 0 4px 12px rgba(45, 107, 138, 0.35); letter-spacing: 0.3px;">
+                                <a href="{{ verification_link }}" class="cta-button" style="display: inline-block; background: linear-gradient(135deg, #0072B2 0%, #004d7a 100%); color: #ffffff; padding: 18px 40px; text-decoration: none; border-radius: 8px; font-weight: 600; font-size: 17px; box-shadow: 0 4px 12px rgba(0, 114, 178, 0.35); letter-spacing: 0.3px;">
                                     ✓ Verify Email Address
                                 </a>
                             </div>
@@ -98,7 +98,7 @@
                                         Copy and paste this link into your browser:
                                     </p>
                                     <div style="background-color: #ffffff; border: 1px solid #cbd5e1; border-radius: 6px; padding: 12px 14px; word-break: break-all;">
-                                        <p style="margin: 0; color: #2d6b8a; font-size: 12px; font-family: 'Courier New', Courier, monospace; line-height: 1.6;">
+                                        <p style="margin: 0; color: #0072B2; font-size: 12px; font-family: 'Courier New', Courier, monospace; line-height: 1.6;">
                                             {{ verification_link }}
                                         </p>
                                     </div>
@@ -124,12 +124,12 @@
                     <tr>
                         <td class="footer-content" style="background: linear-gradient(180deg, #f8fafc 0%, #f1f5f9 100%); padding: 30px 40px; text-align: center; border-top: 1px solid #e2e8f0;">
                             <div style="margin-bottom: 20px;">
-                                <a href="{{ site_url }}" style="display: inline-block; color: #2d6b8a; text-decoration: none; font-weight: 600; font-size: 14px; padding: 10px 20px; border: 2px solid #2d6b8a; border-radius: 6px; transition: all 0.2s ease;">
+                                <a href="{{ site_url }}" style="display: inline-block; color: #0072B2; text-decoration: none; font-weight: 600; font-size: 14px; padding: 10px 20px; border: 2px solid #0072B2; border-radius: 6px; transition: all 0.2s ease;">
                                     Visit {{ site_name }}
                                 </a>
                             </div>
                             <p style="margin: 0 0 8px 0; color: #64748b; font-size: 12px; line-height: 1.6;">
-                                Need help? <a href="{{ site_url }}/contact" style="color: #2d6b8a; text-decoration: none;">Contact us</a> or visit our <a href="{{ site_url }}/help" style="color: #2d6b8a; text-decoration: none;">help center</a>
+                                Need help? <a href="{{ site_url }}/contact" style="color: #0072B2; text-decoration: none;">Contact us</a> or visit our <a href="{{ site_url }}/help" style="color: #0072B2; text-decoration: none;">help center</a>
                             </p>
                             <p style="margin: 15px 0 0 0; color: #94a3b8; font-size: 11px; line-height: 1.5;">
                                 &copy; {{ current_year }} {{ site_name }}. All rights reserved.<br>

--- a/backend/app/templates/emails/new_dive.html
+++ b/backend/app/templates/emails/new_dive.html
@@ -30,7 +30,7 @@
                     
                     <!-- Header -->
                     <tr>
-                        <td class="email-header" style="background: linear-gradient(135deg, #2d6b8a 0%, #1e4a63 100%); padding: 35px 30px; text-align: center;">
+                        <td class="email-header" style="background: linear-gradient(135deg, #0072B2 0%, #004d7a 100%); padding: 35px 30px; text-align: center;">
                             <div>
                                 <img src="https://raw.githubusercontent.com/kargig/divemap/refs/heads/main/frontend/public/divemap_navbar_logo.png" alt="{{ site_name }} Logo" class="logo-img" width="120" height="120" style="display: block; height: 120px; width: auto; margin: 0 auto 12px;">
                                 <h1 class="header-title" style="margin: 0; color: #ffffff; font-size: 28px; font-weight: 600; text-shadow: 0 1px 3px rgba(0,0,0,0.2); letter-spacing: 0.5px;">{{ site_name }}</h1>
@@ -47,7 +47,7 @@
                                 <div class="icon-circle" style="width: 60px; height: 60px; background: linear-gradient(135deg, #e0f2fe 0%, #bae6fd 100%); border-radius: 50%; margin: 0 auto 20px; display: table-cell; vertical-align: middle; text-align: center;">
                                     <span class="icon-emoji" style="font-size: 32px; line-height: 60px; display: inline-block; vertical-align: middle;">🌊</span>
                                 </div>
-                                <h2 style="color: #2d6b8a; margin: 0 0 15px 0; font-size: 26px; font-weight: 700; line-height: 1.3;">{{ notification.title }}</h2>
+                                <h2 style="color: #0072B2; margin: 0 0 15px 0; font-size: 26px; font-weight: 700; line-height: 1.3;">{{ notification.title }}</h2>
                             </div>
                             
                             <p style="color: #475569; font-size: 16px; line-height: 1.7; margin-bottom: 30px; text-align: center;">
@@ -57,7 +57,7 @@
                             {% if notification.link_url %}
                             <!-- CTA Button -->
                             <div style="text-align: center; margin: 40px 0;">
-                                <a href="{{ site_url }}{{ notification.link_url }}" style="display: inline-block; background: linear-gradient(135deg, #2d6b8a 0%, #1e4a63 100%); color: #ffffff; padding: 18px 40px; text-decoration: none; border-radius: 8px; font-weight: 600; font-size: 17px; box-shadow: 0 4px 12px rgba(45, 107, 138, 0.35); letter-spacing: 0.3px;">
+                                <a href="{{ site_url }}{{ notification.link_url }}" style="display: inline-block; background: linear-gradient(135deg, #0072B2 0%, #004d7a 100%); color: #ffffff; padding: 18px 40px; text-decoration: none; border-radius: 8px; font-weight: 600; font-size: 17px; box-shadow: 0 4px 12px rgba(0, 114, 178, 0.35); letter-spacing: 0.3px;">
                                     View Dive
                                 </a>
                             </div>
@@ -79,7 +79,7 @@
                             </p>
                             {% endif %}
                             <p style="margin: 0 0 20px 0;">
-                                <a href="{{ site_url }}/profile/notifications" style="display: inline-block; color: #2d6b8a; text-decoration: none; font-weight: 600; font-size: 14px; padding: 10px 20px; border: 2px solid #2d6b8a; border-radius: 6px;">
+                                <a href="{{ site_url }}/profile/notifications" style="display: inline-block; color: #0072B2; text-decoration: none; font-weight: 600; font-size: 14px; padding: 10px 20px; border: 2px solid #0072B2; border-radius: 6px;">
                                     Manage Preferences
                                 </a>
                             </p>

--- a/backend/app/templates/emails/new_dive_site.html
+++ b/backend/app/templates/emails/new_dive_site.html
@@ -30,7 +30,7 @@
                     
                     <!-- Header -->
                     <tr>
-                        <td class="email-header" style="background: linear-gradient(135deg, #2d6b8a 0%, #1e4a63 100%); padding: 35px 30px; text-align: center;">
+                        <td class="email-header" style="background: linear-gradient(135deg, #0072B2 0%, #004d7a 100%); padding: 35px 30px; text-align: center;">
                             <div>
                                 <img src="https://raw.githubusercontent.com/kargig/divemap/refs/heads/main/frontend/public/divemap_navbar_logo.png" alt="{{ site_name }} Logo" class="logo-img" width="120" height="120" style="display: block; height: 120px; width: auto; margin: 0 auto 12px;">
                                 <h1 class="header-title" style="margin: 0; color: #ffffff; font-size: 28px; font-weight: 600; text-shadow: 0 1px 3px rgba(0,0,0,0.2); letter-spacing: 0.5px;">{{ site_name }}</h1>
@@ -47,7 +47,7 @@
                                 <div class="icon-circle" style="width: 60px; height: 60px; background: linear-gradient(135deg, #e0f2fe 0%, #bae6fd 100%); border-radius: 50%; margin: 0 auto 20px; display: table-cell; vertical-align: middle; text-align: center;">
                                     <span class="icon-emoji" style="font-size: 32px; line-height: 60px; display: inline-block; vertical-align: middle;">📍</span>
                                 </div>
-                                <h2 style="color: #2d6b8a; margin: 0 0 15px 0; font-size: 26px; font-weight: 700; line-height: 1.3;">{{ notification.title }}</h2>
+                                <h2 style="color: #0072B2; margin: 0 0 15px 0; font-size: 26px; font-weight: 700; line-height: 1.3;">{{ notification.title }}</h2>
                             </div>
                             
                             <p style="color: #475569; font-size: 16px; line-height: 1.7; margin-bottom: 30px; text-align: center;">
@@ -57,7 +57,7 @@
                             {% if notification.link_url %}
                             <!-- CTA Button -->
                             <div style="text-align: center; margin: 40px 0;">
-                                <a href="{{ site_url }}{{ notification.link_url }}" style="display: inline-block; background: linear-gradient(135deg, #2d6b8a 0%, #1e4a63 100%); color: #ffffff; padding: 18px 40px; text-decoration: none; border-radius: 8px; font-weight: 600; font-size: 17px; box-shadow: 0 4px 12px rgba(45, 107, 138, 0.35); letter-spacing: 0.3px;">
+                                <a href="{{ site_url }}{{ notification.link_url }}" style="display: inline-block; background: linear-gradient(135deg, #0072B2 0%, #004d7a 100%); color: #ffffff; padding: 18px 40px; text-decoration: none; border-radius: 8px; font-weight: 600; font-size: 17px; box-shadow: 0 4px 12px rgba(0, 114, 178, 0.35); letter-spacing: 0.3px;">
                                     View Dive Site
                                 </a>
                             </div>
@@ -79,7 +79,7 @@
                             </p>
                             {% endif %}
                             <p style="margin: 0 0 20px 0;">
-                                <a href="{{ site_url }}/profile/notifications" style="display: inline-block; color: #2d6b8a; text-decoration: none; font-weight: 600; font-size: 14px; padding: 10px 20px; border: 2px solid #2d6b8a; border-radius: 6px;">
+                                <a href="{{ site_url }}/profile/notifications" style="display: inline-block; color: #0072B2; text-decoration: none; font-weight: 600; font-size: 14px; padding: 10px 20px; border: 2px solid #0072B2; border-radius: 6px;">
                                     Manage Preferences
                                 </a>
                             </p>

--- a/backend/app/templates/emails/new_dive_trip.html
+++ b/backend/app/templates/emails/new_dive_trip.html
@@ -30,7 +30,7 @@
                     
                     <!-- Header -->
                     <tr>
-                        <td class="email-header" style="background: linear-gradient(135deg, #2d6b8a 0%, #1e4a63 100%); padding: 35px 30px; text-align: center;">
+                        <td class="email-header" style="background: linear-gradient(135deg, #0072B2 0%, #004d7a 100%); padding: 35px 30px; text-align: center;">
                             <div>
                                 <img src="https://raw.githubusercontent.com/kargig/divemap/refs/heads/main/frontend/public/divemap_navbar_logo.png" alt="{{ site_name }} Logo" class="logo-img" width="120" height="120" style="display: block; height: 120px; width: auto; margin: 0 auto 12px;">
                                 <h1 class="header-title" style="margin: 0; color: #ffffff; font-size: 28px; font-weight: 600; text-shadow: 0 1px 3px rgba(0,0,0,0.2); letter-spacing: 0.5px;">{{ site_name }}</h1>
@@ -47,7 +47,7 @@
                                 <div class="icon-circle" style="width: 60px; height: 60px; background: linear-gradient(135deg, #e0f2fe 0%, #bae6fd 100%); border-radius: 50%; margin: 0 auto 20px; display: table-cell; vertical-align: middle; text-align: center;">
                                     <span class="icon-emoji" style="font-size: 32px; line-height: 60px; display: inline-block; vertical-align: middle;">🚢</span>
                                 </div>
-                                <h2 style="color: #2d6b8a; margin: 0 0 15px 0; font-size: 26px; font-weight: 700; line-height: 1.3;">{{ notification.title }}</h2>
+                                <h2 style="color: #0072B2; margin: 0 0 15px 0; font-size: 26px; font-weight: 700; line-height: 1.3;">{{ notification.title }}</h2>
                             </div>
                             
                             <p style="color: #475569; font-size: 16px; line-height: 1.7; margin-bottom: 30px; text-align: center;">
@@ -57,7 +57,7 @@
                             {% if notification.link_url %}
                             <!-- CTA Button -->
                             <div style="text-align: center; margin: 40px 0;">
-                                <a href="{{ site_url }}{{ notification.link_url }}" style="display: inline-block; background: linear-gradient(135deg, #2d6b8a 0%, #1e4a63 100%); color: #ffffff; padding: 18px 40px; text-decoration: none; border-radius: 8px; font-weight: 600; font-size: 17px; box-shadow: 0 4px 12px rgba(45, 107, 138, 0.35); letter-spacing: 0.3px;">
+                                <a href="{{ site_url }}{{ notification.link_url }}" style="display: inline-block; background: linear-gradient(135deg, #0072B2 0%, #004d7a 100%); color: #ffffff; padding: 18px 40px; text-decoration: none; border-radius: 8px; font-weight: 600; font-size: 17px; box-shadow: 0 4px 12px rgba(0, 114, 178, 0.35); letter-spacing: 0.3px;">
                                     View Dive Trip
                                 </a>
                             </div>
@@ -79,7 +79,7 @@
                             </p>
                             {% endif %}
                             <p style="margin: 0 0 20px 0;">
-                                <a href="{{ site_url }}/profile/notifications" style="display: inline-block; color: #2d6b8a; text-decoration: none; font-weight: 600; font-size: 14px; padding: 10px 20px; border: 2px solid #2d6b8a; border-radius: 6px;">
+                                <a href="{{ site_url }}/profile/notifications" style="display: inline-block; color: #0072B2; text-decoration: none; font-weight: 600; font-size: 14px; padding: 10px 20px; border: 2px solid #0072B2; border-radius: 6px;">
                                     Manage Preferences
                                 </a>
                             </p>

--- a/backend/app/templates/emails/new_diving_center.html
+++ b/backend/app/templates/emails/new_diving_center.html
@@ -30,7 +30,7 @@
                     
                     <!-- Header -->
                     <tr>
-                        <td class="email-header" style="background: linear-gradient(135deg, #2d6b8a 0%, #1e4a63 100%); padding: 35px 30px; text-align: center;">
+                        <td class="email-header" style="background: linear-gradient(135deg, #0072B2 0%, #004d7a 100%); padding: 35px 30px; text-align: center;">
                             <div>
                                 <img src="https://raw.githubusercontent.com/kargig/divemap/refs/heads/main/frontend/public/divemap_navbar_logo.png" alt="{{ site_name }} Logo" class="logo-img" width="120" height="120" style="display: block; height: 120px; width: auto; margin: 0 auto 12px;">
                                 <h1 class="header-title" style="margin: 0; color: #ffffff; font-size: 28px; font-weight: 600; text-shadow: 0 1px 3px rgba(0,0,0,0.2); letter-spacing: 0.5px;">{{ site_name }}</h1>
@@ -47,7 +47,7 @@
                                 <div class="icon-circle" style="width: 60px; height: 60px; background: linear-gradient(135deg, #e0f2fe 0%, #bae6fd 100%); border-radius: 50%; margin: 0 auto 20px; display: table-cell; vertical-align: middle; text-align: center;">
                                     <span class="icon-emoji" style="font-size: 32px; line-height: 60px; display: inline-block; vertical-align: middle;">🏢</span>
                                 </div>
-                                <h2 style="color: #2d6b8a; margin: 0 0 15px 0; font-size: 26px; font-weight: 700; line-height: 1.3;">{{ notification.title }}</h2>
+                                <h2 style="color: #0072B2; margin: 0 0 15px 0; font-size: 26px; font-weight: 700; line-height: 1.3;">{{ notification.title }}</h2>
                             </div>
                             
                             <p style="color: #475569; font-size: 16px; line-height: 1.7; margin-bottom: 30px; text-align: center;">
@@ -57,7 +57,7 @@
                             {% if notification.link_url %}
                             <!-- CTA Button -->
                             <div style="text-align: center; margin: 40px 0;">
-                                <a href="{{ site_url }}{{ notification.link_url }}" style="display: inline-block; background: linear-gradient(135deg, #2d6b8a 0%, #1e4a63 100%); color: #ffffff; padding: 18px 40px; text-decoration: none; border-radius: 8px; font-weight: 600; font-size: 17px; box-shadow: 0 4px 12px rgba(45, 107, 138, 0.35); letter-spacing: 0.3px;">
+                                <a href="{{ site_url }}{{ notification.link_url }}" style="display: inline-block; background: linear-gradient(135deg, #0072B2 0%, #004d7a 100%); color: #ffffff; padding: 18px 40px; text-decoration: none; border-radius: 8px; font-weight: 600; font-size: 17px; box-shadow: 0 4px 12px rgba(0, 114, 178, 0.35); letter-spacing: 0.3px;">
                                     View Diving Center
                                 </a>
                             </div>
@@ -79,7 +79,7 @@
                             </p>
                             {% endif %}
                             <p style="margin: 0 0 20px 0;">
-                                <a href="{{ site_url }}/profile/notifications" style="display: inline-block; color: #2d6b8a; text-decoration: none; font-weight: 600; font-size: 14px; padding: 10px 20px; border: 2px solid #2d6b8a; border-radius: 6px;">
+                                <a href="{{ site_url }}/profile/notifications" style="display: inline-block; color: #0072B2; text-decoration: none; font-weight: 600; font-size: 14px; padding: 10px 20px; border: 2px solid #0072B2; border-radius: 6px;">
                                     Manage Preferences
                                 </a>
                             </p>

--- a/backend/app/templates/emails/password_changed.html
+++ b/backend/app/templates/emails/password_changed.html
@@ -39,7 +39,7 @@
                     
                     <!-- Header with Logo -->
                     <tr>
-                        <td class="email-header" style="background: linear-gradient(135deg, #2d6b8a 0%, #1e4a63 100%); padding: 35px 30px; text-align: center;">
+                        <td class="email-header" style="background: linear-gradient(135deg, #0072B2 0%, #004d7a 100%); padding: 35px 30px; text-align: center;">
                             <!-- Logo and Site Name -->
                             <div>
                                 <img src="https://raw.githubusercontent.com/kargig/divemap/refs/heads/main/frontend/public/divemap_navbar_logo.png" alt="{{ site_name }} Logo" class="logo-img" width="120" height="120" style="display: block; height: 120px; width: auto; margin: 0 auto 12px;">
@@ -57,7 +57,7 @@
                                 <div class="icon-circle" style="width: 60px; height: 60px; background: linear-gradient(135deg, #e0f2fe 0%, #bae6fd 100%); border-radius: 50%; margin: 0 auto 20px; display: table-cell; vertical-align: middle; text-align: center;">
                                     <span class="icon-emoji" style="font-size: 32px; line-height: 60px; display: inline-block; vertical-align: middle;">✅</span>
                                 </div>
-                                <h2 class="content-title" style="color: #2d6b8a; margin: 0 0 15px 0; font-size: 26px; font-weight: 700; line-height: 1.3;">Password Changed</h2>
+                                <h2 class="content-title" style="color: #0072B2; margin: 0 0 15px 0; font-size: 26px; font-weight: 700; line-height: 1.3;">Password Changed</h2>
                                 <p style="color: #64748b; font-size: 16px; line-height: 1.6; margin: 0; max-width: 480px; margin-left: auto; margin-right: auto;">
                                     The password for your {{ site_name }} account ({{ user_email }}) has been successfully changed.
                                 </p>
@@ -65,7 +65,7 @@
                             
                             <!-- Main CTA Button -->
                             <div style="text-align: center; margin: 40px 0;">
-                                <a href="{{ login_url }}" class="cta-button" style="display: inline-block; background: linear-gradient(135deg, #2d6b8a 0%, #1e4a63 100%); color: #ffffff; padding: 18px 40px; text-decoration: none; border-radius: 8px; font-weight: 600; font-size: 17px; box-shadow: 0 4px 12px rgba(45, 107, 138, 0.35); letter-spacing: 0.3px;">
+                                <a href="{{ login_url }}" class="cta-button" style="display: inline-block; background: linear-gradient(135deg, #0072B2 0%, #004d7a 100%); color: #ffffff; padding: 18px 40px; text-decoration: none; border-radius: 8px; font-weight: 600; font-size: 17px; box-shadow: 0 4px 12px rgba(0, 114, 178, 0.35); letter-spacing: 0.3px;">
                                     Login to your account
                                 </a>
                             </div>
@@ -89,12 +89,12 @@
                     <tr>
                         <td class="footer-content" style="background: linear-gradient(180deg, #f8fafc 0%, #f1f5f9 100%); padding: 30px 40px; text-align: center; border-top: 1px solid #e2e8f0;">
                             <div style="margin-bottom: 20px;">
-                                <a href="{{ site_url }}" style="display: inline-block; color: #2d6b8a; text-decoration: none; font-weight: 600; font-size: 14px; padding: 10px 20px; border: 2px solid #2d6b8a; border-radius: 6px; transition: all 0.2s ease;">
+                                <a href="{{ site_url }}" style="display: inline-block; color: #0072B2; text-decoration: none; font-weight: 600; font-size: 14px; padding: 10px 20px; border: 2px solid #0072B2; border-radius: 6px; transition: all 0.2s ease;">
                                     Visit {{ site_name }}
                                 </a>
                             </div>
                             <p style="margin: 0 0 8px 0; color: #64748b; font-size: 12px; line-height: 1.6;">
-                                Need help? <a href="{{ site_url }}/contact" style="color: #2d6b8a; text-decoration: none;">Contact us</a> or visit our <a href="{{ site_url }}/help" style="color: #2d6b8a; text-decoration: none;">help center</a>
+                                Need help? <a href="{{ site_url }}/contact" style="color: #0072B2; text-decoration: none;">Contact us</a> or visit our <a href="{{ site_url }}/help" style="color: #0072B2; text-decoration: none;">help center</a>
                             </p>
                             <p style="margin: 15px 0 0 0; color: #94a3b8; font-size: 11px; line-height: 1.5;">
                                 &copy; {{ current_year }} {{ site_name }}. All rights reserved.<br>

--- a/backend/app/templates/emails/password_reset.html
+++ b/backend/app/templates/emails/password_reset.html
@@ -39,7 +39,7 @@
                     
                     <!-- Header with Logo -->
                     <tr>
-                        <td class="email-header" style="background: linear-gradient(135deg, #2d6b8a 0%, #1e4a63 100%); padding: 35px 30px; text-align: center;">
+                        <td class="email-header" style="background: linear-gradient(135deg, #0072B2 0%, #004d7a 100%); padding: 35px 30px; text-align: center;">
                             <!-- Logo and Site Name -->
                             <div>
                                 <img src="https://raw.githubusercontent.com/kargig/divemap/refs/heads/main/frontend/public/divemap_navbar_logo.png" alt="{{ site_name }} Logo" class="logo-img" width="120" height="120" style="display: block; height: 120px; width: auto; margin: 0 auto 12px;">
@@ -57,7 +57,7 @@
                                 <div class="icon-circle" style="width: 60px; height: 60px; background: linear-gradient(135deg, #e0f2fe 0%, #bae6fd 100%); border-radius: 50%; margin: 0 auto 20px; display: table-cell; vertical-align: middle; text-align: center;">
                                     <span class="icon-emoji" style="font-size: 32px; line-height: 60px; display: inline-block; vertical-align: middle;">🔑</span>
                                 </div>
-                                <h2 class="content-title" style="color: #2d6b8a; margin: 0 0 15px 0; font-size: 26px; font-weight: 700; line-height: 1.3;">Reset your password</h2>
+                                <h2 class="content-title" style="color: #0072B2; margin: 0 0 15px 0; font-size: 26px; font-weight: 700; line-height: 1.3;">Reset your password</h2>
                                 <p style="color: #64748b; font-size: 16px; line-height: 1.6; margin: 0; max-width: 480px; margin-left: auto; margin-right: auto;">
                                     We received a request to reset the password for your account associated with {{ user_email }}.
                                 </p>
@@ -65,7 +65,7 @@
                             
                             <!-- Main CTA Button -->
                             <div style="text-align: center; margin: 40px 0;">
-                                <a href="{{ reset_link }}" class="cta-button" style="display: inline-block; background: linear-gradient(135deg, #2d6b8a 0%, #1e4a63 100%); color: #ffffff; padding: 18px 40px; text-decoration: none; border-radius: 8px; font-weight: 600; font-size: 17px; box-shadow: 0 4px 12px rgba(45, 107, 138, 0.35); letter-spacing: 0.3px;">
+                                <a href="{{ reset_link }}" class="cta-button" style="display: inline-block; background: linear-gradient(135deg, #0072B2 0%, #004d7a 100%); color: #ffffff; padding: 18px 40px; text-decoration: none; border-radius: 8px; font-weight: 600; font-size: 17px; box-shadow: 0 4px 12px rgba(0, 114, 178, 0.35); letter-spacing: 0.3px;">
                                     Reset Password
                                 </a>
                             </div>
@@ -98,7 +98,7 @@
                                         Copy and paste this link into your browser:
                                     </p>
                                     <div style="background-color: #ffffff; border: 1px solid #cbd5e1; border-radius: 6px; padding: 12px 14px; word-break: break-all;">
-                                        <p style="margin: 0; color: #2d6b8a; font-size: 12px; font-family: 'Courier New', Courier, monospace; line-height: 1.6;">
+                                        <p style="margin: 0; color: #0072B2; font-size: 12px; font-family: 'Courier New', Courier, monospace; line-height: 1.6;">
                                             {{ reset_link }}
                                         </p>
                                     </div>
@@ -124,12 +124,12 @@
                     <tr>
                         <td class="footer-content" style="background: linear-gradient(180deg, #f8fafc 0%, #f1f5f9 100%); padding: 30px 40px; text-align: center; border-top: 1px solid #e2e8f0;">
                             <div style="margin-bottom: 20px;">
-                                <a href="{{ site_url }}" style="display: inline-block; color: #2d6b8a; text-decoration: none; font-weight: 600; font-size: 14px; padding: 10px 20px; border: 2px solid #2d6b8a; border-radius: 6px; transition: all 0.2s ease;">
+                                <a href="{{ site_url }}" style="display: inline-block; color: #0072B2; text-decoration: none; font-weight: 600; font-size: 14px; padding: 10px 20px; border: 2px solid #0072B2; border-radius: 6px; transition: all 0.2s ease;">
                                     Visit {{ site_name }}
                                 </a>
                             </div>
                             <p style="margin: 0 0 8px 0; color: #64748b; font-size: 12px; line-height: 1.6;">
-                                Need help? <a href="{{ site_url }}/contact" style="color: #2d6b8a; text-decoration: none;">Contact us</a> or visit our <a href="{{ site_url }}/help" style="color: #2d6b8a; text-decoration: none;">help center</a>
+                                Need help? <a href="{{ site_url }}/contact" style="color: #0072B2; text-decoration: none;">Contact us</a> or visit our <a href="{{ site_url }}/help" style="color: #0072B2; text-decoration: none;">help center</a>
                             </p>
                             <p style="margin: 15px 0 0 0; color: #94a3b8; font-size: 11px; line-height: 1.5;">
                                 &copy; {{ current_year }} {{ site_name }}. All rights reserved.<br>

--- a/backend/app/templates/emails/test_email.html
+++ b/backend/app/templates/emails/test_email.html
@@ -30,7 +30,7 @@
                     
                     <!-- Header -->
                     <tr>
-                        <td class="email-header" style="background: linear-gradient(135deg, #2d6b8a 0%, #1e4a63 100%); padding: 35px 30px; text-align: center;">
+                        <td class="email-header" style="background: linear-gradient(135deg, #0072B2 0%, #004d7a 100%); padding: 35px 30px; text-align: center;">
                             <div>
                                 <img src="https://raw.githubusercontent.com/kargig/divemap/refs/heads/main/frontend/public/divemap_navbar_logo.png" alt="{{ site_name }} Logo" class="logo-img" width="120" height="120" style="display: block; height: 120px; width: auto; margin: 0 auto 12px;">
                                 <h1 class="header-title" style="margin: 0; color: #ffffff; font-size: 28px; font-weight: 600; text-shadow: 0 1px 3px rgba(0,0,0,0.2); letter-spacing: 0.5px;">{{ site_name }}</h1>
@@ -47,7 +47,7 @@
                                 <div class="icon-circle" style="width: 60px; height: 60px; background: linear-gradient(135deg, #e0f2fe 0%, #bae6fd 100%); border-radius: 50%; margin: 0 auto 20px; display: table-cell; vertical-align: middle; text-align: center;">
                                     <span class="icon-emoji" style="font-size: 32px; line-height: 60px; display: inline-block; vertical-align: middle;">✅</span>
                                 </div>
-                                <h2 style="color: #2d6b8a; margin: 0 0 15px 0; font-size: 26px; font-weight: 700; line-height: 1.3;">{{ notification.title }}</h2>
+                                <h2 style="color: #0072B2; margin: 0 0 15px 0; font-size: 26px; font-weight: 700; line-height: 1.3;">{{ notification.title }}</h2>
                             </div>
                             
                             <p style="color: #475569; font-size: 16px; line-height: 1.7; margin-bottom: 30px; text-align: center;">
@@ -57,7 +57,7 @@
                             {% if notification.link_url %}
                             <!-- CTA Button -->
                             <div style="text-align: center; margin: 40px 0;">
-                                <a href="{{ site_url }}{{ notification.link_url }}" style="display: inline-block; background: linear-gradient(135deg, #2d6b8a 0%, #1e4a63 100%); color: #ffffff; padding: 18px 40px; text-decoration: none; border-radius: 8px; font-weight: 600; font-size: 17px; box-shadow: 0 4px 12px rgba(45, 107, 138, 0.35); letter-spacing: 0.3px;">
+                                <a href="{{ site_url }}{{ notification.link_url }}" style="display: inline-block; background: linear-gradient(135deg, #0072B2 0%, #004d7a 100%); color: #ffffff; padding: 18px 40px; text-decoration: none; border-radius: 8px; font-weight: 600; font-size: 17px; box-shadow: 0 4px 12px rgba(0, 114, 178, 0.35); letter-spacing: 0.3px;">
                                     View Details
                                 </a>
                             </div>

--- a/backend/app/templates/emails/weekly_digest.html
+++ b/backend/app/templates/emails/weekly_digest.html
@@ -31,7 +31,7 @@
                     
                     <!-- Header -->
                     <tr>
-                        <td class="email-header" style="background: linear-gradient(135deg, #2d6b8a 0%, #1e4a63 100%); padding: 35px 30px; text-align: center;">
+                        <td class="email-header" style="background: linear-gradient(135deg, #0072B2 0%, #004d7a 100%); padding: 35px 30px; text-align: center;">
                             <div>
                                 <img src="https://raw.githubusercontent.com/kargig/divemap/refs/heads/main/frontend/public/divemap_navbar_logo.png" alt="{{ site_name }} Logo" class="logo-img" width="120" height="120" style="display: block; height: 120px; width: auto; margin: 0 auto 12px;">
                                 <h1 class="header-title" style="margin: 0; color: #ffffff; font-size: 28px; font-weight: 600; text-shadow: 0 1px 3px rgba(0,0,0,0.2); letter-spacing: 0.5px;">{{ site_name }}</h1>
@@ -49,18 +49,18 @@
                                 <div class="icon-circle" style="width: 60px; height: 60px; background: linear-gradient(135deg, #e0f2fe 0%, #bae6fd 100%); border-radius: 50%; margin: 0 auto 20px; display: table-cell; vertical-align: middle; text-align: center;">
                                     <span class="icon-emoji" style="font-size: 32px; line-height: 60px; display: inline-block; vertical-align: middle;">📊</span>
                                 </div>
-                                <h2 style="color: #2d6b8a; margin: 0 0 12px 0; font-size: 26px; font-weight: 700;">Your weekly summary</h2>
-                                <p style="color: #64748b; font-size: 15px; margin: 0 0 8px 0;">You have <strong style="color: #1e4a63; font-size: 20px;">{{ count }}</strong> new notification{{ 's' if count != 1 else '' }} this week</p>
+                                <h2 style="color: #0072B2; margin: 0 0 12px 0; font-size: 26px; font-weight: 700;">Your weekly summary</h2>
+                                <p style="color: #64748b; font-size: 15px; margin: 0 0 8px 0;">You have <strong style="color: #004d7a; font-size: 20px;">{{ count }}</strong> new notification{{ 's' if count != 1 else '' }} this week</p>
                             </div>
                             
                             <!-- Notifications List -->
                             <div style="margin: 30px 0;">
                                 {% for notification in notifications %}
-                                <div class="notification-card" style="background-color: #ffffff; border: 2px solid #e5e7eb; border-left: 5px solid #2d6b8a; padding: 22px; margin-bottom: 18px; border-radius: 8px; box-shadow: 0 2px 6px rgba(0,0,0,0.06);">
-                                    <h3 style="margin: 0 0 12px 0; color: #2d6b8a; font-size: 18px; font-weight: 600; line-height: 1.4;">{{ notification.title }}</h3>
+                                <div class="notification-card" style="background-color: #ffffff; border: 2px solid #e5e7eb; border-left: 5px solid #0072B2; padding: 22px; margin-bottom: 18px; border-radius: 8px; box-shadow: 0 2px 6px rgba(0,0,0,0.06);">
+                                    <h3 style="margin: 0 0 12px 0; color: #0072B2; font-size: 18px; font-weight: 600; line-height: 1.4;">{{ notification.title }}</h3>
                                     <p style="margin: 0 0 16px 0; color: #475569; font-size: 15px; line-height: 1.6;">{{ notification.message }}</p>
                                     {% if notification.link_url %}
-                                    <a href="{{ site_url }}{{ notification.link_url }}" style="display: inline-flex; align-items: center; gap: 6px; color: #2d6b8a; text-decoration: none; font-weight: 600; font-size: 14px; padding: 8px 16px; background-color: #f0f9ff; border-radius: 6px;">
+                                    <a href="{{ site_url }}{{ notification.link_url }}" style="display: inline-flex; align-items: center; gap: 6px; color: #0072B2; text-decoration: none; font-weight: 600; font-size: 14px; padding: 8px 16px; background-color: #f0f9ff; border-radius: 6px;">
                                         View Details <span style="font-size: 16px;">→</span>
                                     </a>
                                     {% endif %}
@@ -70,7 +70,7 @@
                             
                             <!-- CTA Button -->
                             <div style="text-align: center; margin: 40px 0 30px 0;">
-                                <a href="{{ site_url }}/notifications" style="display: inline-block; background: linear-gradient(135deg, #2d6b8a 0%, #1e4a63 100%); color: #ffffff; padding: 18px 40px; text-decoration: none; border-radius: 8px; font-weight: 600; font-size: 17px; box-shadow: 0 4px 12px rgba(45, 107, 138, 0.35); letter-spacing: 0.3px;">
+                                <a href="{{ site_url }}/notifications" style="display: inline-block; background: linear-gradient(135deg, #0072B2 0%, #004d7a 100%); color: #ffffff; padding: 18px 40px; text-decoration: none; border-radius: 8px; font-weight: 600; font-size: 17px; box-shadow: 0 4px 12px rgba(0, 114, 178, 0.35); letter-spacing: 0.3px;">
                                     View All Notifications
                                 </a>
                             </div>
@@ -91,7 +91,7 @@
                             </p>
                             {% endif %}
                             <p style="margin: 0 0 20px 0;">
-                                <a href="{{ site_url }}/profile/notifications" style="display: inline-block; color: #2d6b8a; text-decoration: none; font-weight: 600; font-size: 14px; padding: 10px 20px; border: 2px solid #2d6b8a; border-radius: 6px;">
+                                <a href="{{ site_url }}/profile/notifications" style="display: inline-block; color: #0072B2; text-decoration: none; font-weight: 600; font-size: 14px; padding: 10px 20px; border: 2px solid #0072B2; border-radius: 6px;">
                                     Manage Preferences
                                 </a>
                             </p>

--- a/frontend/src/components/DiveSiteCard.jsx
+++ b/frontend/src/components/DiveSiteCard.jsx
@@ -20,7 +20,7 @@ export const DiveSiteListCard = ({
 
   return (
     <div
-      className={`dive-item bg-white rounded-xl shadow-sm border border-gray-100 border-l-4 border-l-[rgb(45,107,138)] p-2.5 sm:p-6 hover:shadow-md transition-all duration-200 relative ${compactLayout ? 'p-2 sm:p-4' : 'p-2.5 sm:p-6'}`}
+      className={`dive-item bg-white rounded-xl shadow-sm border border-gray-100 border-l-4 border-l-[rgb(0,114,178)] p-2.5 sm:p-6 hover:shadow-md transition-all duration-200 relative ${compactLayout ? 'p-2 sm:p-4' : 'p-2.5 sm:p-6'}`}
     >
       <div className='flex gap-2.5 sm:gap-6'>
         {/* Desktop Thumbnail */}
@@ -174,7 +174,7 @@ export const DiveSiteGridCard = ({
 }) => {
   return (
     <div
-      className={`dive-item rounded-xl shadow-sm border border-gray-100 border-l-4 border-l-[rgb(45,107,138)] flex flex-col hover:shadow-md hover:-translate-y-1 transition-all duration-200 bg-white ${compactLayout ? 'h-full' : ''}`}
+      className={`dive-item rounded-xl shadow-sm border border-gray-100 border-l-4 border-l-[rgb(0,114,178)] flex flex-col hover:shadow-md hover:-translate-y-1 transition-all duration-200 bg-white ${compactLayout ? 'h-full' : ''}`}
     >
       {/* Image Header */}
       <div className='relative h-48 overflow-hidden rounded-tr-xl'>

--- a/frontend/src/components/Lightbox/Lightbox.jsx
+++ b/frontend/src/components/Lightbox/Lightbox.jsx
@@ -84,7 +84,7 @@ export default function Lightbox(props) {
       .yarl__thumbnails .yarl__thumbnail[aria-current="true"],
       [class*="yarl__thumbnail"][class*="active"],
       [class*="thumbnail"][class*="active"] {
-        border: 4px solid #2d6b8a !important;
+        border: 4px solid #0072B2 !important;
       }
     `;
 

--- a/frontend/src/components/Logo.jsx
+++ b/frontend/src/components/Logo.jsx
@@ -18,7 +18,7 @@ const Logo = ({
   };
 
   const textSizeClasses = {
-    small: 'text-sm',
+    small: 'text-lg',
     medium: 'text-lg',
     large: 'text-xl',
     xlarge: 'text-2xl',

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -16,7 +16,7 @@ const Navbar = () => {
         isMobile && !navbarVisible ? '-translate-y-full' : 'translate-y-0'
       }`}
       style={{
-        backgroundColor: '#2d6b8a',
+        backgroundColor: '#0072B2',
       }}
     >
       {/* Sea Components Background */}

--- a/frontend/src/components/NavbarMobileControls.jsx
+++ b/frontend/src/components/NavbarMobileControls.jsx
@@ -67,8 +67,8 @@ const NavbarMobileControls = () => {
 
   // Custom theme variables for antd-mobile to match the blue design
   const customTheme = {
-    '--adm-color-background': '#2d6b8a',
-    '--adm-color-box': '#2d6b8a', // Ensures list background is blue
+    '--adm-color-background': '#0072B2',
+    '--adm-color-box': '#0072B2', // Ensures list background is blue
     '--adm-color-text': '#ffffff', // White-ish for better contrast
     '--adm-color-weak': '#ffffff', // Force weak text to white
     '--adm-color-text-secondary': '#bfdbfe', // blue-200 for secondary text
@@ -79,15 +79,19 @@ const NavbarMobileControls = () => {
 
   return (
     <>
-      <div className='md:hidden flex items-center gap-4'>
+      <div className='md:hidden flex items-center gap-1 sm:gap-3'>
         {user && <ChatDropdown />}
         {user && <NotificationBell />}
         <button
           onClick={toggleMobileMenu}
-          className='text-white hover:text-blue-200 transition-colors'
+          className='text-white hover:text-blue-200 transition-colors ml-0'
           aria-label={isMobileMenuOpen ? 'Close mobile menu' : 'Open mobile menu'}
         >
-          {isMobileMenuOpen ? <X className='h-6 w-6' /> : <MenuIcon className='h-6 w-6' />}
+          {isMobileMenuOpen ? (
+            <X className='h-6 w-6' />
+          ) : (
+            <MenuIcon className='h-6 w-6 scale-150' />
+          )}
         </button>
       </div>
 
@@ -99,7 +103,7 @@ const NavbarMobileControls = () => {
           width: '85vw',
           display: 'flex',
           flexDirection: 'column',
-          backgroundColor: '#2d6b8a',
+          backgroundColor: '#0072B2',
         }}
       >
         <div style={customTheme} className='flex flex-col h-full'>

--- a/frontend/src/components/TripCard.jsx
+++ b/frontend/src/components/TripCard.jsx
@@ -135,8 +135,8 @@ const TripCard = ({
 
   // Card classes based on view mode
   const cardClasses = isGrid
-    ? 'bg-white rounded-xl shadow-sm border border-gray-100 border-l-4 border-l-[rgb(45,107,138)] overflow-hidden flex flex-col h-full hover:shadow-md transition-shadow duration-300'
-    : `bg-white rounded-xl shadow-sm border border-gray-100 border-l-4 border-l-[rgb(45,107,138)] mb-6 hover:shadow-md transition-shadow duration-300 relative ${
+    ? 'bg-white rounded-xl shadow-sm border border-gray-100 border-l-4 border-l-[rgb(0,114,178)] overflow-hidden flex flex-col h-full hover:shadow-md transition-shadow duration-300'
+    : `bg-white rounded-xl shadow-sm border border-gray-100 border-l-4 border-l-[rgb(0,114,178)] mb-6 hover:shadow-md transition-shadow duration-300 relative ${
         !user ? 'pointer-events-none' : ''
       }`;
 

--- a/frontend/src/components/UploadPhotosComponent.jsx
+++ b/frontend/src/components/UploadPhotosComponent.jsx
@@ -286,7 +286,7 @@ const UploadPhotosComponent = ({
     return (
       <Card
         style={{
-          borderColor: '#2d6b8a',
+          borderColor: '#0072B2',
           borderWidth: '2px',
           marginTop: '6px',
           marginBottom: '6px',

--- a/frontend/src/components/tables/LeaderboardTable.jsx
+++ b/frontend/src/components/tables/LeaderboardTable.jsx
@@ -41,7 +41,7 @@ const LeaderboardTable = ({
             <Avatar src={imgUrl} alt={name} size='sm' fallbackText={name} />
             <Link
               to={linkTo}
-              className='font-semibold text-gray-900 truncate max-w-[120px] sm:max-w-none hover:text-blue-600 transition-colors'
+              className='font-semibold text-blue-600 truncate max-w-[120px] sm:max-w-none hover:text-blue-800 transition-colors'
             >
               {name}
             </Link>
@@ -53,7 +53,9 @@ const LeaderboardTable = ({
       header: metricLabel,
       accessorKey: 'count',
       cell: info => (
-        <span className='font-bold text-blue-600'>{info.getValue().toLocaleString()}</span>
+        <span className='font-bold' style={{ color: '#0072B2' }}>
+          {info.getValue().toLocaleString()}
+        </span>
       ),
     },
   ];
@@ -85,7 +87,7 @@ const LeaderboardTable = ({
               {headerGroup.headers.map(header => (
                 <th
                   key={header.id}
-                  className='px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider'
+                  className='px-4 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider'
                 >
                   {flexRender(header.column.columnDef.header, header.getContext())}
                 </th>
@@ -96,8 +98,11 @@ const LeaderboardTable = ({
         <tbody className='bg-white divide-y divide-gray-200'>
           {table.getRowModel().rows.map(row => (
             <tr key={row.id} className='hover:bg-blue-50 transition-colors'>
-              {row.getVisibleCells().map(cell => (
-                <td key={cell.id} className='px-4 py-3 whitespace-nowrap text-sm text-gray-900'>
+              {row.getVisibleCells().map((cell, index) => (
+                <td
+                  key={cell.id}
+                  className={`px-4 py-3 whitespace-nowrap text-sm text-gray-900 ${index === 2 ? 'text-center' : ''}`}
+                >
                   {flexRender(cell.column.columnDef.cell, cell.getContext())}
                 </td>
               ))}

--- a/frontend/src/pages/DiveRoutes.jsx
+++ b/frontend/src/pages/DiveRoutes.jsx
@@ -309,7 +309,7 @@ const DiveRoutes = () => {
               return (
                 <div
                   key={route.id}
-                  className={`bg-white rounded-xl shadow-sm border border-gray-100 border-l-4 border-l-[rgb(45,107,138)] hover:shadow-md hover:-translate-y-1 transition-all duration-200 flex flex-col ${compactLayout ? 'p-2 sm:p-4' : 'p-3 sm:p-6'}`}
+                  className={`bg-white rounded-xl shadow-sm border border-gray-100 border-l-4 border-l-[rgb(0,114,178)] hover:shadow-md hover:-translate-y-1 transition-all duration-200 flex flex-col ${compactLayout ? 'p-2 sm:p-4' : 'p-3 sm:p-6'}`}
                 >
                   {/* Header: Title & Type */}
                   <div className='mb-2'>

--- a/frontend/src/pages/Dives.jsx
+++ b/frontend/src/pages/Dives.jsx
@@ -1028,7 +1028,7 @@ const Dives = () => {
               {dives?.map(dive => (
                 <div
                   key={dive.id}
-                  className={`dive-item rounded-xl shadow-sm border border-gray-100 border-l-4 border-l-[rgb(45,107,138)] p-2.5 sm:p-6 hover:shadow-md transition-all duration-200 ${
+                  className={`dive-item rounded-xl shadow-sm border border-gray-100 border-l-4 border-l-[rgb(0,114,178)] p-2.5 sm:p-6 hover:shadow-md transition-all duration-200 ${
                     dive.is_private ? 'bg-purple-50/30' : 'bg-white'
                   }`}
                 >
@@ -1173,7 +1173,7 @@ const Dives = () => {
               {dives?.map(dive => (
                 <div
                   key={dive.id}
-                  className={`dive-item rounded-xl shadow-sm border border-gray-100 border-l-4 border-l-[rgb(45,107,138)] flex flex-col hover:shadow-md hover:-translate-y-1 transition-all duration-200 ${
+                  className={`dive-item rounded-xl shadow-sm border border-gray-100 border-l-4 border-l-[rgb(0,114,178)] flex flex-col hover:shadow-md hover:-translate-y-1 transition-all duration-200 ${
                     dive.is_private ? 'bg-purple-50/30' : 'bg-white'
                   }`}
                 >

--- a/frontend/src/pages/DivingCenters.jsx
+++ b/frontend/src/pages/DivingCenters.jsx
@@ -465,7 +465,7 @@ const DivingCenters = () => {
                     {divingCenters?.map(center => (
                       <div
                         key={center.id}
-                        className={`dive-item bg-white rounded-xl shadow-sm border border-gray-100 border-l-4 border-l-[rgb(45,107,138)] p-1.5 sm:p-4 hover:shadow-md transition-all duration-200 relative`}
+                        className={`dive-item bg-white rounded-xl shadow-sm border border-gray-100 border-l-4 border-l-[rgb(0,114,178)] p-1.5 sm:p-4 hover:shadow-md transition-all duration-200 relative`}
                       >
                         {/* Main content column */}
                         <div className='flex flex-col'>
@@ -597,7 +597,7 @@ const DivingCenters = () => {
                     {divingCenters?.map(center => (
                       <div
                         key={center.id}
-                        className={`dive-item bg-white rounded-xl shadow-sm border border-gray-200 border-l-4 border-l-[rgb(45,107,138)] overflow-hidden hover:shadow-lg transition-all duration-300 hover:scale-[1.02] ${
+                        className={`dive-item bg-white rounded-xl shadow-sm border border-gray-200 border-l-4 border-l-[rgb(0,114,178)] overflow-hidden hover:shadow-lg transition-all duration-300 hover:scale-[1.02] ${
                           compactLayout ? 'p-4' : 'p-6'
                         }`}
                       >

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -190,12 +190,17 @@ const Home = () => {
 
       {/* Mobile Hero with Gradient - Visible only on Mobile */}
 
-      <div className='block md:hidden w-full mb-8 rounded-2xl overflow-hidden shadow-lg bg-gradient-to-br from-blue-600 to-indigo-700 text-white p-8 text-center'>
+      <div
+        className='block md:hidden w-full mb-8 rounded-2xl overflow-hidden shadow-lg text-white p-8 text-center'
+        style={{
+          background: 'linear-gradient(135deg, #0072B2 0%, #004d7a 100%)',
+        }}
+      >
         <h1 className='text-3xl font-extrabold tracking-tight mb-4'>
-          Discover Amazing <span className='text-blue-200'>Dive Sites</span>
+          Discover Amazing <span style={{ color: '#80c9ed' }}>Dive Sites</span>
         </h1>
 
-        <p className='text-lg text-blue-100 leading-relaxed'>
+        <p className='text-lg leading-relaxed' style={{ color: '#eaf4f9' }}>
           Explore the world's best scuba locations, read reviews from fellow divers, and find your
           next underwater adventure.
         </p>
@@ -336,18 +341,26 @@ const Home = () => {
       )}
 
       {/* Stats Section (Integrated) */}
-      <div className='relative overflow-hidden bg-gradient-to-br from-blue-900 to-slate-900 rounded-3xl py-10 mb-10 shadow-2xl'>
+      <div
+        className='relative overflow-hidden rounded-3xl py-10 mb-10 shadow-2xl'
+        style={{
+          background: 'linear-gradient(135deg, #003656 0%, #001a2a 100%)',
+        }}
+      >
         <div className='absolute inset-0 opacity-10 bg-[url("https://www.transparenttextures.com/patterns/cubes.png")]'></div>
         <div className='relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8'>
           <div className='text-center mb-8'>
-            <h3 className='text-sm font-bold uppercase tracking-widest text-blue-400 mb-2'>
+            <h3
+              className='text-sm font-bold uppercase tracking-widest mb-2'
+              style={{ color: '#56B4E9' }}
+            >
               Our Growing Community
             </h3>
             <p className='text-2xl font-bold text-white'>Real-time Dive Statistics</p>
           </div>
           <div className='grid grid-cols-2 md:grid-cols-5 gap-6'>
             <Link to='/dives' className='text-center group'>
-              <div className='text-3xl sm:text-4xl font-extrabold text-white mb-1 group-hover:text-blue-400 transition-colors'>
+              <div className='text-3xl sm:text-4xl font-extrabold text-white mb-1 transition-colors group-hover:text-[#56B4E9]'>
                 <AnimatedCounter
                   targetValue={stats?.dives || 0}
                   isBackendAvailable={isBackendAvailable}
@@ -360,7 +373,7 @@ const Home = () => {
               </div>
             </Link>
             <Link to='/dive-sites' className='text-center group'>
-              <div className='text-3xl sm:text-4xl font-extrabold text-white mb-1 group-hover:text-blue-400 transition-colors'>
+              <div className='text-3xl sm:text-4xl font-extrabold text-white mb-1 transition-colors group-hover:text-[#56B4E9]'>
                 <AnimatedCounter
                   targetValue={stats?.dive_sites || 0}
                   duration={2200}
@@ -377,7 +390,7 @@ const Home = () => {
               to='/dive-sites?sort_by=average_rating&sort_order=desc'
               className='text-center group block'
             >
-              <div className='text-3xl sm:text-4xl font-extrabold text-white mb-1 group-hover:text-blue-400 transition-colors'>
+              <div className='text-3xl sm:text-4xl font-extrabold text-white mb-1 transition-colors group-hover:text-[#56B4E9]'>
                 <AnimatedCounter
                   targetValue={stats?.reviews || 0}
                   duration={2400}
@@ -391,7 +404,7 @@ const Home = () => {
               </div>
             </Link>
             <Link to='/diving-centers' className='text-center group'>
-              <div className='text-3xl sm:text-4xl font-extrabold text-white mb-1 group-hover:text-blue-400 transition-colors'>
+              <div className='text-3xl sm:text-4xl font-extrabold text-white mb-1 transition-colors group-hover:text-[#56B4E9]'>
                 <AnimatedCounter
                   targetValue={stats?.diving_centers || 0}
                   duration={2600}
@@ -405,7 +418,7 @@ const Home = () => {
               </div>
             </Link>
             <Link to='/dive-trips' className='text-center group'>
-              <div className='text-3xl sm:text-4xl font-extrabold text-white mb-1 group-hover:text-blue-400 transition-colors'>
+              <div className='text-3xl sm:text-4xl font-extrabold text-white mb-1 transition-colors group-hover:text-[#56B4E9]'>
                 <AnimatedCounter
                   targetValue={stats?.dive_trips || 0}
                   duration={2800}
@@ -444,7 +457,10 @@ const Home = () => {
       </section>
 
       {/* Final CTA */}
-      <div className='text-center py-20 bg-blue-50 rounded-3xl mb-12 px-6'>
+      <div
+        className='text-center py-20 rounded-3xl mb-12 px-6'
+        style={{ backgroundColor: '#eaf4f9' }}
+      >
         <h2 className='text-4xl font-extrabold text-gray-900 mb-6'>
           Ready to Start Your Diving Journey?
         </h2>
@@ -458,6 +474,7 @@ const Home = () => {
               type='primary'
               size='large'
               className='h-14 px-10 text-lg font-bold rounded-xl shadow-lg'
+              style={{ backgroundColor: '#0072B2' }}
             >
               Get Started Free
             </Button>
@@ -465,7 +482,8 @@ const Home = () => {
           <Link to='/dive-sites'>
             <Button
               size='large'
-              className='h-14 px-10 text-lg font-bold rounded-xl border-2 border-blue-600 text-blue-600 hover:text-blue-700'
+              className='h-14 px-10 text-lg font-bold rounded-xl border-2 hover:opacity-80 transition-all'
+              style={{ borderColor: '#0072B2', color: '#0072B2' }}
             >
               Explore Sites
             </Button>

--- a/frontend/src/pages/LeaderboardPage.jsx
+++ b/frontend/src/pages/LeaderboardPage.jsx
@@ -35,7 +35,7 @@ const CategoryCard = ({ title, icon: Icon, metric, label, limit = 5 }) => {
           <div className='p-1.5 bg-white rounded-lg shadow-sm'>
             <Icon className='w-4 h-4 text-blue-600' />
           </div>
-          <h3 className='font-bold text-gray-900'>{title}</h3>
+          <h3 className='text-xl font-bold text-gray-900'>{title}</h3>
         </div>
       </div>
       <div className='p-2'>
@@ -90,11 +90,11 @@ const LeaderboardPage = () => {
               <div className='text-center'>
                 <Link
                   to={`/users/${topThree[1].username}`}
-                  className='font-bold text-gray-900 hover:text-blue-600 transition-colors'
+                  className='font-bold text-blue-600 hover:text-blue-800 transition-colors'
                 >
                   {topThree[1].username}
                 </Link>
-                <p className='text-sm font-medium text-blue-600'>
+                <p className='text-sm font-medium' style={{ color: '#0072B2' }}>
                   {topThree[1].points.toLocaleString()} pts
                 </p>
               </div>
@@ -121,11 +121,11 @@ const LeaderboardPage = () => {
               <div className='text-center'>
                 <Link
                   to={`/users/${topThree[0].username}`}
-                  className='text-xl font-black text-gray-900 hover:text-blue-600 transition-colors block'
+                  className='text-xl font-black text-blue-600 hover:text-blue-800 transition-colors block'
                 >
                   {topThree[0].username}
                 </Link>
-                <p className='text-lg font-bold text-blue-600'>
+                <p className='text-lg font-bold' style={{ color: '#0072B2' }}>
                   {topThree[0].points.toLocaleString()} pts
                 </p>
               </div>
@@ -149,11 +149,11 @@ const LeaderboardPage = () => {
               <div className='text-center'>
                 <Link
                   to={`/users/${topThree[2].username}`}
-                  className='font-bold text-gray-900 hover:text-blue-600 transition-colors'
+                  className='font-bold text-blue-600 hover:text-blue-800 transition-colors'
                 >
                   {topThree[2].username}
                 </Link>
-                <p className='text-sm font-medium text-blue-600'>
+                <p className='text-sm font-medium' style={{ color: '#0072B2' }}>
                   {topThree[2].points.toLocaleString()} pts
                 </p>
               </div>
@@ -169,7 +169,7 @@ const LeaderboardPage = () => {
           <div className='p-4 bg-blue-600 text-white flex items-center justify-between'>
             <div className='flex items-center space-x-2'>
               <Trophy className='w-5 h-5' />
-              <h3 className='font-bold'>Top Divers (Overall)</h3>
+              <h3 className='text-xl font-bold'>Top Divers (Overall)</h3>
             </div>
           </div>
           <div className='p-2'>
@@ -212,7 +212,7 @@ const LeaderboardPage = () => {
               key={group.pts}
               className='bg-white p-4 rounded-xl border border-gray-100 text-center flex flex-col justify-center shadow-sm'
             >
-              <p className='text-2xl font-black text-blue-600 mb-3'>
+              <p className='text-2xl font-black mb-3' style={{ color: '#0072B2' }}>
                 +{group.pts}
                 <span className='text-xs ml-1 text-gray-500 font-bold uppercase'>pts</span>
               </p>

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -10,6 +10,14 @@ module.exports = {
         display: ['"Outfit"', 'system-ui', 'sans-serif'],
       },
       colors: {
+        // --- Divemap.blue Accessible Theme (Okabe-Ito Palette) ---
+        'divemap-blue': '#0072B2', // Okabe-Ito True Blue - Core brand color
+        'divemap-sky': '#56B4E9',  // Okabe-Ito Sky Blue - Bright highlight color
+        'divemap-deep': '#004d7a', // Deep Ocean Blue - Used for gradients
+        'divemap-trench': '#001a2a', // Dark Trench Blue - Used for dark section backgrounds
+        'divemap-surface': '#eaf4f9', // Bright Water Tint - Used for light CTA boxes
+        
+        // --- Legacy Colors ---
         'dive-primary': '#2563eb', // blue-600
         'dive-success': '#15803d', // green-700
         'dive-warning': '#9a3412', // orange-800


### PR DESCRIPTION
Migrate core theme colors from teal (#2d6b8a) to Okabe-Ito True Blue (#0072B2) to align with the new divemap.blue domain and ensure colorblind accessibility.

Frontend enhancements:
- Redesign Home page hero, stats, and CTA sections with oceanic blue gradients and accessible highlight colors.
- Polish Leaderboard UI with center-aligned columns, increased title font sizes, and consistent link styling for usernames.
- Improve Mobile Navbar UX by increasing burger icon size (scale-150) and tightening spacing between action icons.
- Increase "Divemap" brand text font size in the mobile navbar.
- Global replacement of legacy teal colors in card borders, lightboxes, and upload components.