### PR TITLE
Refactor buttons to use consistent brand colors

### DIFF
--- a/frontend/src/components/Chat/ChatWidget.jsx
+++ b/frontend/src/components/Chat/ChatWidget.jsx
@@ -267,7 +267,7 @@ const ChatWidget = () => {
           className={`
             pointer-events-auto
             flex items-center justify-center w-14 h-14 rounded-full shadow-lg transition-all duration-300 ease-in-out hover:scale-110 active:scale-95
-            ${isOpen ? 'bg-gray-200 text-gray-600 rotate-90' : 'bg-blue-600 text-white'}
+            ${isOpen ? 'bg-gray-200 text-gray-600 rotate-90' : 'bg-divemap-blue text-white'}
             ${isDragging ? 'cursor-grabbing scale-110 shadow-2xl' : 'cursor-grab'}
             ${getTranslation()}
           `}

--- a/frontend/src/components/Chat/ChatWindow.jsx
+++ b/frontend/src/components/Chat/ChatWindow.jsx
@@ -115,7 +115,7 @@ const ChatWindow = ({
     >
       {/* Header */}
       <div
-        className={`flex items-center px-3 py-2 sm:px-4 sm:py-3 bg-blue-600 text-white shrink-0 ${isEmbedded ? 'justify-center relative' : 'justify-between'}`}
+        className={`flex items-center px-3 py-2 sm:px-4 sm:py-3 bg-divemap-blue text-white shrink-0 ${isEmbedded ? 'justify-center relative' : 'justify-between'}`}
       >
         <div className='flex items-center gap-1.5 min-w-0'>
           <ChatbotIcon size={18} className='text-blue-100 shrink-0' />
@@ -131,7 +131,7 @@ const ChatWindow = ({
                 if (onClose) onClose(); // Close the floating widget if it's open
                 navigate('/ai-chat-history');
               }}
-              className='p-1.5 hover:bg-blue-700 rounded-full transition-colors'
+              className='p-1.5 hover:bg-white/10 rounded-full transition-colors'
               title='View Chat History'
             >
               <History size={16} />
@@ -141,7 +141,7 @@ const ChatWindow = ({
             <button
               data-testid='chat-clear-button'
               onClick={onClear}
-              className='p-1.5 hover:bg-blue-700 rounded-full transition-colors'
+              className='p-1.5 hover:bg-white/10 rounded-full transition-colors'
               title='Clear Chat'
             >
               <Trash2 size={16} />
@@ -152,7 +152,7 @@ const ChatWindow = ({
             <button
               data-testid='chat-expand-button'
               onClick={onToggleExpand}
-              className='p-1.5 hover:bg-blue-700 rounded-full transition-colors hidden md:block'
+              className='p-1.5 hover:bg-white/10 rounded-full transition-colors hidden md:block'
               title={isExpanded ? 'Collapse' : 'Expand'}
             >
               {isExpanded ? <Minimize2 size={16} /> : <Maximize2 size={16} />}
@@ -162,7 +162,7 @@ const ChatWindow = ({
             <button
               data-testid='chat-close-button'
               onClick={onClose}
-              className='p-1.5 hover:bg-blue-700 rounded-full transition-colors'
+              className='p-1.5 hover:bg-white/10 rounded-full transition-colors'
               title='Close'
             >
               <X size={18} />
@@ -179,14 +179,14 @@ const ChatWindow = ({
         {!isAuthenticated ? (
           <div className='py-8 sm:py-12 flex flex-col items-center justify-center text-gray-500 text-center px-6 space-y-4'>
             <div className='w-16 h-16 bg-blue-100 dark:bg-blue-900/30 rounded-full flex items-center justify-center mb-2'>
-              <Lock size={32} className='text-blue-600' />
+              <Lock size={32} className='text-divemap-blue' />
             </div>
             <h4 className='font-bold text-gray-900 dark:text-white'>Authentication Required</h4>
             <p className='text-sm max-w-xs'>
               Please{' '}
               <Link
                 to='/login'
-                className='text-blue-600 hover:underline'
+                className='text-divemap-blue hover:underline'
                 onClick={() => onClose?.()}
               >
                 log in
@@ -194,7 +194,7 @@ const ChatWindow = ({
               or{' '}
               <Link
                 to='/register'
-                className='text-blue-600 hover:underline'
+                className='text-divemap-blue hover:underline'
                 onClick={() => onClose?.()}
               >
                 register
@@ -258,7 +258,7 @@ const ChatWindow = ({
               onChange={e => setInput(e.target.value)}
               onKeyDown={handleKeyDown}
               placeholder='Ask anything...'
-              className='flex-1 max-h-32 min-h-[44px] py-2 px-3 sm:py-2.5 sm:px-4 bg-gray-100 dark:bg-gray-800 border-0 rounded-2xl focus:ring-2 focus:ring-blue-500 resize-none text-xs sm:text-sm dark:text-white scrollbar-hide'
+              className='flex-1 max-h-32 min-h-[44px] py-2 px-3 sm:py-2.5 sm:px-4 bg-gray-100 dark:bg-gray-800 border-0 rounded-2xl focus:ring-2 focus:ring-divemap-sky resize-none text-xs sm:text-sm dark:text-white scrollbar-hide'
               rows={1}
               style={{ height: 'auto' }} // Adjust height logic if needed
             />
@@ -266,7 +266,7 @@ const ChatWindow = ({
               data-testid='chat-send-button'
               onClick={handleSend}
               disabled={!input.trim() || isLoading}
-              className='p-2 sm:p-2.5 bg-blue-600 text-white rounded-full hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors shadow-sm mb-0.5 shrink-0 flex items-center justify-center min-w-[36px] min-h-[36px] sm:min-w-[44px] sm:min-h-[44px]'
+              className='p-2 sm:p-2.5 bg-divemap-blue text-white rounded-full hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors shadow-sm mb-0.5 shrink-0 flex items-center justify-center min-w-[36px] min-h-[36px] sm:min-w-[44px] sm:min-h-[44px]'
             >
               <Send className='w-4 h-4 sm:w-[18px] sm:h-[18px]' />
             </button>

--- a/frontend/src/components/DiveSiteRoutes.jsx
+++ b/frontend/src/components/DiveSiteRoutes.jsx
@@ -74,7 +74,7 @@ const DiveSiteRoutes = ({ diveSiteId, isMobileCollapsed = false }) => {
         </h2>
         <button
           onClick={handleDrawNewRoute}
-          className='flex items-center gap-1 sm:gap-2 px-3 py-1.5 sm:px-4 sm:py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors text-xs sm:text-sm font-medium shadow-sm shrink-0'
+          className='flex items-center gap-1 sm:gap-2 px-3 py-1.5 sm:px-4 sm:py-2 text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 hover:text-gray-900 transition-colors text-xs sm:text-sm font-medium shadow-sm shrink-0'
         >
           <Plus className='w-3.5 h-3.5 sm:w-4 sm:h-4' />
           Draw Route

--- a/frontend/src/components/DivingCenterForm.jsx
+++ b/frontend/src/components/DivingCenterForm.jsx
@@ -415,15 +415,7 @@ const DivingCenterForm = ({
             type='button'
             onClick={suggestFromCoordinates}
             disabled={!watchedValues.latitude || !watchedValues.longitude}
-            className='px-4 py-2 text-white rounded-md disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2 transition-colors'
-            style={{ backgroundColor: UI_COLORS.success }}
-            onMouseEnter={e =>
-              !e.currentTarget.disabled && (e.currentTarget.style.backgroundColor = '#007a5c')
-            }
-            onMouseLeave={e =>
-              !e.currentTarget.disabled &&
-              (e.currentTarget.style.backgroundColor = UI_COLORS.success)
-            }
+            className='flex items-center px-4 py-2 text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 hover:text-gray-900 transition-colors disabled:opacity-50 disabled:cursor-not-allowed gap-2'
           >
             <svg className='w-4 h-4' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
               <path

--- a/frontend/src/components/EmptyState.jsx
+++ b/frontend/src/components/EmptyState.jsx
@@ -29,7 +29,7 @@ const EmptyState = ({
         {onClearFilters && (
           <button
             onClick={onClearFilters}
-            className='inline-flex items-center gap-2 px-6 py-2 bg-blue-600 text-white font-bold rounded-lg hover:bg-blue-700 transition-colors shadow-lg hover:shadow-blue-500/25'
+            className='inline-flex items-center gap-2 px-6 py-2 bg-divemap-blue text-white font-bold rounded-lg hover:opacity-90 transition-colors shadow-lg hover:shadow-divemap-blue/25'
           >
             <FilterX className='w-4 h-4' />
             Clear All Filters

--- a/frontend/src/components/ImportDivesModal.jsx
+++ b/frontend/src/components/ImportDivesModal.jsx
@@ -29,6 +29,7 @@ import { TANK_SIZES } from '../utils/diveConstants';
 
 import FuzzySearchInput from './FuzzySearchInput';
 import GasTanksDisplay from './GasTanksDisplay';
+import Button from './ui/Button';
 import Modal from './ui/Modal';
 
 const ImportDivesModal = ({ isOpen, onClose, onSuccess }) => {
@@ -597,19 +598,12 @@ const ImportDivesModal = ({ isOpen, onClose, onSuccess }) => {
         </div>
 
         <div className='flex justify-between items-center pt-4'>
-          <button
-            onClick={() => setCurrentStep('upload')}
-            className='px-4 py-2 text-sm text-gray-600 hover:text-gray-900 font-medium'
-          >
+          <Button variant='ghost' onClick={() => setCurrentStep('upload')}>
             Back
-          </button>
-          <button
-            onClick={handleProcessCSV}
-            disabled={isProcessing}
-            className='px-6 py-2 bg-blue-600 text-white rounded-lg text-sm font-semibold hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed shadow-sm transition-all'
-          >
+          </Button>
+          <Button variant='primary' onClick={handleProcessCSV} isLoading={isProcessing}>
             {isProcessing ? 'Processing...' : `Process ${csvTotalRows} Dives`}
-          </button>
+          </Button>
         </div>
       </div>
     );
@@ -641,12 +635,9 @@ const ImportDivesModal = ({ isOpen, onClose, onSuccess }) => {
                 <p className='text-sm text-gray-600'>
                   Drag and drop XML, CSV, FIT or JSON files here, or click to browse
                 </p>
-                <button
-                  onClick={() => fileInputRef.current?.click()}
-                  className='bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition-colors'
-                >
+                <Button variant='secondary' onClick={() => fileInputRef.current?.click()}>
                   Select Files
-                </button>
+                </Button>
               </div>
               <input
                 ref={fileInputRef}
@@ -675,29 +666,18 @@ const ImportDivesModal = ({ isOpen, onClose, onSuccess }) => {
             )}
 
             <div className='flex justify-end gap-3'>
-              <button
-                onClick={handleClose}
-                className='px-4 py-2 text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200 transition-colors'
-              >
+              <Button variant='secondary' onClick={handleClose}>
                 Cancel
-              </button>
-              <button
+              </Button>
+              <Button
+                variant='primary'
                 onClick={handleUpload}
-                disabled={selectedFiles.length === 0 || isProcessing}
-                className='px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center gap-2'
+                disabled={selectedFiles.length === 0}
+                isLoading={isProcessing}
+                icon={<Upload size={16} />}
               >
-                {isProcessing ? (
-                  <>
-                    <div className='animate-spin rounded-full h-4 w-4 border-b-2 border-white'></div>
-                    Processing...
-                  </>
-                ) : (
-                  <>
-                    <Upload size={16} />
-                    Process Files
-                  </>
-                )}
-              </button>
+                {isProcessing ? 'Processing...' : 'Process Files'}
+              </Button>
             </div>
           </div>
         )}
@@ -1048,25 +1028,19 @@ const ImportDivesModal = ({ isOpen, onClose, onSuccess }) => {
             </div>
 
             <div className='flex justify-end gap-3 pt-4 border-t border-gray-200'>
-              <button
-                onClick={() => setCurrentStep('upload')}
-                className='px-4 py-2 text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200 transition-colors'
-              >
+              <Button variant='secondary' onClick={() => setCurrentStep('upload')}>
                 Back
-              </button>
-              <button
+              </Button>
+              <Button
+                variant='primary'
                 onClick={handleConfirmImport}
-                disabled={isProcessing}
-                className='px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center gap-2'
+                isLoading={isProcessing}
+                icon={<Check size={16} />}
               >
                 {isProcessing ? (
-                  <>
-                    <div className='animate-spin rounded-full h-4 w-4 border-b-2 border-white'></div>
-                    Importing...
-                  </>
+                  'Importing...'
                 ) : (
                   <>
-                    <Check size={16} />
                     Import{' '}
                     {
                       parsedDives.filter(
@@ -1079,7 +1053,7 @@ const ImportDivesModal = ({ isOpen, onClose, onSuccess }) => {
                     Dives
                   </>
                 )}
-              </button>
+              </Button>
             </div>
           </div>
         )}

--- a/frontend/src/components/TripCard.jsx
+++ b/frontend/src/components/TripCard.jsx
@@ -63,7 +63,7 @@ const TripCard = ({
         <Link
           to={`/dive-sites/${diveSiteId}/${slug}`}
           state={{ from: window.location.pathname + window.location.search }}
-          className='text-xs sm:text-sm font-medium text-blue-600 hover:text-blue-700 hover:underline transition-colors truncate !min-h-0'
+          className='text-xs sm:text-sm font-medium text-divemap-blue hover:text-blue-700 hover:underline transition-colors truncate !min-h-0'
         >
           {diveSiteName}
         </Link>
@@ -181,7 +181,7 @@ const TripCard = ({
                   {user ? (
                     <Link
                       to={tripUrl}
-                      className='text-blue-600 hover:text-blue-800 transition-colors'
+                      className='text-divemap-blue hover:text-blue-800 transition-colors'
                     >
                       {tripName}
                     </Link>
@@ -206,7 +206,7 @@ const TripCard = ({
                   <div className='flex items-center space-x-1 mr-2'>
                     <button
                       onClick={() => onEdit?.(trip)}
-                      className='min-h-[44px] min-w-[44px] flex items-center justify-center text-blue-600 hover:bg-blue-50 rounded-md transition-colors'
+                      className='min-h-[44px] min-w-[44px] flex items-center justify-center text-divemap-blue hover:bg-blue-50 rounded-md transition-colors'
                       title='Edit Trip'
                     >
                       <Edit className='h-5 w-5' />
@@ -236,7 +236,7 @@ const TripCard = ({
                   country: trip.diving_center_country,
                   region: trip.diving_center_region,
                 })}`}
-                className='text-xs sm:text-sm font-medium text-blue-600 hover:text-blue-800 hover:underline transition-colors truncate'
+                className='text-xs sm:text-sm font-medium text-divemap-blue hover:text-blue-800 hover:underline transition-colors truncate'
               >
                 {trip.diving_center_name}
               </Link>
@@ -279,7 +279,7 @@ const TripCard = ({
           className={`grid grid-cols-2 ${isGrid ? 'gap-2' : 'sm:grid-cols-2 lg:grid-cols-6 gap-2 sm:gap-3 lg:gap-2'} mb-4 lg:mb-3`}
         >
           <div className='flex items-center text-gray-600 p-1.5 sm:p-2 lg:p-1.5 bg-gray-50/50 rounded-lg border border-gray-100'>
-            <Calendar className='h-3.5 w-3.5 mr-2 text-blue-600 flex-shrink-0' />
+            <Calendar className='h-3.5 w-3.5 mr-2 text-divemap-blue flex-shrink-0' />
             <div className='min-w-0'>
               <div className='text-xs text-gray-500 uppercase tracking-wide leading-tight'>
                 Date
@@ -487,7 +487,7 @@ const TripCard = ({
         {isGrid && (
           <Link
             to={tripUrl}
-            className='mt-auto w-full text-center bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2 rounded-lg transition-colors text-sm'
+            className='mt-auto w-full text-center bg-divemap-blue hover:opacity-90 text-white font-semibold py-2 rounded-lg transition-colors text-sm'
           >
             View Trip
           </Link>

--- a/frontend/src/components/TripFormModal.jsx
+++ b/frontend/src/components/TripFormModal.jsx
@@ -7,6 +7,7 @@ import { getDifficultyOptions } from '../utils/difficultyHelpers';
 import { tripSchemas, createResolver, getErrorMessage } from '../utils/formHelpers';
 
 import DivingCenterSearchableDropdown from './DivingCenterSearchableDropdown';
+import Button from './ui/Button';
 import { DiveSiteSearchDropdown } from './ui/DiveSiteSearchDropdown';
 import MarkdownEditor from './ui/MarkdownEditor';
 import Modal from './ui/Modal';
@@ -371,14 +372,15 @@ const TripFormModal = ({
       <div className='border-t pt-4'>
         <div className='flex justify-between items-center mb-4'>
           <h4 className='text-lg font-medium text-gray-900'>Dives</h4>
-          <button
+          <Button
             type='button'
             onClick={addDive}
-            className='flex items-center px-3 py-1 bg-blue-600 text-white rounded-md hover:bg-blue-700 text-sm'
+            variant='secondary'
+            size='sm'
+            icon={<Plus className='h-4 w-4' />}
           >
-            <Plus className='h-4 w-4 mr-1' />
             Add Dive
-          </button>
+          </Button>
         </div>
 
         {fields.length === 0 && (
@@ -515,7 +517,7 @@ const TripFormModal = ({
           type='checkbox'
           id='broadcast'
           {...register('broadcast_to_followers')}
-          className='w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500'
+          className='w-4 h-4 text-divemap-blue border-gray-300 rounded focus:ring-divemap-sky'
         />
         <label htmlFor='broadcast' className='text-sm font-medium text-gray-700'>
           {trip ? 'Broadcast update to followers' : 'Broadcast this trip to followers'}
@@ -524,20 +526,13 @@ const TripFormModal = ({
 
       <div className='flex justify-end space-x-3 pt-4 border-t'>
         {onCancel && (
-          <button
-            type='button'
-            onClick={onCancel}
-            className='px-4 py-2 text-gray-600 border rounded-md hover:bg-gray-50'
-          >
+          <Button type='button' onClick={onCancel} variant='secondary'>
             Cancel
-          </button>
+          </Button>
         )}
-        <button
-          type='submit'
-          className='px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700'
-        >
+        <Button type='submit' variant='primary'>
           Save Trip
-        </button>
+        </Button>
       </div>
     </form>
   );

--- a/frontend/src/components/UserChat/ChatRoom.jsx
+++ b/frontend/src/components/UserChat/ChatRoom.jsx
@@ -230,13 +230,13 @@ const ChatRoom = ({ roomId, room, currentUserId, onToggleSettings, onBack }) => 
 
         <div className='flex items-center gap-2'>
           {showHints && (
-            <div className='hidden lg:flex items-center gap-2 px-3 py-1.5 bg-blue-50 dark:bg-blue-900/20 border border-blue-100 dark:border-blue-800 rounded-full animate-in fade-in slide-in-from-right-4 duration-300'>
-              <HelpCircle size={14} className='text-blue-500 shrink-0' />
-              <div className='text-[10px] text-blue-800 dark:text-blue-200 flex items-center gap-2'>
+            <div className='hidden lg:flex items-center gap-2 px-3 py-1.5 bg-divemap-surface dark:bg-blue-900/20 border border-divemap-blue/20 dark:border-blue-800 rounded-full animate-in fade-in slide-in-from-right-4 duration-300'>
+              <HelpCircle size={14} className='text-divemap-blue shrink-0' />
+              <div className='text-[10px] text-divemap-deep dark:text-blue-200 flex items-center gap-2'>
                 <span className='whitespace-nowrap'>{activeTip}</span>
                 <button
                   onClick={dismissHints}
-                  className='text-blue-400 hover:text-blue-600 transition-colors ml-1'
+                  className='text-divemap-sky hover:text-divemap-blue transition-colors ml-1'
                   title='Dismiss tips'
                 >
                   <X size={12} />
@@ -379,7 +379,7 @@ const ChatRoom = ({ roomId, room, currentUserId, onToggleSettings, onBack }) => 
                 <Smile size={24} />
               </button>
 
-              <div className='flex-1 bg-white dark:bg-gray-700 rounded-2xl shadow-sm border border-gray-200 dark:border-gray-600 focus-within:ring-2 focus-within:ring-blue-500 transition-shadow'>
+              <div className='flex-1 bg-white dark:bg-gray-700 rounded-2xl shadow-sm border border-gray-200 dark:border-gray-600 focus-within:ring-2 focus-within:ring-divemap-sky transition-shadow'>
                 <TextareaAutosize
                   minRows={1}
                   maxRows={5}
@@ -399,7 +399,7 @@ const ChatRoom = ({ roomId, room, currentUserId, onToggleSettings, onBack }) => 
               <button
                 type='submit'
                 disabled={!inputText.trim() || isSending}
-                className='p-3 bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white rounded-full transition-colors flex items-center justify-center w-12 h-12 mb-0.5 shadow-sm'
+                className='p-3 bg-divemap-blue hover:opacity-90 disabled:opacity-50 text-white rounded-full transition-colors flex items-center justify-center w-12 h-12 mb-0.5 shadow-sm'
               >
                 {isSending ? (
                   <Loader2 size={20} className='animate-spin' />

--- a/frontend/src/components/UserChat/MessageBubble.jsx
+++ b/frontend/src/components/UserChat/MessageBubble.jsx
@@ -33,7 +33,7 @@ const MessageBubble = ({
       return (
         <Link
           to={href}
-          className='text-blue-600 dark:text-blue-400 font-semibold hover:underline decoration-blue-500/30 underline-offset-2'
+          className='text-divemap-blue dark:text-blue-400 font-semibold hover:underline decoration-divemap-sky underline-offset-2'
         >
           {children}
         </Link>
@@ -44,7 +44,7 @@ const MessageBubble = ({
         href={href}
         target='_blank'
         rel='noopener noreferrer'
-        className='text-blue-600 dark:text-blue-400 font-semibold hover:underline decoration-blue-500/30 underline-offset-2'
+        className='text-divemap-blue dark:text-blue-400 font-semibold hover:underline decoration-divemap-sky underline-offset-2'
       >
         {children}
       </a>
@@ -63,7 +63,7 @@ const MessageBubble = ({
         return (
           <span
             key={i}
-            className={`font-semibold cursor-pointer hover:underline ${isOwn ? 'text-blue-200 hover:text-white' : 'text-blue-600 dark:text-blue-400'}`}
+            className={`font-semibold cursor-pointer hover:underline ${isOwn ? 'text-blue-200 hover:text-white' : 'text-divemap-blue dark:text-blue-400'}`}
           >
             {part}
           </span>
@@ -98,8 +98,8 @@ const MessageBubble = ({
         <div className='mr-2 mt-auto flex-shrink-0 w-8 h-8'>
           {showAvatar &&
             (isBot ? (
-              <div className='w-8 h-8 rounded-full bg-blue-50 flex items-center justify-center border border-blue-100'>
-                <ChatbotIcon className='w-5 h-5 text-blue-600' />
+              <div className='w-8 h-8 rounded-full bg-divemap-surface flex items-center justify-center border border-divemap-blue/10'>
+                <ChatbotIcon className='w-5 h-5 text-divemap-blue' />
               </div>
             ) : (
               <Avatar
@@ -124,9 +124,9 @@ const MessageBubble = ({
           <div
             className={`px-3 sm:px-4 py-1.5 sm:py-2 text-sm shadow-sm transition-colors ${
               isOwn
-                ? `bg-blue-600 text-white rounded-2xl ${!showName ? 'rounded-tr-[4px]' : ''} ${isLastInGroup ? 'rounded-br-sm' : 'rounded-br-[4px]'}`
+                ? `bg-divemap-blue text-white rounded-2xl ${!showName ? 'rounded-tr-[4px]' : ''} ${isLastInGroup ? 'rounded-br-sm' : 'rounded-br-[4px]'}`
                 : isBot
-                  ? `bg-blue-50 dark:bg-blue-900/20 text-gray-800 dark:text-gray-100 border border-blue-100 dark:border-blue-800 rounded-2xl ${!showName ? 'rounded-tl-[4px]' : ''} ${isLastInGroup ? 'rounded-bl-sm' : 'rounded-bl-[4px]'}`
+                  ? `bg-divemap-surface dark:bg-blue-900/20 text-gray-800 dark:text-gray-100 border border-divemap-blue/10 dark:border-blue-800 rounded-2xl ${!showName ? 'rounded-tl-[4px]' : ''} ${isLastInGroup ? 'rounded-bl-sm' : 'rounded-bl-[4px]'}`
                   : `bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100 border border-gray-100 dark:border-gray-600 rounded-2xl ${!showName ? 'rounded-tl-[4px]' : ''} ${isLastInGroup ? 'rounded-bl-sm' : 'rounded-bl-[4px]'}`
             }`}
           >
@@ -146,8 +146,8 @@ const MessageBubble = ({
 
                 return (
                   <div className='bg-white dark:bg-gray-800 rounded-xl overflow-hidden shadow-md mt-1 mb-2 border border-gray-200 dark:border-gray-700 min-w-[180px] sm:min-w-[280px] max-w-sm'>
-                    <div className='p-1.5 sm:p-3 border-b border-gray-100 dark:border-gray-700 bg-blue-50 dark:bg-blue-900/30 flex justify-between items-center'>
-                      <span className='text-[9px] sm:text-xs font-bold text-blue-600 dark:text-blue-400 uppercase tracking-wide'>
+                    <div className='p-1.5 sm:p-3 border-b border-gray-100 dark:border-gray-700 bg-divemap-surface dark:bg-blue-900/30 flex justify-between items-center'>
+                      <span className='text-[9px] sm:text-xs font-bold text-divemap-blue dark:text-blue-400 uppercase tracking-wide'>
                         {tripData.is_update ? 'Updated Trip Announcement' : 'New Trip Announcement'}
                       </span>
                       {tripData.status === 'confirmed' && (
@@ -260,7 +260,7 @@ const MessageBubble = ({
 
                       <Link
                         to={`/dive-trips/${tripData.trip_id}`}
-                        className='block w-full text-center bg-blue-600 hover:bg-blue-700 text-white font-semibold py-1.5 sm:py-2.5 text-[10px] sm:text-sm rounded-lg transition-colors shadow-sm'
+                        className='block w-full text-center bg-divemap-blue hover:opacity-90 text-white font-semibold py-1.5 sm:py-2.5 text-[10px] sm:text-sm rounded-lg transition-colors shadow-sm'
                       >
                         View Trip Details
                       </Link>

--- a/frontend/src/pages/CheckYourEmail.jsx
+++ b/frontend/src/pages/CheckYourEmail.jsx
@@ -76,7 +76,7 @@ const CheckYourEmail = () => {
           <div className='bg-white py-8 px-6 shadow rounded-lg'>
             <div className='text-center'>
               <div className='mx-auto flex items-center justify-center w-16 h-16 rounded-full bg-blue-100 mb-4'>
-                <Mail className='w-8 h-8 text-blue-600' />
+                <Mail className='w-8 h-8 text-divemap-blue' />
               </div>
 
               <h3 className='text-lg font-medium text-gray-900 mb-2'>Verification Email Sent</h3>
@@ -117,7 +117,7 @@ const CheckYourEmail = () => {
                   <button
                     onClick={handleResendVerification}
                     disabled={resending}
-                    className='w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed'
+                    className='w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-divemap-blue hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-divemap-sky disabled:opacity-50 disabled:cursor-not-allowed'
                   >
                     {resending ? 'Sending...' : 'Resend Verification Email'}
                   </button>
@@ -125,7 +125,7 @@ const CheckYourEmail = () => {
 
                 <Link
                   to='/login'
-                  className='block w-full text-center py-2 px-4 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500'
+                  className='block w-full text-center py-2 px-4 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-divemap-sky'
                 >
                   Go to Login
                 </Link>

--- a/frontend/src/pages/CreateDive.jsx
+++ b/frontend/src/pages/CreateDive.jsx
@@ -924,14 +924,7 @@ const CreateDive = () => {
                                 <button
                                   type='button'
                                   onClick={handleUrlAdd}
-                                  className='px-4 py-2 text-white rounded-md'
-                                  style={{ backgroundColor: UI_COLORS.success, color: 'white' }}
-                                  onMouseEnter={e =>
-                                    (e.currentTarget.style.backgroundColor = '#007a5c')
-                                  }
-                                  onMouseLeave={e =>
-                                    (e.currentTarget.style.backgroundColor = UI_COLORS.success)
-                                  }
+                                  className='flex items-center px-4 py-2 text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 hover:text-gray-900 transition-colors'
                                 >
                                   Add Media
                                 </button>
@@ -1131,7 +1124,7 @@ const CreateDive = () => {
                     <button
                       type='button'
                       onClick={handleAddNewTag}
-                      className='px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 flex items-center gap-2'
+                      className='px-4 py-2 text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 hover:text-gray-900 transition-colors flex items-center gap-2'
                     >
                       <Plus size={16} />
                       Add

--- a/frontend/src/pages/CreateDiveSite.jsx
+++ b/frontend/src/pages/CreateDiveSite.jsx
@@ -681,15 +681,7 @@ const CreateDiveSite = () => {
                   type='button'
                   onClick={suggestLocation}
                   disabled={!formData.latitude || !formData.longitude}
-                  className='px-4 py-2 text-white rounded-md disabled:opacity-50 disabled:cursor-not-allowed'
-                  style={{ backgroundColor: UI_COLORS.success }}
-                  onMouseEnter={e =>
-                    !e.currentTarget.disabled && (e.currentTarget.style.backgroundColor = '#007a5c')
-                  }
-                  onMouseLeave={e =>
-                    !e.currentTarget.disabled &&
-                    (e.currentTarget.style.backgroundColor = UI_COLORS.success)
-                  }
+                  className='flex items-center px-4 py-2 text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 hover:text-gray-900 transition-colors disabled:opacity-50 disabled:cursor-not-allowed gap-2'
                 >
                   🗺️ Suggest Country & Region from Coordinates
                 </button>
@@ -904,14 +896,7 @@ const CreateDiveSite = () => {
                                 <button
                                   type='button'
                                   onClick={handleUrlAdd}
-                                  className='px-4 py-2 text-white rounded-md'
-                                  style={{ backgroundColor: UI_COLORS.success, color: 'white' }}
-                                  onMouseEnter={e =>
-                                    (e.currentTarget.style.backgroundColor = '#007a5c')
-                                  }
-                                  onMouseLeave={e =>
-                                    (e.currentTarget.style.backgroundColor = UI_COLORS.success)
-                                  }
+                                  className='flex items-center px-4 py-2 text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 hover:text-gray-900 transition-colors'
                                 >
                                   Add Media
                                 </button>

--- a/frontend/src/pages/CreateDivingCenter.jsx
+++ b/frontend/src/pages/CreateDivingCenter.jsx
@@ -7,6 +7,7 @@ import { useNavigate } from 'react-router-dom';
 import api from '../api';
 import DivingCenterForm from '../components/DivingCenterForm';
 import SEO from '../components/SEO';
+import Button from '../components/ui/Button';
 import { useAuth } from '../contexts/AuthContext';
 import { extractErrorMessage } from '../utils/apiErrors';
 import { formatCost, DEFAULT_CURRENCY } from '../utils/currency';
@@ -261,14 +262,14 @@ const CreateDivingCenter = () => {
                 </div>
 
                 <div className='flex items-end'>
-                  <button
+                  <Button
                     type='button'
                     onClick={addOrganization}
-                    className='flex items-center px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700'
+                    variant='secondary'
+                    icon={<Plus className='h-4 w-4' />}
                   >
-                    <Plus className='h-4 w-4 mr-2' />
                     Add Organization
-                  </button>
+                  </Button>
                 </div>
               </div>
             </div>

--- a/frontend/src/pages/DiveSiteDetail.jsx
+++ b/frontend/src/pages/DiveSiteDetail.jsx
@@ -1156,7 +1156,7 @@ const DiveSiteDetail = () => {
                       to={`https://www.google.com/maps/dir/?api=1&destination=${diveSite.latitude},${diveSite.longitude}`}
                       target='_blank'
                       rel='noopener noreferrer'
-                      variant='primary'
+                      variant='secondary'
                       className='flex-[1.8] px-3 py-1.5 text-xs sm:text-sm font-medium rounded-md shadow-sm'
                       title='Get driving directions from Google Maps'
                       icon={<Navigation className='h-3.5 w-3.5 sm:h-4 sm:w-4' />}

--- a/frontend/src/pages/DiveSites.jsx
+++ b/frontend/src/pages/DiveSites.jsx
@@ -587,7 +587,7 @@ const DiveSites = () => {
               label: 'Explore on Map',
               icon: Compass,
               onClick: () => navigate('/map?type=dive-sites'),
-              variant: 'primary',
+              variant: 'secondary',
             },
             {
               label: 'Suggest a New Site',
@@ -599,7 +599,7 @@ const DiveSites = () => {
                 }
                 navigate('/dive-sites/create');
               },
-              variant: 'secondary',
+              variant: 'primary',
             },
           ]}
         />

--- a/frontend/src/pages/DiveTrips.jsx
+++ b/frontend/src/pages/DiveTrips.jsx
@@ -572,7 +572,7 @@ const DiveTrips = () => {
               label: 'Explore Map',
               icon: Compass,
               onClick: () => navigate('/map?type=dive-trips'),
-              variant: 'primary',
+              variant: 'secondary',
             },
             ...(user
               ? [
@@ -580,7 +580,7 @@ const DiveTrips = () => {
                     label: 'Create Trip',
                     icon: Plus,
                     onClick: () => navigate('/dive-trips/create'),
-                    variant: 'secondary',
+                    variant: 'primary',
                   },
                 ]
               : []),
@@ -752,7 +752,7 @@ const DiveTrips = () => {
 
                   {filters.difficulty_code && <p>• Try a different difficulty level</p>}
                 </div>
-                <Button onClick={clearFilters} variant='primary' className='mt-4'>
+                <Button onClick={clearFilters} variant='secondary' className='mt-4'>
                   Clear All Filters
                 </Button>
               </div>

--- a/frontend/src/pages/DivingCenterDetail.jsx
+++ b/frontend/src/pages/DivingCenterDetail.jsx
@@ -775,13 +775,15 @@ const DivingCenterDetail = () => {
             />
           )}
           {shouldShowEdit && (
-            <Link
+            <Button
+              as={Link}
               to={`/diving-centers/${id}/edit`}
-              className='inline-flex items-center justify-center px-3 py-1.5 text-xs sm:text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 border border-transparent transition-colors'
+              variant='primary'
+              icon={<Edit className='h-3.5 w-3.5 sm:h-4 sm:w-4' />}
+              className='px-3 py-1.5 text-xs sm:text-sm font-medium'
             >
-              <Edit className='h-3.5 w-3.5 sm:h-4 sm:w-4 mr-1.5' />
               Edit
-            </Link>
+            </Button>
           )}
         </div>
       </div>
@@ -1256,7 +1258,7 @@ const DivingCenterDetail = () => {
                 <Button
                   type='submit'
                   disabled={broadcastTextMutation.isLoading || !broadcastMessage.trim()}
-                  variant='primary'
+                  variant='secondary'
                   icon={<MessageSquare className='h-4 w-4' />}
                 >
                   {broadcastTextMutation.isLoading ? 'Sending...' : 'Send Broadcast'}

--- a/frontend/src/pages/DivingCenters.jsx
+++ b/frontend/src/pages/DivingCenters.jsx
@@ -320,13 +320,13 @@ const DivingCenters = () => {
             {
               label: 'Explore Map',
               icon: Map,
-              variant: 'primary',
+              variant: 'secondary',
               onClick: () => handleViewModeChange('map'),
             },
             {
               label: 'Add Center',
               icon: Plus,
-              variant: 'secondary',
+              variant: 'primary',
               onClick: () => navigate('/diving-centers/create'),
             },
           ]}

--- a/frontend/src/pages/EditDive.jsx
+++ b/frontend/src/pages/EditDive.jsx
@@ -1206,14 +1206,7 @@ const EditDive = () => {
                                 <button
                                   type='button'
                                   onClick={handleUrlAdd}
-                                  className='px-4 py-2 text-white rounded-md'
-                                  style={{ backgroundColor: UI_COLORS.success, color: 'white' }}
-                                  onMouseEnter={e =>
-                                    (e.currentTarget.style.backgroundColor = '#007a5c')
-                                  }
-                                  onMouseLeave={e =>
-                                    (e.currentTarget.style.backgroundColor = UI_COLORS.success)
-                                  }
+                                  className='flex items-center px-4 py-2 text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 hover:text-gray-900 transition-colors'
                                 >
                                   Add Media
                                 </button>
@@ -1503,12 +1496,7 @@ const EditDive = () => {
                     <button
                       type='button'
                       onClick={handleAddNewTag}
-                      className='px-4 py-2 text-white rounded-md flex items-center gap-2'
-                      style={{ backgroundColor: UI_COLORS.success }}
-                      onMouseEnter={e => (e.currentTarget.style.backgroundColor = '#007a5c')}
-                      onMouseLeave={e =>
-                        (e.currentTarget.style.backgroundColor = UI_COLORS.success)
-                      }
+                      className='px-4 py-2 text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 hover:text-gray-900 transition-colors flex items-center gap-2'
                     >
                       <Plus size={16} />
                       Add

--- a/frontend/src/pages/EditDiveSite.jsx
+++ b/frontend/src/pages/EditDiveSite.jsx
@@ -1342,12 +1342,7 @@ const EditDiveSite = () => {
                     <button
                       type='button'
                       onClick={() => setShowAliasForm(!showAliasForm)}
-                      className='flex items-center px-4 py-2 text-white rounded-md'
-                      style={{ backgroundColor: UI_COLORS.success, color: 'white' }}
-                      onMouseEnter={e => (e.currentTarget.style.backgroundColor = '#007a5c')}
-                      onMouseLeave={e =>
-                        (e.currentTarget.style.backgroundColor = UI_COLORS.success)
-                      }
+                      className='flex items-center px-4 py-2 text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 hover:text-gray-900 transition-colors'
                     >
                       <Plus className='w-4 h-4 mr-2' />
                       Add Alias
@@ -1379,16 +1374,7 @@ const EditDiveSite = () => {
                             type='button'
                             onClick={handleAddAlias}
                             disabled={addAliasMutation.isLoading}
-                            className='px-4 py-2 text-white rounded-md disabled:opacity-50'
-                            style={{ backgroundColor: UI_COLORS.success, color: 'white' }}
-                            onMouseEnter={e =>
-                              !e.currentTarget.disabled &&
-                              (e.currentTarget.style.backgroundColor = '#007a5c')
-                            }
-                            onMouseLeave={e =>
-                              !e.currentTarget.disabled &&
-                              (e.currentTarget.style.backgroundColor = UI_COLORS.success)
-                            }
+                            className='px-4 py-2 text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 hover:text-gray-900 transition-colors disabled:opacity-50'
                           >
                             {addAliasMutation.isLoading ? 'Adding...' : 'Add Alias'}
                           </button>
@@ -1581,16 +1567,7 @@ const EditDiveSite = () => {
                     type='button'
                     onClick={suggestLocation}
                     disabled={!formData.latitude || !formData.longitude}
-                    className='px-4 py-2 text-white rounded-md disabled:opacity-50 disabled:cursor-not-allowed'
-                    style={{ backgroundColor: UI_COLORS.success, color: 'white' }}
-                    onMouseEnter={e =>
-                      !e.currentTarget.disabled &&
-                      (e.currentTarget.style.backgroundColor = '#007a5c')
-                    }
-                    onMouseLeave={e =>
-                      !e.currentTarget.disabled &&
-                      (e.currentTarget.style.backgroundColor = UI_COLORS.success)
-                    }
+                    className='flex items-center px-4 py-2 text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 hover:text-gray-900 transition-colors disabled:opacity-50 disabled:cursor-not-allowed gap-2'
                   >
                     🗺️ Suggest Country & Region from Coordinates
                   </button>
@@ -1617,16 +1594,7 @@ const EditDiveSite = () => {
                           type='button'
                           onClick={detectShoreDirection}
                           disabled={!formData.latitude || !formData.longitude}
-                          className='px-4 py-2 text-white rounded-md disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap'
-                          style={{ backgroundColor: UI_COLORS.success }}
-                          onMouseEnter={e =>
-                            !e.currentTarget.disabled &&
-                            (e.currentTarget.style.backgroundColor = '#007a5c')
-                          }
-                          onMouseLeave={e =>
-                            !e.currentTarget.disabled &&
-                            (e.currentTarget.style.backgroundColor = UI_COLORS.success)
-                          }
+                          className='flex items-center px-4 py-2 text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 hover:text-gray-900 transition-colors disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap'
                         >
                           🔍 Re-detect from Coordinates
                         </button>
@@ -1818,14 +1786,7 @@ const EditDiveSite = () => {
                                 <button
                                   type='button'
                                   onClick={handleAddMedia}
-                                  className='px-4 py-2 text-white rounded-md'
-                                  style={{ backgroundColor: UI_COLORS.success, color: 'white' }}
-                                  onMouseEnter={e =>
-                                    (e.currentTarget.style.backgroundColor = '#007a5c')
-                                  }
-                                  onMouseLeave={e =>
-                                    (e.currentTarget.style.backgroundColor = UI_COLORS.success)
-                                  }
+                                  className='flex items-center px-4 py-2 text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 hover:text-gray-900 transition-colors'
                                 >
                                   Add Media
                                 </button>
@@ -1915,12 +1876,7 @@ const EditDiveSite = () => {
                     <button
                       type='button'
                       onClick={() => setShowTagForm(!showTagForm)}
-                      className='flex items-center px-4 py-2 text-white rounded-md'
-                      style={{ backgroundColor: UI_COLORS.success, color: 'white' }}
-                      onMouseEnter={e => (e.currentTarget.style.backgroundColor = '#007a5c')}
-                      onMouseLeave={e =>
-                        (e.currentTarget.style.backgroundColor = UI_COLORS.success)
-                      }
+                      className='flex items-center px-4 py-2 text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 hover:text-gray-900 transition-colors'
                     >
                       <Tag className='w-4 h-4 mr-2' />
                       Add Tag
@@ -1974,16 +1930,7 @@ const EditDiveSite = () => {
                               });
                             }}
                             disabled={createTagMutation.isLoading}
-                            className='px-4 py-2 text-white rounded-md disabled:opacity-50'
-                            style={{ backgroundColor: UI_COLORS.success, color: 'white' }}
-                            onMouseEnter={e =>
-                              !e.currentTarget.disabled &&
-                              (e.currentTarget.style.backgroundColor = '#007a5c')
-                            }
-                            onMouseLeave={e =>
-                              !e.currentTarget.disabled &&
-                              (e.currentTarget.style.backgroundColor = UI_COLORS.success)
-                            }
+                            className='px-4 py-2 text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 hover:text-gray-900 transition-colors disabled:opacity-50'
                           >
                             {createTagMutation.isLoading ? 'Adding...' : 'Add Tag'}
                           </button>
@@ -2106,10 +2053,7 @@ const EditDiveSite = () => {
                 <button
                   type='button'
                   onClick={handleToggleDivingCenterForm}
-                  className='flex items-center px-4 py-2 text-white rounded-md'
-                  style={{ backgroundColor: UI_COLORS.success }}
-                  onMouseEnter={e => (e.currentTarget.style.backgroundColor = '#007a5c')}
-                  onMouseLeave={e => (e.currentTarget.style.backgroundColor = UI_COLORS.success)}
+                  className='flex items-center px-4 py-2 text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 hover:text-gray-900 transition-colors'
                 >
                   <Building className='w-4 h-4 mr-2' />
                   Add Diving Center

--- a/frontend/src/pages/EditDivingCenter.jsx
+++ b/frontend/src/pages/EditDivingCenter.jsx
@@ -598,16 +598,7 @@ const EditDivingCenter = () => {
                       type='button'
                       onClick={handleAddOrganization}
                       disabled={addOrganizationMutation.isLoading}
-                      className='flex items-center px-4 py-2 text-white rounded-md disabled:opacity-50'
-                      style={{ backgroundColor: UI_COLORS.success }}
-                      onMouseEnter={e =>
-                        !e.currentTarget.disabled &&
-                        (e.currentTarget.style.backgroundColor = '#007a5c')
-                      }
-                      onMouseLeave={e =>
-                        !e.currentTarget.disabled &&
-                        (e.currentTarget.style.backgroundColor = UI_COLORS.success)
-                      }
+                      className='flex items-center px-4 py-2 text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 hover:text-gray-900 transition-colors disabled:opacity-50'
                     >
                       <Plus className='h-4 w-4 mr-2' />
                       {addOrganizationMutation.isLoading ? 'Adding...' : 'Add Organization'}
@@ -677,10 +668,7 @@ const EditDivingCenter = () => {
                 <button
                   type='button'
                   onClick={() => setIsAddingGear(!isAddingGear)}
-                  className='flex items-center px-4 py-2 text-white rounded-md'
-                  style={{ backgroundColor: UI_COLORS.success }}
-                  onMouseEnter={e => (e.currentTarget.style.backgroundColor = '#007a5c')}
-                  onMouseLeave={e => (e.currentTarget.style.backgroundColor = UI_COLORS.success)}
+                  className='flex items-center px-4 py-2 text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 hover:text-gray-900 transition-colors'
                 >
                   <Plus className='w-4 h-4 mr-2' />
                   Add Gear Rental
@@ -759,16 +747,7 @@ const EditDivingCenter = () => {
                         type='button'
                         onClick={handleAddGear}
                         disabled={addGearMutation.isLoading}
-                        className='px-4 py-2 text-white rounded-md disabled:opacity-50'
-                        style={{ backgroundColor: UI_COLORS.success }}
-                        onMouseEnter={e =>
-                          !e.currentTarget.disabled &&
-                          (e.currentTarget.style.backgroundColor = '#007a5c')
-                        }
-                        onMouseLeave={e =>
-                          !e.currentTarget.disabled &&
-                          (e.currentTarget.style.backgroundColor = UI_COLORS.success)
-                        }
+                        className='px-4 py-2 text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 hover:text-gray-900 transition-colors disabled:opacity-50'
                       >
                         {addGearMutation.isLoading ? 'Adding...' : 'Add Gear Rental'}
                       </button>

--- a/frontend/src/pages/ForgotPassword.jsx
+++ b/frontend/src/pages/ForgotPassword.jsx
@@ -67,7 +67,7 @@ const ForgotPassword = () => {
               </p>
             </div>
             <div className='mt-4'>
-              <Link to='/login' className='text-blue-600 hover:text-blue-500 font-medium'>
+              <Link to='/login' className='text-divemap-blue hover:opacity-80 font-medium'>
                 Back to Sign In
               </Link>
             </div>
@@ -115,14 +115,14 @@ const ForgotPassword = () => {
                 <button
                   type='submit'
                   disabled={loading}
-                  className='group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50'
+                  className='group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-divemap-blue hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-divemap-sky disabled:opacity-50'
                 >
                   {loading ? 'Sending...' : 'Send Reset Link'}
                 </button>
               </div>
 
               <div className='text-center'>
-                <Link to='/login' className='font-medium text-blue-600 hover:text-blue-500'>
+                <Link to='/login' className='font-medium text-divemap-blue hover:opacity-80'>
                   Back to Sign In
                 </Link>
               </div>

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -471,10 +471,8 @@ const Home = () => {
         <div className='flex flex-wrap gap-4 justify-center'>
           <Link to='/register'>
             <Button
-              type='primary'
               size='large'
-              className='h-14 px-10 text-lg font-bold rounded-xl shadow-lg'
-              style={{ backgroundColor: '#0072B2' }}
+              className='h-14 px-10 text-lg font-bold rounded-xl shadow-md border border-gray-200 hover:border-gray-400 transition-all'
             >
               Get Started Free
             </Button>

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -218,7 +218,7 @@ const Login = () => {
             </h2>
             <p className='mt-2 text-center text-sm text-gray-600'>
               Or{' '}
-              <Link to='/register' className='font-medium text-blue-600 hover:text-blue-500'>
+              <Link to='/register' className='font-medium text-divemap-blue hover:opacity-80'>
                 create a new account
               </Link>
             </p>
@@ -272,7 +272,7 @@ const Login = () => {
                   <div className='text-sm'>
                     <Link
                       to='/forgot-password'
-                      className='font-medium text-blue-600 hover:text-blue-500'
+                      className='font-medium text-divemap-blue hover:opacity-80'
                     >
                       Forgot your password?
                     </Link>
@@ -304,7 +304,7 @@ const Login = () => {
                 <button
                   type='submit'
                   disabled={loading || !isBackendReady}
-                  className='group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed'
+                  className='group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-divemap-blue hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-divemap-sky disabled:opacity-50 disabled:cursor-not-allowed'
                 >
                   {loading
                     ? 'Signing in...'

--- a/frontend/src/pages/PersonalAccessTokens.jsx
+++ b/frontend/src/pages/PersonalAccessTokens.jsx
@@ -153,7 +153,7 @@ const PersonalAccessTokens = () => {
         <div className='mb-6'>
           <Link
             to='/profile'
-            className='inline-flex items-center text-blue-600 hover:text-blue-800 mb-4 transition-colors'
+            className='inline-flex items-center text-divemap-blue hover:text-blue-800 mb-4 transition-colors'
           >
             <ChevronLeft className='h-4 w-4 mr-1' />
             Back to Profile
@@ -161,7 +161,7 @@ const PersonalAccessTokens = () => {
           <div className='flex flex-col md:flex-row md:items-center justify-between gap-4'>
             <div>
               <Title level={2} className='!mb-1 flex items-center'>
-                <Key className='mr-3 text-blue-600' />
+                <Key className='mr-3 text-divemap-blue' />
                 Personal Access Tokens
               </Title>
               <Paragraph className='text-gray-500'>
@@ -173,7 +173,7 @@ const PersonalAccessTokens = () => {
               icon={<Plus size={18} />}
               onClick={() => setIsCreateModalVisible(true)}
               size='large'
-              className='bg-blue-600'
+              className='bg-divemap-blue'
             >
               Generate New Token
             </Button>
@@ -258,7 +258,7 @@ const PersonalAccessTokens = () => {
                 type='primary'
                 htmlType='submit'
                 loading={createTokenMutation.isLoading}
-                className='bg-blue-600'
+                className='bg-divemap-blue'
               >
                 Generate Token
               </Button>
@@ -281,7 +281,7 @@ const PersonalAccessTokens = () => {
               key='close'
               type='primary'
               onClick={() => setIsSuccessModalVisible(false)}
-              className='bg-blue-600'
+              className='bg-divemap-blue'
             >
               I have saved my token
             </Button>,

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -685,17 +685,18 @@ const Profile = () => {
                 <h2 className='text-lg sm:text-xl font-semibold text-gray-900 uppercase tracking-tight'>
                   Account Information
                 </h2>
-                <button
+                <Button
                   onClick={() => {
                     if (isEditing) {
                       resetProfile();
                     }
                     setIsEditing(!isEditing);
                   }}
-                  className='px-3 py-1.5 sm:px-4 sm:py-2 text-blue-600 hover:text-blue-700 font-medium text-sm sm:text-base transition-colors duration-200'
+                  variant={isEditing ? 'secondary' : 'primary'}
+                  size='sm'
                 >
-                  {isEditing ? 'Cancel' : 'Edit'}
-                </button>
+                  {isEditing ? 'Cancel' : 'Edit Profile'}
+                </Button>
               </div>
 
               {isEditing ? (

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -209,7 +209,7 @@ const Register = () => {
             </h2>
             <p className='mt-2 text-center text-sm text-gray-600'>
               Or{' '}
-              <Link to='/login' className='font-medium text-blue-600 hover:text-blue-500'>
+              <Link to='/login' className='font-medium text-divemap-blue hover:opacity-80'>
                 sign in to your existing account
               </Link>
             </p>
@@ -324,7 +324,7 @@ const Register = () => {
                 <button
                   type='submit'
                   disabled={loading || !isBackendReady}
-                  className='group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed'
+                  className='group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-divemap-blue hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-divemap-sky disabled:opacity-50 disabled:cursor-not-allowed'
                 >
                   {loading
                     ? 'Creating account...'
@@ -392,7 +392,7 @@ const Register = () => {
               <div className='text-center'>
                 <p className='text-sm text-gray-600'>
                   Already have an account?{' '}
-                  <Link to='/login' className='font-medium text-blue-600 hover:text-blue-500'>
+                  <Link to='/login' className='font-medium text-divemap-blue hover:opacity-80'>
                     Sign in here
                   </Link>
                 </p>

--- a/frontend/src/pages/ResetPassword.jsx
+++ b/frontend/src/pages/ResetPassword.jsx
@@ -85,7 +85,7 @@ const ResetPassword = () => {
         <SEO title='Verifying | Divemap' description='Verifying password reset token.' />
         <div className='min-h-screen flex items-center justify-center bg-gray-50'>
           <div className='text-center'>
-            <div className='animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto'></div>
+            <div className='animate-spin rounded-full h-12 w-12 border-b-2 border-divemap-blue mx-auto'></div>
             <p className='mt-4 text-gray-600'>Verifying link...</p>
           </div>
         </div>
@@ -112,7 +112,10 @@ const ResetPassword = () => {
               </p>
             </div>
             <div className='mt-4'>
-              <Link to='/forgot-password' className='text-blue-600 hover:text-blue-500 font-medium'>
+              <Link
+                to='/forgot-password'
+                className='text-divemap-blue hover:opacity-80 font-medium'
+              >
                 Request a new reset link
               </Link>
             </div>
@@ -197,7 +200,7 @@ const ResetPassword = () => {
                 <button
                   type='submit'
                   disabled={loading}
-                  className='group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50'
+                  className='group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-divemap-blue hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-divemap-sky disabled:opacity-50'
                 >
                   {loading ? 'Resetting...' : 'Reset Password'}
                 </button>

--- a/frontend/src/pages/VerifyEmail.jsx
+++ b/frontend/src/pages/VerifyEmail.jsx
@@ -142,7 +142,7 @@ const VerifyEmail = () => {
           <div className='bg-white py-8 px-6 shadow rounded-lg'>
             {status === 'verifying' && (
               <div className='text-center'>
-                <div className='animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto'></div>
+                <div className='animate-spin rounded-full h-12 w-12 border-b-2 border-divemap-blue mx-auto'></div>
                 <p className='mt-4 text-gray-600'>Verifying your email address...</p>
               </div>
             )}
@@ -172,7 +172,7 @@ const VerifyEmail = () => {
                 <div className='mt-6'>
                   <button
                     onClick={() => navigate('/login')}
-                    className='w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500'
+                    className='w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-divemap-blue hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-divemap-sky'
                   >
                     Go to Login
                   </button>
@@ -204,13 +204,13 @@ const VerifyEmail = () => {
                   <div className='mt-6 space-y-3'>
                     <button
                       onClick={() => setShowResendForm(true)}
-                      className='w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500'
+                      className='w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-divemap-blue hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-divemap-sky'
                     >
                       Request New Verification Email
                     </button>
                     <button
                       onClick={() => navigate('/login')}
-                      className='w-full flex justify-center py-2 px-4 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500'
+                      className='w-full flex justify-center py-2 px-4 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-divemap-sky'
                     >
                       Go to Login
                     </button>
@@ -230,14 +230,14 @@ const VerifyEmail = () => {
                         value={resendEmail}
                         onChange={e => setResendEmail(e.target.value)}
                         placeholder='Enter your email address'
-                        className='w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm'
+                        className='w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-divemap-sky focus:border-divemap-blue sm:text-sm'
                         disabled={resending}
                       />
                     </div>
                     <button
                       onClick={handleResendVerification}
                       disabled={resending || !resendEmail.includes('@')}
-                      className='w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed'
+                      className='w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-divemap-blue hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-divemap-sky disabled:opacity-50 disabled:cursor-not-allowed'
                     >
                       {resending ? 'Sending...' : 'Send Verification Email'}
                     </button>
@@ -246,7 +246,7 @@ const VerifyEmail = () => {
                         setShowResendForm(false);
                         setResendEmail('');
                       }}
-                      className='w-full flex justify-center py-2 px-4 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500'
+                      className='w-full flex justify-center py-2 px-4 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-divemap-sky'
                     >
                       Cancel
                     </button>


### PR DESCRIPTION
This commit standardizes button styling across the frontend to align with the brand identity and the "One Primary Button" rule.

- Replaced legacy Tailwind classes (`bg-blue-600`, `bg-blue-500`) with brand-specific variables (`bg-divemap-blue`).
- Updated focus rings to use `divemap-sky`.
- Adjusted button variants (`primary`, `secondary`) on edit, detail, and index pages to establish a clear visual hierarchy.
- Fixed inconsistent styling in chat components and authentication pages.

This ensures a cohesive user experience and simplifies future UI updates.