### PR TITLE
Fix buddy avatar resolution and route creator null reference

### DIFF
--- a/backend/app/routers/dives/dives_crud.py
+++ b/backend/app/routers/dives/dives_crud.py
@@ -12,6 +12,7 @@ This module contains core CRUD operations for dives:
 """
 
 from fastapi import Depends, HTTPException, status, Query, BackgroundTasks
+from app.utils import _get_cached_avatar_url
 from sqlalchemy.orm import Session, joinedload, selectinload
 from sqlalchemy import or_, and_, desc, asc, distinct, func
 from typing import List, Optional
@@ -258,7 +259,11 @@ async def create_dive(
                 "id": buddy.id,
                 "username": buddy.username,
                 "name": buddy.name,
-                "avatar_url": buddy.avatar_url
+                "avatar_url": buddy.avatar_url,
+                "avatar_full_url": _get_cached_avatar_url(
+                    buddy.avatar_url,
+                    buddy.avatar_type.value if hasattr(buddy.avatar_type, 'value') else str(buddy.avatar_type)
+                ) if buddy.avatar_url else None
             }
             for buddy in db_dive.buddies
         ],
@@ -890,7 +895,11 @@ def get_dives(
                 "id": buddy.id,
                 "username": buddy.username,
                 "name": buddy.name,
-                "avatar_url": buddy.avatar_url
+                "avatar_url": buddy.avatar_url,
+                "avatar_full_url": _get_cached_avatar_url(
+                    buddy.avatar_url,
+                    buddy.avatar_type.value if hasattr(buddy.avatar_type, 'value') else str(buddy.avatar_type)
+                ) if buddy.avatar_url else None
             }
             for buddy in dive.buddies
         ]
@@ -1055,7 +1064,11 @@ def get_dive(
             "id": buddy.id,
             "username": buddy.username,
             "name": buddy.name,
-            "avatar_url": buddy.avatar_url
+            "avatar_url": buddy.avatar_url,
+            "avatar_full_url": _get_cached_avatar_url(
+                buddy.avatar_url,
+                buddy.avatar_type.value if hasattr(buddy.avatar_type, 'value') else str(buddy.avatar_type)
+            ) if buddy.avatar_url else None
         }
         for buddy in dive_buddies
     ]
@@ -1076,7 +1089,7 @@ def get_dive(
                 "route_type": selected_route.route_type,
                 "route_data": selected_route.route_data,
                 "created_by": selected_route.created_by,
-                "creator_username": selected_route.creator.username,
+                "creator_username": selected_route.creator.username if selected_route.creator else None,
                 "created_at": selected_route.created_at
             }
 
@@ -1497,7 +1510,11 @@ def update_dive(
             "id": buddy.id,
             "username": buddy.username,
             "name": buddy.name,
-            "avatar_url": buddy.avatar_url
+            "avatar_url": buddy.avatar_url,
+            "avatar_full_url": _get_cached_avatar_url(
+                buddy.avatar_url,
+                buddy.avatar_type.value if hasattr(buddy.avatar_type, 'value') else str(buddy.avatar_type)
+            ) if buddy.avatar_url else None
         }
         for buddy in dive_buddies
     ]
@@ -1515,7 +1532,7 @@ def update_dive(
                 "route_type": selected_route.route_type,
                 "route_data": selected_route.route_data,
                 "created_by": selected_route.created_by,
-                "creator_username": selected_route.creator.username,
+                "creator_username": selected_route.creator.username if selected_route.creator else None,
                 "created_at": selected_route.created_at
             }
 

--- a/frontend/src/pages/CreateDive.jsx
+++ b/frontend/src/pages/CreateDive.jsx
@@ -1060,7 +1060,7 @@ const CreateDive = () => {
                         >
                           {buddy.avatar_url ? (
                             <img
-                              src={buddy.avatar_url}
+                              src={buddy.avatar_full_url || buddy.avatar_url}
                               alt={buddy.username}
                               className='w-6 h-6 rounded-full object-cover'
                             />

--- a/frontend/src/pages/DiveDetail.jsx
+++ b/frontend/src/pages/DiveDetail.jsx
@@ -784,7 +784,7 @@ const DiveDetail = () => {
                           >
                             {buddy.avatar_url ? (
                               <img
-                                src={buddy.avatar_url}
+                                src={buddy.avatar_full_url || buddy.avatar_url}
                                 alt={buddy.username}
                                 className='w-8 h-8 rounded-full object-cover'
                               />

--- a/frontend/src/pages/Dives.jsx
+++ b/frontend/src/pages/Dives.jsx
@@ -1121,7 +1121,7 @@ const Dives = () => {
                               >
                                 {buddy.avatar_url ? (
                                   <img
-                                    src={buddy.avatar_url}
+                                    src={buddy.avatar_full_url || buddy.avatar_url}
                                     className='w-full h-full object-cover'
                                     alt=''
                                   />

--- a/frontend/src/pages/EditDive.jsx
+++ b/frontend/src/pages/EditDive.jsx
@@ -1434,7 +1434,7 @@ const EditDive = () => {
                         >
                           {buddy.avatar_url ? (
                             <img
-                              src={buddy.avatar_url}
+                              src={buddy.avatar_full_url || buddy.avatar_url}
                               alt={buddy.username}
                               className='w-6 h-6 rounded-full object-cover'
                             />


### PR DESCRIPTION
The API previously returned raw avatar strings for dive buddies, which caused broken images in the UI for users with R2-hosted avatars. The backend now resolves these to pre-signed `avatar_full_url` fields using the `_get_cached_avatar_url` helper across all dive endpoints.

Additionally, this commit resolves a `NoneType` AttributeError in `get_dive` when accessing `selected_route.creator.username` for system-generated or orphaned routes.

Changes:
- Add global import for `_get_cached_avatar_url` in `dives_crud.py`.
- Append `avatar_full_url` to buddy responses in all dive endpoints.
- Add null-safety check for `selected_route.creator` in `get_dive` and `update_dive`.
- Update React UI components to prefer `avatar_full_url` for buddy images.