### PR TITLE
Refine UI for logos and dive detail page layout

### DIFF
--- a/backend/app/routers/dives/dives_admin.py
+++ b/backend/app/routers/dives/dives_admin.py
@@ -448,7 +448,9 @@ def get_all_dives_admin(
                 "phone": dive.diving_center.phone,
                 "website": dive.diving_center.website,
                 "latitude": float(dive.diving_center.latitude) if dive.diving_center.latitude else None,
-                "longitude": float(dive.diving_center.longitude) if dive.diving_center.longitude else None
+                "longitude": float(dive.diving_center.longitude) if dive.diving_center.longitude else None,
+                "logo_url": dive.diving_center.logo_url,
+                "logo_full_url": r2_storage.get_photo_url(dive.diving_center.logo_url) if getattr(dive.diving_center, 'logo_url', None) else None
             }
 
         # Get tags (already eagerly loaded)
@@ -670,7 +672,9 @@ def update_dive_admin(
                 "phone": diving_center.phone,
                 "website": diving_center.website,
                 "latitude": float(diving_center.latitude) if diving_center.latitude else None,
-                "longitude": float(diving_center.longitude) if diving_center.longitude else None
+                "longitude": float(diving_center.longitude) if diving_center.longitude else None,
+                "logo_url": diving_center.logo_url,
+                "logo_full_url": r2_storage.get_photo_url(diving_center.logo_url) if diving_center.logo_url else None
             }
 
     # Get tags for this dive

--- a/backend/app/routers/dives/dives_crud.py
+++ b/backend/app/routers/dives/dives_crud.py
@@ -247,7 +247,9 @@ async def create_dive(
             "phone": db_dive.diving_center.phone,
             "website": db_dive.diving_center.website,
             "latitude": float(db_dive.diving_center.latitude) if db_dive.diving_center.latitude else None,
-            "longitude": float(db_dive.diving_center.longitude) if db_dive.diving_center.longitude else None
+            "longitude": float(db_dive.diving_center.longitude) if db_dive.diving_center.longitude else None,
+            "logo_url": db_dive.diving_center.logo_url,
+            "logo_full_url": r2_storage.get_photo_url(db_dive.diving_center.logo_url) if db_dive.diving_center.logo_url else None
         } if db_dive.diving_center else None,
         "media": [],
         "tags": [{"id": t.tag.id, "name": t.tag.name} for t in db_dive.tags if t.tag],
@@ -874,7 +876,9 @@ def get_dives(
                 "phone": dive.diving_center.phone,
                 "website": dive.diving_center.website,
                 "latitude": float(dive.diving_center.latitude) if dive.diving_center.latitude else None,
-                "longitude": float(dive.diving_center.longitude) if dive.diving_center.longitude else None
+                "longitude": float(dive.diving_center.longitude) if dive.diving_center.longitude else None,
+                "logo_url": dive.diving_center.logo_url,
+                "logo_full_url": r2_storage.get_photo_url(dive.diving_center.logo_url) if getattr(dive.diving_center, 'logo_url', None) else None
             }
 
         # Get tags (already eagerly loaded via selectinload)
@@ -1026,7 +1030,9 @@ def get_dive(
                 "phone": diving_center.phone,
                 "website": diving_center.website,
                 "latitude": float(diving_center.latitude) if diving_center.latitude else None,
-                "longitude": float(diving_center.longitude) if diving_center.longitude else None
+                "longitude": float(diving_center.longitude) if diving_center.longitude else None,
+                "logo_url": diving_center.logo_url,
+                "logo_full_url": r2_storage.get_photo_url(diving_center.logo_url) if diving_center.logo_url else None
             }
 
     # Get tags for this dive
@@ -1466,7 +1472,9 @@ def update_dive(
                 "phone": diving_center.phone,
                 "website": diving_center.website,
                 "latitude": float(diving_center.latitude) if diving_center.latitude else None,
-                "longitude": float(diving_center.longitude) if diving_center.longitude else None
+                "longitude": float(diving_center.longitude) if diving_center.longitude else None,
+                "logo_url": diving_center.logo_url,
+                "logo_full_url": r2_storage.get_photo_url(diving_center.logo_url) if diving_center.logo_url else None
             }
 
     # Get tags for this dive

