### PR TITLE
Fix hardware back button navigation in WebView

### DIFF
--- a/REPO_MAP.md
+++ b/REPO_MAP.md
@@ -88,7 +88,7 @@ React application built with Vite, Tailwind CSS, and OpenLayers.
     - **Tables (`tables/`):** `LeaderboardTable.jsx`, and modular `Admin...Table.jsx` components.
     - **Calculators (`calculators/`):** Scuba physics tools (`BestMix`, `GasPlanning`, `MinGas`, `Mod`, `SacRate`, `Weight`).
     - **UI Primitives (`ui/`):** `Button.jsx`, `Modal.jsx`, `Select.jsx`, `Tabs.jsx`, `Combobox.jsx`, `ShellRating.jsx`, `Pagination.jsx`.
-    - **System/Infrastructure:** `SessionManager.jsx`, `PWAUpdater.jsx`, `SEO.jsx`, `Turnstile.jsx`, `NotificationBell.jsx`.
+    - **System/Infrastructure:** `SessionManager.jsx`, `PWAUpdater.jsx`, `SEO.jsx`, `Turnstile.jsx`, `NotificationBell.jsx`, `CapacitorBackButtonHandler.jsx`.
 - `hooks/`: Custom React hooks (Settings, Viewport Data, Responsive Layout).
 - `services/`: Frontend-specific service logic (Notification permissions, PWA lifecycle).
 - `utils/`: Helpers and validation:

--- a/divemap-webview-android/.gitignore
+++ b/divemap-webview-android/.gitignore
@@ -1,0 +1,5 @@
+# Ignore release artifacts
+*.apk
+*.aab
+releases/
+release-notes/

--- a/frontend/android/.gitignore
+++ b/frontend/android/.gitignore
@@ -21,6 +21,7 @@ out/
 
 # Gradle files
 .gradle/
+.kotlin/
 build/
 
 # Local configuration file (sdk path, etc)

--- a/frontend/android/app/build.gradle
+++ b/frontend/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "gr.divemap.twa"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 18
-        versionName "1.7.6"
+        versionCode 21
+        versionName "1.7.9"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/frontend/android/app/src/main/java/gr/divemap/twa/MainActivity.java
+++ b/frontend/android/app/src/main/java/gr/divemap/twa/MainActivity.java
@@ -33,13 +33,4 @@ public class MainActivity extends BridgeActivity {
             webSettings.setUserAgentString(chromeUserAgent);
         }
     }
-
-    @Override
-    public void onBackPressed() {
-        if (this.bridge != null && this.bridge.getWebView() != null && this.bridge.getWebView().canGoBack()) {
-            this.bridge.getWebView().goBack();
-        } else {
-            super.onBackPressed();
-        }
-    }
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,6 +5,7 @@ import { Toaster, ToastBar, toast } from 'react-hot-toast';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { BrowserRouter as Router, Routes, Route, Navigate, useLocation } from 'react-router-dom';
 
+import CapacitorBackButtonHandler from './components/CapacitorBackButtonHandler';
 import ChatWidget from './components/Chat/ChatWidget';
 import EmailVerificationBanner from './components/EmailVerificationBanner';
 import Navbar from './components/Navbar';
