### PR TITLE
Fix avatar resolution and implement URL caching

### DIFF
--- a/backend/app/routers/user_chat.py
+++ b/backend/app/routers/user_chat.py
@@ -7,6 +7,7 @@ import logging
 
 from fastapi import BackgroundTasks
 from app.database import get_db
+from app.utils import populate_avatar_full_url
 from app.models import User, UserChatRoom, UserChatRoomMember, UserChatMessage, DivingCenter, DivingCenterManager, BusinessChatStatus
 from app.auth import get_current_active_user
 from app.schemas.user_chat import (
@@ -206,6 +207,14 @@ async def create_chat_room(
         db.commit()
         db.refresh(new_room)
         
+        # Populate avatars for response
+        for m in new_room.members:
+            if m.user:
+                temp_data = {}
+                populate_avatar_full_url(m.user, temp_data)
+                m.user.avatar_full_url = temp_data.get("avatar_full_url")
+                m.user.avatar_type = m.user.avatar_type or "google"
+        
         # Inject auto-greeting
         if is_b2c:
             from app.models import DivingCenterChatSettings
@@ -327,6 +336,20 @@ async def list_chat_rooms(
                 room.unread_count = unread_count
                 # Override room.is_archived with the user-specific member value
                 room.is_archived = member_record.is_archived
+
+        # Populate avatars for all members in the room
+        # Memoization dictionary to avoid redundant processing within the same request
+        avatar_memo = {}
+        for m in room.members:
+            if m.user:
+                if m.user.id not in avatar_memo:
+                    temp_data = {}
+                    populate_avatar_full_url(m.user, temp_data)
+                    m.user.avatar_full_url = temp_data.get("avatar_full_url")
+                    m.user.avatar_type = m.user.avatar_type or "google"
+                    avatar_memo[m.user.id] = (m.user.avatar_full_url, m.user.avatar_type)
+                else:
+                    m.user.avatar_full_url, m.user.avatar_type = avatar_memo[m.user.id]
             
     return rooms
 
@@ -398,6 +421,15 @@ async def toggle_room_archive(
         
     db.commit()
     db.refresh(room)
+
+    # Populate avatars for response
+    for m in room.members:
+        if m.user:
+            temp_data = {}
+            populate_avatar_full_url(m.user, temp_data)
+            m.user.avatar_full_url = temp_data.get("avatar_full_url")
+            m.user.avatar_type = m.user.avatar_type or "google"
+
     return room
 
 @router.post("/rooms/{room_id}/messages", response_model=ChatMessageResponse, status_code=status.HTTP_201_CREATED)
@@ -479,6 +511,13 @@ async def send_message(
     # Decrypt content for the response
     response_msg = ChatMessageResponse.model_validate(new_message)
     response_msg.content = message_in.content
+    
+    if response_msg.sender and new_message.sender:
+        temp_data = {}
+        populate_avatar_full_url(new_message.sender, temp_data)
+        response_msg.sender.avatar_full_url = temp_data.get("avatar_full_url")
+        response_msg.sender.avatar_type = new_message.sender.avatar_type or "google"
+        
     return response_msg
 
 @router.put("/messages/{message_id}", response_model=ChatMessageResponse)
@@ -514,6 +553,13 @@ async def edit_message(
     # Return decrypted
     response_msg = ChatMessageResponse.model_validate(message)
     response_msg.content = message_in.content
+    
+    if response_msg.sender and message.sender:
+        temp_data = {}
+        populate_avatar_full_url(message.sender, temp_data)
+        response_msg.sender.avatar_full_url = temp_data.get("avatar_full_url")
+        response_msg.sender.avatar_type = message.sender.avatar_type or "google"
+        
     return response_msg
 
 @router.get("/rooms/{room_id}/messages", response_model=List[ChatMessageResponse])
@@ -557,6 +603,7 @@ async def get_messages(
     
     # 3. Decrypt and mask identity if B2C
     result = []
+    avatar_memo = {} # Per-request cache
     
     # Pre-fetch manager ids for masking if it's a B2C room
     manager_ids = set()
@@ -579,6 +626,18 @@ async def get_messages(
             if dc:
                 resp_msg.sender.username = dc.name
                 resp_msg.sender.avatar_url = dc.logo_url
+                # For masked center identity, we use logo_url as avatar_full_url too
+                resp_msg.sender.avatar_full_url = dc.logo_url
+        elif resp_msg.sender and msg.sender:
+            # Regular user: populate avatar full URL with memoization
+            if msg.sender_id not in avatar_memo:
+                temp_data = {}
+                populate_avatar_full_url(msg.sender, temp_data)
+                resp_msg.sender.avatar_full_url = temp_data.get("avatar_full_url")
+                resp_msg.sender.avatar_type = msg.sender.avatar_type or "google"
+                avatar_memo[msg.sender_id] = (resp_msg.sender.avatar_full_url, resp_msg.sender.avatar_type)
+            else:
+                resp_msg.sender.avatar_full_url, resp_msg.sender.avatar_type = avatar_memo[msg.sender_id]
                 
         result.append(resp_msg)
         
@@ -634,6 +693,15 @@ async def update_chat_room(
         
     db.commit()
     db.refresh(room)
+
+    # Populate avatars for response
+    for m in room.members:
+        if m.user:
+            temp_data = {}
+            populate_avatar_full_url(m.user, temp_data)
+            m.user.avatar_full_url = temp_data.get("avatar_full_url")
+            m.user.avatar_type = m.user.avatar_type or "google"
+
     return room
 
 @router.delete("/rooms/{room_id}/leave", status_code=status.HTTP_200_OK)

--- a/backend/app/routers/user_friendships.py
+++ b/backend/app/routers/user_friendships.py
@@ -4,6 +4,7 @@ from sqlalchemy import or_, and_, func
 from typing import List
 
 from app.database import get_db
+from app.utils import populate_avatar_full_url
 from app.models import User, UserFriendship
 from app.auth import get_current_active_user
 from app.schemas.user_friendship import FriendshipResponse, FriendshipRequestCreate
@@ -42,6 +43,14 @@ async def send_friend_request(
                 existing.updated_at = func.now()
                 db.commit()
                 db.refresh(existing)
+
+                # Populate avatars for response
+                for user_obj in [existing.user, existing.friend]:
+                    if user_obj:
+                        temp_data = {}
+                        populate_avatar_full_url(user_obj, temp_data)
+                        user_obj.avatar_full_url = temp_data.get("avatar_full_url")
+                        user_obj.avatar_type = user_obj.avatar_type or "google"
                 
                 # Send notification to the original initiator
                 from app.services.notification_service import NotificationService
@@ -65,6 +74,14 @@ async def send_friend_request(
             existing.updated_at = func.now()
             db.commit()
             db.refresh(existing)
+
+            # Populate avatars for response
+            for user_obj in [existing.user, existing.friend]:
+                if user_obj:
+                    temp_data = {}
+                    populate_avatar_full_url(user_obj, temp_data)
+                    user_obj.avatar_full_url = temp_data.get("avatar_full_url")
+                    user_obj.avatar_type = user_obj.avatar_type or "google"
             
             # Send notification
             from app.services.notification_service import NotificationService
@@ -87,6 +104,14 @@ async def send_friend_request(
     db.add(new_request)
     db.commit()
     db.refresh(new_request)
+
+    # Populate avatars for response
+    for user_obj in [new_request.user, new_request.friend]:
+        if user_obj:
+            temp_data = {}
+            populate_avatar_full_url(user_obj, temp_data)
+            user_obj.avatar_full_url = temp_data.get("avatar_full_url")
+            user_obj.avatar_type = user_obj.avatar_type or "google"
     
     # Send notification
     from app.services.notification_service import NotificationService
@@ -119,7 +144,22 @@ async def list_friends(
         ),
         UserFriendship.status == status_filter.upper()
     )
-    return query.all()
+    results = query.all()
+    
+    # Populate avatars for both user and friend
+    for friendship in results:
+        if friendship.user:
+            temp_data = {}
+            populate_avatar_full_url(friendship.user, temp_data)
+            friendship.user.avatar_full_url = temp_data.get("avatar_full_url")
+            friendship.user.avatar_type = friendship.user.avatar_type or "google"
+        if friendship.friend:
+            temp_data = {}
+            populate_avatar_full_url(friendship.friend, temp_data)
+            friendship.friend.avatar_full_url = temp_data.get("avatar_full_url")
+            friendship.friend.avatar_type = friendship.friend.avatar_type or "google"
+            
+    return results
 
 @router.put("/requests/{friendship_id}/accept", response_model=FriendshipResponse)
 async def accept_friend_request(
@@ -147,6 +187,14 @@ async def accept_friend_request(
     friendship.updated_at = func.now()
     db.commit()
     db.refresh(friendship)
+    
+    # Populate avatars for both user and friend
+    for user_obj in [friendship.user, friendship.friend]:
+        if user_obj:
+            temp_data = {}
+            populate_avatar_full_url(user_obj, temp_data)
+            user_obj.avatar_full_url = temp_data.get("avatar_full_url")
+            user_obj.avatar_type = user_obj.avatar_type or "google"
     
     # Send notification to the initiator
     from app.services.notification_service import NotificationService
@@ -181,6 +229,15 @@ async def reject_friend_request(
     friendship.updated_at = func.now()
     db.commit()
     db.refresh(friendship)
+
+    # Populate avatars for both user and friend
+    for user_obj in [friendship.user, friendship.friend]:
+        if user_obj:
+            temp_data = {}
+            populate_avatar_full_url(user_obj, temp_data)
+            user_obj.avatar_full_url = temp_data.get("avatar_full_url")
+            user_obj.avatar_type = user_obj.avatar_type or "google"
+
     return friendship
 
 @router.delete("/{friendship_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/schemas/user_chat.py
+++ b/backend/app/schemas/user_chat.py
@@ -7,6 +7,8 @@ class UserBasicInfo(BaseModel):
     id: int
     username: str
     avatar_url: Optional[str] = None
+    avatar_type: Optional[str] = "google"
+    avatar_full_url: Optional[str] = None
     
     class Config:
         from_attributes = True

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -3,6 +3,7 @@ from typing import Optional
 from sqlalchemy.orm import Session
 from datetime import datetime, timezone
 import orjson
+from cachetools import cached, TTLCache
 
 
 def is_diving_center_reviews_enabled(db: Session) -> bool:
@@ -625,23 +626,33 @@ def normalize_datetime_to_utc(dt: Optional[datetime]) -> Optional[datetime]:
         return dt.replace(tzinfo=timezone.utc)
     return dt.astimezone(timezone.utc)
 
-def populate_avatar_full_url(user, response_model_dict: dict) -> dict:
-    """Populate avatar_full_url based on avatar_type and avatar_url"""
+# Cache presigned URLs for 55 minutes (3300s) to safely beat the 1-hour expiration
+@cached(cache=TTLCache(maxsize=1024, ttl=3300))
+def _get_cached_avatar_url(avatar_url: str, avatar_type: str) -> Optional[str]:
+    """Helper to generate and cache presigned avatar URLs based on the raw URL string."""
     from app.services.r2_storage_service import r2_storage
     from app.schemas import AvatarType
-    
+
+    if avatar_type == AvatarType.custom:
+        return r2_storage.get_photo_url(avatar_url)
+    elif avatar_type == AvatarType.library:
+        return r2_storage.get_library_avatar_url(avatar_url)
+    return avatar_url
+
+
+def populate_avatar_full_url(user, response_model_dict: dict) -> dict:
+    """Populate avatar_full_url based on avatar_type and avatar_url"""
     if not user.avatar_url:
         response_model_dict['avatar_full_url'] = None
         return response_model_dict
 
-    if user.avatar_type == AvatarType.custom:
-        response_model_dict['avatar_full_url'] = r2_storage.get_photo_url(user.avatar_url)
-    elif user.avatar_type == AvatarType.library:
-        response_model_dict['avatar_full_url'] = r2_storage.get_library_avatar_url(user.avatar_url)
-    else: # google or fallback
-        response_model_dict['avatar_full_url'] = user.avatar_url
-        
+    # Use the cached helper to avoid redundant cryptographic signing
+    # avatar_type is cast to string for hashability in lru_cache
+    avatar_type_str = user.avatar_type.value if hasattr(user.avatar_type, 'value') else str(user.avatar_type)
+    response_model_dict['avatar_full_url'] = _get_cached_avatar_url(user.avatar_url, avatar_type_str)
+
     # Always include original google avatar if available
     response_model_dict['google_avatar_url'] = user.google_avatar_url
-        
+
     return response_model_dict
+

--- a/backend/tests/test_avatars.py
+++ b/backend/tests/test_avatars.py
@@ -132,7 +132,7 @@ def test_populate_avatar_full_url_utility(db_session, test_user):
         assert result["avatar_full_url"] == "https://presigned-url.com"
         
         # Case 2: Library Avatar
-        test_user.avatar_url = "library/avatars/eel.webp"
+        test_user.avatar_url = "library/avatars/unique_eel.webp"
         test_user.avatar_type = "library"
         mock_storage.get_library_avatar_url.return_value = "https://library-url.com"
         

--- a/frontend/src/components/UserChat/ChatDropdown.jsx
+++ b/frontend/src/components/UserChat/ChatDropdown.jsx
@@ -105,7 +105,10 @@ const ChatDropdown = () => {
                   : otherMembers[0]?.user?.username || 'Chat';
                 const displayAvatar = room.is_group
                   ? null
-                  : otherMembers[0]?.user?.avatar_url || otherMembers[0]?.avatar_url;
+                  : otherMembers[0]?.user?.avatar_full_url ||
+                    otherMembers[0]?.user?.avatar_url ||
+                    otherMembers[0]?.avatar_full_url ||
+                    otherMembers[0]?.avatar_url;
 
                 return (
                   <button

--- a/frontend/src/components/UserChat/ChatInbox.jsx
+++ b/frontend/src/components/UserChat/ChatInbox.jsx
@@ -101,7 +101,11 @@ const ChatInbox = ({ rooms, activeRoomId, onSelectRoom, onNewChat, isLoading, bu
                 otherMembers[0]?.user?.username ||
                 otherMembers[0]?.username ||
                 (room.diving_center_id ? 'Business Chat' : 'Unknown User');
-              displayAvatar = otherMembers[0]?.user?.avatar_url || otherMembers[0]?.avatar_url;
+              displayAvatar =
+                otherMembers[0]?.user?.avatar_full_url ||
+                otherMembers[0]?.user?.avatar_url ||
+                otherMembers[0]?.avatar_full_url ||
+                otherMembers[0]?.avatar_url;
             }
           }
           return (

--- a/frontend/src/components/UserChat/ChatRoom.jsx
+++ b/frontend/src/components/UserChat/ChatRoom.jsx
@@ -191,7 +191,11 @@ const ChatRoom = ({ roomId, room, currentUserId, onToggleSettings, onBack }) => 
       displayAvatar = room.diving_center.logo_url;
     } else {
       displayName = otherMembers[0]?.user?.username || 'Chat';
-      displayAvatar = otherMembers[0]?.user?.avatar_url || otherMembers[0]?.avatar_url;
+      displayAvatar =
+        otherMembers[0]?.user?.avatar_full_url ||
+        otherMembers[0]?.user?.avatar_url ||
+        otherMembers[0]?.avatar_full_url ||
+        otherMembers[0]?.avatar_url;
     }
   }
   const maxReadAt = otherMembers.length

--- a/frontend/src/components/UserChat/MessageBubble.jsx
+++ b/frontend/src/components/UserChat/MessageBubble.jsx
@@ -103,7 +103,7 @@ const MessageBubble = ({
               </div>
             ) : (
               <Avatar
-                src={message.sender?.avatar_url}
+                src={message.sender?.avatar_full_url || message.sender?.avatar_url}
                 size='sm'
                 username={message.sender?.username}
               />
@@ -331,7 +331,7 @@ const MessageBubble = ({
         <div className='ml-2 mt-auto flex-shrink-0 w-8 h-8'>
           {showAvatar && (
             <Avatar
-              src={message.sender?.avatar_url}
+              src={message.sender?.avatar_full_url || message.sender?.avatar_url}
               size='sm'
               username={message.sender?.username}
             />

--- a/frontend/src/components/UserChat/NewChatModal.jsx
+++ b/frontend/src/components/UserChat/NewChatModal.jsx
@@ -155,7 +155,7 @@ const NewChatModal = ({ isOpen, onClose, onRoomCreated }) => {
                   >
                     <div className='relative'>
                       <Avatar
-                        src={buddy.avatar_url}
+                        src={buddy.avatar_full_url || buddy.avatar_url}
                         alt={buddy.username}
                         size='md'
                         username={buddy.username}

--- a/frontend/src/components/UserChat/RoomSettings.jsx
+++ b/frontend/src/components/UserChat/RoomSettings.jsx
@@ -75,7 +75,11 @@ const RoomSettings = ({ room, currentUserId, onClose }) => {
       roomTypeLabel = room.is_broadcast ? 'Broadcast Channel' : 'Business Chat';
     } else {
       displayName = otherMembers[0]?.user?.username || 'Chat';
-      displayAvatar = otherMembers[0]?.user?.avatar_url || otherMembers[0]?.avatar_url;
+      displayAvatar =
+        otherMembers[0]?.user?.avatar_full_url ||
+        otherMembers[0]?.user?.avatar_url ||
+        otherMembers[0]?.avatar_full_url ||
+        otherMembers[0]?.avatar_url;
     }
   }
 
@@ -163,7 +167,7 @@ const RoomSettings = ({ room, currentUserId, onClose }) => {
               >
                 <div className='flex items-center gap-3 min-w-0'>
                   <Avatar
-                    src={member.user?.avatar_url}
+                    src={member.user?.avatar_full_url || member.user?.avatar_url}
                     alt={member.user?.username}
                     size='sm'
                     username={member.user?.username}

--- a/frontend/src/components/UserSearchInput.jsx
+++ b/frontend/src/components/UserSearchInput.jsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect, useRef, useMemo } from 'react';
 
 import { searchUsers } from '../api';
 
+import Avatar from './Avatar';
 import Combobox from './ui/Combobox';
 
 /**
@@ -80,17 +81,12 @@ const UserSearchInput = ({
     const { user } = option;
     return (
       <div className='flex items-center gap-3 w-full'>
-        {user.avatar_url ? (
-          <img
-            src={user.avatar_url}
-            alt={user.username}
-            className='w-8 h-8 rounded-full object-cover'
-          />
-        ) : (
-          <div className='w-8 h-8 rounded-full bg-gray-200 flex items-center justify-center'>
-            <User size={16} className='text-gray-500' />
-          </div>
-        )}
+        <Avatar
+          src={user.avatar_full_url || user.avatar_url}
+          alt={user.username}
+          size='sm'
+          username={user.username}
+        />
         <div className='flex flex-col min-w-0'>
           <div className='text-sm font-medium text-gray-900 truncate'>{user.username}</div>
           {user.name && <div className='text-xs text-gray-500 truncate'>{user.name}</div>}

--- a/frontend/src/components/ui/UserSearchDropdown.jsx
+++ b/frontend/src/components/ui/UserSearchDropdown.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { searchUsers } from '../../api';
+import Avatar from '../Avatar';
 
 import AutocompleteDropdown from './AutocompleteDropdown';
 
@@ -24,17 +25,12 @@ export const UserSearchDropdown = ({
 
   const renderUserItem = user => (
     <div className='flex items-center gap-2'>
-      {user.avatar_url ? (
-        <img
-          src={user.avatar_url}
-          alt={user.username}
-          className='w-6 h-6 rounded-full object-cover'
-        />
-      ) : (
-        <div className='w-6 h-6 rounded-full bg-blue-100 flex items-center justify-center text-blue-600 text-xs font-bold'>
-          {user.username.charAt(0).toUpperCase()}
-        </div>
-      )}
+      <Avatar
+        src={user.avatar_full_url || user.avatar_url}
+        alt={user.username}
+        size='xs'
+        username={user.username}
+      />
       <div>
         <div className='font-medium text-gray-900'>{user.username}</div>
         {user.name && <div className='text-xs text-gray-500'>{user.name}</div>}

--- a/frontend/src/pages/Buddies.jsx
+++ b/frontend/src/pages/Buddies.jsx
@@ -108,9 +108,14 @@ const Buddies = () => {
             ) : (
               <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4'>
                 {buddies.map(friendship => {
+                  // Safeguard against deleted users or malformed data
+                  if (!friendship.user || !friendship.friend) return null;
+
                   // Determine which user in the friendship is the buddy (not the current user)
                   const buddyUser =
                     friendship.user.id === currentUser.id ? friendship.friend : friendship.user;
+
+                  if (!buddyUser) return null;
 
                   return (
                     <div
@@ -122,7 +127,7 @@ const Buddies = () => {
                         className='flex items-center gap-3 flex-1 min-w-0 group'
                       >
                         <Avatar
-                          src={buddyUser.avatar_url}
+                          src={buddyUser.avatar_full_url || buddyUser.avatar_url}
                           alt={buddyUser.username}
                           size='md'
                           fallbackText={buddyUser.username}

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -131,7 +131,7 @@ const Home = () => {
           >
             <div className='relative'>
               <Avatar
-                src={user.avatar_url}
+                src={user.avatar_full_url || user.avatar_url}
                 alt={user.username}
                 size='lg'
                 fallbackText={user.username}

--- a/frontend/src/sw.js
+++ b/frontend/src/sw.js
@@ -2,7 +2,11 @@
 /* eslint-disable no-restricted-globals */
 import { CacheableResponsePlugin } from 'workbox-cacheable-response';
 import { ExpirationPlugin } from 'workbox-expiration';
-import { precacheAndRoute, cleanupOutdatedCaches, createHandlerBoundToURL } from 'workbox-precaching';
+import {
+  precacheAndRoute,
+  cleanupOutdatedCaches,
+  createHandlerBoundToURL,
+} from 'workbox-precaching';
 import { registerRoute, NavigationRoute } from 'workbox-routing';
 import { NetworkFirst, CacheFirst, StaleWhileRevalidate } from 'workbox-strategies';
 
@@ -33,12 +37,15 @@ try {
       new RegExp('^/api/'),
       new RegExp('^/docs'),
       new RegExp('^/redoc'),
-      new RegExp('^/openapi.json')
+      new RegExp('^/openapi.json'),
     ],
   });
   registerRoute(navigationRoute);
 } catch (error) {
-  console.warn('NavigationRoute setup failed (likely due to missing /index.html in precache in dev mode):', error);
+  console.warn(
+    'NavigationRoute setup failed (likely due to missing /index.html in precache in dev mode):',
+    error
+  );
 }
 
 // --- Runtime Caching ---


### PR DESCRIPTION
Add `avatar_full_url` and `avatar_type` fields to `UserBasicInfo` schema to properly pass resolved R2 image URLs to the frontend.

Update `populate_avatar_full_url` to use `cachetools.TTLCache` to securely and efficiently memoize S3 presigned URL generation (55-minute TTL) to avoid computing HMAC-SHA256 repeatedly per request. Apply this memoization across user_chat and user_friendships routers.

Update React frontend components (Home Leaderboard, Messages, Buddies, Search) to prioritize `avatar_full_url` over raw `avatar_url` database strings so that Cloudflare R2 images load correctly. Refactor search dropdowns to utilize the standard `Avatar` component for consistency.

Add null-checks to the `Buddies` map loop to prevent React crashes caused by incomplete or deleted user profiles.