### PR TITLE
Feat: implement OAuth discovery and protected resource metadata

### DIFF
--- a/frontend/public/.well-known/oauth-authorization-server
+++ b/frontend/public/.well-known/oauth-authorization-server
@@ -1,0 +1,8 @@
+{
+  "issuer": "https://divemap.gr",
+  "token_endpoint": "https://divemap.gr/api/v1/auth/login",
+  "response_types_supported": ["token"],
+  "grant_types_supported": ["password", "refresh_token"],
+  "token_endpoint_auth_methods_supported": ["client_secret_post"],
+  "service_documentation": "https://divemap.gr/docs"
+}

--- a/frontend/public/.well-known/oauth-protected-resource
+++ b/frontend/public/.well-known/oauth-protected-resource
@@ -1,0 +1,4 @@
+{
+  "resource": "https://divemap.gr/api/v1/",
+  "authorization_servers": ["https://divemap.gr"]
+}

--- a/nginx/dev.conf
+++ b/nginx/dev.conf
@@ -265,6 +265,24 @@ http {
             add_header Link '</openapi.json>; rel="api-catalog", </docs>; rel="service-doc", </llms.txt>; rel="service-desc"' always;
         }
 
+        # OAuth 2.0 Authorization Server Discovery Metadata (RFC 8414)
+        location = /.well-known/oauth-authorization-server {
+            proxy_pass http://frontend;
+            proxy_set_header Host $host;
+            proxy_hide_header Content-Type;
+            add_header Content-Type "application/json" always;
+            add_header Link '</openapi.json>; rel="api-catalog", </docs>; rel="service-doc", </llms.txt>; rel="service-desc"' always;
+        }
+
+        # OAuth Protected Resource Metadata (RFC 9728)
+        location = /.well-known/oauth-protected-resource {
+            proxy_pass http://frontend;
+            proxy_set_header Host $host;
+            proxy_hide_header Content-Type;
+            add_header Content-Type "application/json" always;
+            add_header Link '</openapi.json>; rel="api-catalog", </docs>; rel="service-doc", </llms.txt>; rel="service-desc"' always;
+        }
+
         # Allow access to .well-known (for Let's Encrypt, Apple/Android App Links, etc.)
         location ^~ /.well-known/ {
             proxy_pass http://frontend;

--- a/nginx/prod.conf
+++ b/nginx/prod.conf
@@ -514,6 +514,22 @@ http {
             allow all;
         }
 
+        # OAuth 2.0 Authorization Server Discovery Metadata (RFC 8414)
+        location = /.well-known/oauth-authorization-server {
+            root /usr/share/nginx/html;
+            add_header Content-Type "application/json" always;
+            add_header Link '</openapi.json>; rel="api-catalog", </docs>; rel="service-doc", </llms.txt>; rel="service-desc"' always;
+            allow all;
+        }
+
+        # OAuth Protected Resource Metadata (RFC 9728)
+        location = /.well-known/oauth-protected-resource {
+            root /usr/share/nginx/html;
+            add_header Content-Type "application/json" always;
+            add_header Link '</openapi.json>; rel="api-catalog", </docs>; rel="service-doc", </llms.txt>; rel="service-desc"' always;
+            allow all;
+        }
+
         # Allow access to .well-known (for Let's Encrypt, Apple/Android App Links, etc.)
         location ^~ /.well-known/ {
             root /usr/share/nginx/html;


### PR DESCRIPTION
Implement the 'oauth-discovery' and 'oauth-protected-resource' agent skills to enable AI agents to automatically discover authentication mechanisms.

- Add a static `oauth-authorization-server` JSON file to the frontend's `.well-known` directory in compliance with RFC 8414, declaring the API's token endpoint and supported grant types.
- Add a static `oauth-protected-resource` JSON file in compliance with RFC 9728, linking the resource URL to the authorization server.
- Configure Nginx to serve both metadata files with the correct `application/json` Content-Type and `Link` headers.
- Extend the `verify_markdown_negotiation.sh` script to test the new OAuth metadata endpoints and validate their JSON payloads.