@@ -181,6 +182,7 @@ function AppContent() {
 
   return (
     <div className='min-h-screen bg-gray-50'>
+      <CapacitorBackButtonHandler />
       <PWAUpdater />
       <Navbar />
       <SessionManager />

--- a/frontend/src/components/CapacitorBackButtonHandler.jsx
+++ b/frontend/src/components/CapacitorBackButtonHandler.jsx
@@ -1,15 +1,15 @@
 import { App } from '@capacitor/app';
 import { Capacitor } from '@capacitor/core';
 import { useEffect, useRef } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
 import { toast } from 'react-hot-toast';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 /**
  * CapacitorBackButtonHandler Component
- * 
- * Specifically designed for Capacitor/WebView environments to handle the 
+ *
+ * Specifically designed for Capacitor/WebView environments to handle the
  * physical hardware back button on Android.
- * 
+ *
  * This version is more robust:
  * 1. It registers the listener only ONCE to avoid race conditions.
  * 2. It uses window.history.back() for maximum compatibility with WebViews.
@@ -20,7 +20,7 @@ const CapacitorBackButtonHandler = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const lastTimeRef = useRef(0);
-  
+
   // Store refs to avoid re-registering the listener when state changes
   const locationRef = useRef(location);
   const navigateRef = useRef(navigate);
@@ -35,16 +35,18 @@ const CapacitorBackButtonHandler = () => {
 
     console.log('[BackButton] Initializing robust listener');
 
-    const handleBackButton = async (data) => {
+    const handleBackButton = async data => {
       const pathname = locationRef.current.pathname;
       const historyState = window.history.state;
-      
+
       // React Router v6/v7 adds an 'idx' to history.state to track position.
       // idx === 0 usually means we are at the entry point of the app.
       const isAtStart = !historyState || historyState.idx === 0;
       const isHome = pathname === '/' || pathname === '/index.html' || pathname === '';
 
-      console.log(`[BackButton] Event: path=${pathname}, idx=${historyState?.idx}, canGoBack=${data.canGoBack}`);
+      console.log(
+        `[BackButton] Event: path=${pathname}, idx=${historyState?.idx}, canGoBack=${data.canGoBack}`
+      );
 
       if (isHome || isAtStart) {
         // App exit logic for Home or start of history
@@ -65,7 +67,7 @@ const CapacitorBackButtonHandler = () => {
         console.log('[BackButton] Attempting history.back()');
         window.history.back();
 
-        // Fallback: If we are still on the same page after a short delay, 
+        // Fallback: If we are still on the same page after a short delay,
         // it means history.back() failed or the WebView history is out of sync.
         setTimeout(() => {
           if (locationRef.current.pathname === pathname) {

--- a/frontend/src/components/CapacitorBackButtonHandler.jsx
+++ b/frontend/src/components/CapacitorBackButtonHandler.jsx
@@ -1,0 +1,90 @@
+import { App } from '@capacitor/app';
+import { Capacitor } from '@capacitor/core';
+import { useEffect, useRef } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { toast } from 'react-hot-toast';
+
+/**
+ * CapacitorBackButtonHandler Component
+ * 
+ * Specifically designed for Capacitor/WebView environments to handle the 
+ * physical hardware back button on Android.
+ * 
+ * This version is more robust:
+ * 1. It registers the listener only ONCE to avoid race conditions.
+ * 2. It uses window.history.back() for maximum compatibility with WebViews.
+ * 3. It includes a fallback mechanism if navigation seems stuck.
+ * 4. It uses React Router's internal history state (idx) for better accuracy.
+ */
+const CapacitorBackButtonHandler = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const lastTimeRef = useRef(0);
+  
+  // Store refs to avoid re-registering the listener when state changes
+  const locationRef = useRef(location);
+  const navigateRef = useRef(navigate);
+
+  useEffect(() => {
+    locationRef.current = location;
+    navigateRef.current = navigate;
+  }, [location, navigate]);
+
+  useEffect(() => {
+    if (!Capacitor.isNativePlatform()) return;
+
+    console.log('[BackButton] Initializing robust listener');
+
+    const handleBackButton = async (data) => {
+      const pathname = locationRef.current.pathname;
+      const historyState = window.history.state;
+      
+      // React Router v6/v7 adds an 'idx' to history.state to track position.
+      // idx === 0 usually means we are at the entry point of the app.
+      const isAtStart = !historyState || historyState.idx === 0;
+      const isHome = pathname === '/' || pathname === '/index.html' || pathname === '';
+
+      console.log(`[BackButton] Event: path=${pathname}, idx=${historyState?.idx}, canGoBack=${data.canGoBack}`);
+
+      if (isHome || isAtStart) {
+        // App exit logic for Home or start of history
+        const currentTime = Date.now();
+        if (currentTime - lastTimeRef.current < 2000) {
+          console.log('[BackButton] Calling exitApp');
+          App.exitApp();
+        } else {
+          lastTimeRef.current = currentTime;
+          toast('Press back again to exit', {
+            duration: 2000,
+            position: 'bottom-center',
+            icon: '👋',
+          });
+        }
+      } else {
+        // Subpage navigation
+        console.log('[BackButton] Attempting history.back()');
+        window.history.back();
+
+        // Fallback: If we are still on the same page after a short delay, 
+        // it means history.back() failed or the WebView history is out of sync.
+        setTimeout(() => {
+          if (locationRef.current.pathname === pathname) {
+            console.log('[BackButton] Fallback: history.back() failed, forcing navigation to Home');
+            navigateRef.current('/', { replace: false });
+          }
+        }, 250);
+      }
+    };
+
+    const listenerPromise = App.addListener('backButton', handleBackButton);
+
+    return () => {
+      console.log('[BackButton] Cleaning up listener');
+      listenerPromise.then(l => l.remove());
+    };
+  }, []); // Singleton listener
+
+  return null;
+};
+
+export default CapacitorBackButtonHandler;

--- a/frontend/src/components/CapacitorBackButtonHandler.test.jsx
+++ b/frontend/src/components/CapacitorBackButtonHandler.test.jsx
@@ -1,9 +1,10 @@
-import { render } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { BrowserRouter } from 'react-router-dom';
-import CapacitorBackButtonHandler from './CapacitorBackButtonHandler';
 import { App } from '@capacitor/app';
 import { Capacitor } from '@capacitor/core';
+import { render } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import CapacitorBackButtonHandler from './CapacitorBackButtonHandler';
 
 // Mock Capacitor
 vi.mock('@capacitor/core', () => ({
@@ -31,7 +32,7 @@ describe('CapacitorBackButtonHandler', () => {
 
   it('does not add listener if not on native platform', () => {
     vi.mocked(Capacitor.isNativePlatform).mockReturnValue(false);
-    
+
     render(
       <BrowserRouter>
         <CapacitorBackButtonHandler />

--- a/frontend/src/components/CapacitorBackButtonHandler.test.jsx
+++ b/frontend/src/components/CapacitorBackButtonHandler.test.jsx
@@ -1,0 +1,56 @@
+import { render } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { BrowserRouter } from 'react-router-dom';
+import CapacitorBackButtonHandler from './CapacitorBackButtonHandler';
+import { App } from '@capacitor/app';
+import { Capacitor } from '@capacitor/core';
+
+// Mock Capacitor
+vi.mock('@capacitor/core', () => ({
+  Capacitor: {
+    isNativePlatform: vi.fn(),
+  },
+}));
+
+vi.mock('@capacitor/app', () => ({
+  App: {
+    addListener: vi.fn(),
+    exitApp: vi.fn(),
+  },
+}));
+
+// Mock react-hot-toast
+vi.mock('react-hot-toast', () => ({
+  toast: vi.fn(),
+}));
+
+describe('CapacitorBackButtonHandler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not add listener if not on native platform', () => {
+    vi.mocked(Capacitor.isNativePlatform).mockReturnValue(false);
+    
+    render(
+      <BrowserRouter>
+        <CapacitorBackButtonHandler />
+      </BrowserRouter>
+    );
+
+    expect(App.addListener).not.toHaveBeenCalled();
+  });
+
+  it('adds listener if on native platform', () => {
+    vi.mocked(Capacitor.isNativePlatform).mockReturnValue(true);
+    vi.mocked(App.addListener).mockReturnValue(Promise.resolve({ remove: vi.fn() }));
+
+    render(
+      <BrowserRouter>
+        <CapacitorBackButtonHandler />
+      </BrowserRouter>
+    );
+
+    expect(App.addListener).toHaveBeenCalledWith('backButton', expect.any(Function));
+  });
+});


### PR DESCRIPTION
Remove the native Android onBackPressed override that was intercepting
events before they reached the Capacitor listener.

Implement a robust CapacitorBackButtonHandler component that:
- Uses React Router's internal history state (idx) for accuracy.
- Leverages window.history.back() for primitive navigation.
- Includes a resilient fallback to Home if history is stuck.
- Implements a double-tap to exit pattern on the Home page.

This resolves issues where subpage navigation was "stuck" and users
could not exit the application from the root page.

Bump Android version to 1.7.9 (Code 21).