--- a/frontend/src/components/Avatar.jsx
+++ b/frontend/src/components/Avatar.jsx
@@ -10,6 +10,7 @@ const Avatar = ({
   className = '',
   fallbackText = null,
   username = null,
+  shape = 'circle',
 }) => {
   const [hasError, setHasError] = useState(false);
 
@@ -27,8 +28,10 @@ const Avatar = ({
     '2xl': 'w-24 h-24 text-2xl',
   };
 
-  const baseClasses =
-    'rounded-full flex items-center justify-center font-semibold text-white bg-gray-500 flex-shrink-0';
+  const shapeClass =
+    shape === 'circle' ? 'rounded-full' : shape === 'square' ? 'rounded-none' : 'rounded-xl';
+
+  const baseClasses = `${shapeClass} flex items-center justify-center font-semibold text-white bg-gray-500 flex-shrink-0`;
   const sizeClass = sizeClasses[size] || sizeClasses.md;
 
   // Generate initials from available text props
@@ -67,7 +70,7 @@ const Avatar = ({
       <img
         src={resolveAvatarUrl(src)}
         alt={alt}
-        className={`${sizeClass} rounded-full object-cover flex-shrink-0 ${className}`}
+        className={`${sizeClass} ${shapeClass} object-cover flex-shrink-0 ${className}`}
         onError={() => setHasError(true)}
       />
     );
@@ -84,6 +87,7 @@ Avatar.propTypes = {
   src: PropTypes.string,
   alt: PropTypes.string,
   size: PropTypes.oneOf(['xs', 'sm', 'md', 'lg', 'xl', '2xl']),
+  shape: PropTypes.oneOf(['circle', 'square', 'rounded']),
   className: PropTypes.string,
   fallbackText: PropTypes.string,
   username: PropTypes.string,

--- a/frontend/src/components/DiveSidebar.jsx
+++ b/frontend/src/components/DiveSidebar.jsx
@@ -6,6 +6,8 @@ import { decodeHtmlEntities } from '../utils/htmlDecode';
 import { slugify } from '../utils/slugify';
 import { renderTextWithLinks } from '../utils/textHelpers';
 
+import Avatar from './Avatar';
+
 const DiveSidebar = ({ dive, formatDate }) => {
   return (
     <div className='space-y-6'>
@@ -43,53 +45,27 @@ const DiveSidebar = ({ dive, formatDate }) => {
       {dive.diving_center && (
         <div className='bg-white rounded-lg shadow p-6'>
           <h2 className='text-xl font-semibold mb-4'>Diving Center</h2>
-          <div className='space-y-3'>
-            <div className='flex items-center gap-2'>
-              <MapPin size={15} className='text-gray-500' />
-              <span className='font-medium'>{dive.diving_center.name}</span>
-            </div>
-            {dive.diving_center.description && (
-              <p className='text-sm text-gray-600'>
-                {renderTextWithLinks(decodeHtmlEntities(dive.diving_center.description))}
-              </p>
-            )}
+          <div className='space-y-4'>
             <RouterLink
               to={`/diving-centers/${dive.diving_center.id}/${slugify(dive.diving_center.name)}`}
               state={{ from: window.location.pathname + window.location.search }}
-              className='text-blue-600 hover:text-blue-800 text-sm'
+              className='flex items-center gap-3 group'
             >
-              View diving center details →
+              <Avatar
+                src={dive.diving_center.logo_full_url || dive.diving_center.logo_url}
+                alt={dive.diving_center.name}
+                size='xl'
+                shape='rounded'
+                fallbackText={dive.diving_center.name}
+                className='border border-gray-100 shadow-sm transition-transform duration-200 group-hover:scale-105'
+              />
+              <span className='font-bold text-gray-900 leading-tight group-hover:text-blue-600 transition-colors'>
+                {dive.diving_center.name}
+              </span>
             </RouterLink>
           </div>
         </div>
       )}
-
-      {/* Statistics */}
-      <div className='bg-white rounded-lg shadow p-6'>
-        <h2 className='text-xl font-semibold mb-4 flex items-center gap-2'>
-          <Gauge className='h-5 w-5 text-gray-400' />
-          Statistics
-        </h2>
-        <div className='space-y-3'>
-          <div className='flex justify-between items-center'>
-            <div className='flex items-center gap-2'>
-              <Notebook size={15} className='text-gray-500' />
-              <span className='text-gray-600'>Total Dives</span>
-            </div>
-            <span className='font-medium'>{dive.user?.number_of_dives || 0}</span>
-          </div>
-          <div className='flex justify-between'>
-            <span className='text-gray-600'>Dive Date</span>
-            <span className='font-medium'>{formatDate(dive.dive_date)}</span>
-          </div>
-          {dive.created_at && (
-            <div className='flex justify-between'>
-              <span className='text-gray-600'>Logged</span>
-              <span className='font-medium'>{formatDate(dive.created_at)}</span>
-            </div>
-          )}
-        </div>
-      </div>
     </div>
   );
 };

--- a/frontend/src/components/DivingCenterSummaryCard.jsx
+++ b/frontend/src/components/DivingCenterSummaryCard.jsx
@@ -85,9 +85,10 @@ const DivingCenterSummaryCard = ({ center, user, onBack, reviewsEnabled }) => {
               <Avatar
                 src={center.logo_full_url || center.logo_url}
                 alt={center.name}
-                size='lg'
+                size='2xl'
+                shape='rounded'
                 fallbackText={center.name}
-                className='border border-gray-200'
+                className='border border-gray-200 shadow-sm'
               />
               <h1 className='text-3xl font-bold text-gray-900 break-words'>{center.name}</h1>
             </div>

--- a/frontend/src/pages/DiveDetail.jsx
+++ b/frontend/src/pages/DiveDetail.jsx
@@ -649,6 +649,11 @@ const DiveDetail = () => {
                   >
                     <span className='leading-tight mt-1'>{dive.user_username}</span>
                   </RouterLink>
+                  {dive.created_at && (
+                    <span className='leading-tight mt-1 text-gray-400'>
+                      on {formatDate(dive.created_at)}
+                    </span>
+                  )}
                 </div>
               )}
             </div>

--- a/frontend/src/pages/EditDivingCenter.jsx
+++ b/frontend/src/pages/EditDivingCenter.jsx
@@ -453,6 +453,7 @@ const EditDivingCenter = () => {
                 src={divingCenter.logo_full_url || divingCenter.logo_url}
                 alt={divingCenter.name}
                 size='2xl'
+                shape='rounded'
                 fallbackText={divingCenter.name}
                 className='border-2 border-gray-100 shadow-sm'
               />
@@ -473,7 +474,11 @@ const EditDivingCenter = () => {
                   >
                     {logoUploading ? 'Uploading...' : 'Choose new image'}
                   </label>
-                  <p className='text-xs text-gray-500'>JPEG, PNG, WEBP up to 5MB</p>
+                  <p className='text-xs text-gray-500'>
+                    JPEG, PNG, WEBP up to 5MB.
+                    <br />
+                    Recommended: 512x512px (1:1 aspect ratio)
+                  </p>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Enhance the visual presentation of diving center logos and streamline the layout of the individual dive log page for better usability.

- Avatar Component: Introduce a new `shape` prop (`circle`, `square`, `rounded`) to allow non-circular images without aggressive cropping, which is particularly useful for corporate logos.
- Diving Center Profiles: Apply `size='2xl'` and `shape='rounded'` to the diving center logos on the public profile and edit pages, providing a much larger, modern "app-icon" aesthetic. Add helper text to the upload button advising users of the 512x512px recommendation.
- Dive Sidebar: Overhaul the dive sidebar by removing the space-consuming diving center text description and the generic "View details" link. Replace it with the new rounded logo and an interactive hover effect on the entire block.
- Dive Details: Remove the broken and redundant "Statistics" box from the sidebar. Reposition the "Logged" timestamp (`created_at`) directly into the primary page header next to the creator attribution line.