### PR TITLE
Standardize difficulty display with reusable component

### DIFF
--- a/frontend/src/components/DiveInfoGrid.jsx
+++ b/frontend/src/components/DiveInfoGrid.jsx
@@ -3,9 +3,10 @@ import { Grid } from 'antd-mobile';
 import { Calendar, Clock, Eye, TrendingUp, User, Notebook, Wind, Droplets } from 'lucide-react';
 import React from 'react';
 
-import { getDifficultyLabel, getDifficultyColorClasses } from '../utils/difficultyHelpers';
 import { getTagColor } from '../utils/tagHelpers';
 import { formatGases } from '../utils/textHelpers';
+
+import DifficultyBadge from './ui/DifficultyBadge';
 
 const DiveInfoGrid = ({ dive, hasDeco, isMobile, formatDate, formatTime }) => {
   const formatGasDisplay = gasStr => {
@@ -87,15 +88,11 @@ const DiveInfoGrid = ({ dive, hasDeco, isMobile, formatDate, formatTime }) => {
                   Difficulty
                 </span>
                 <div className='flex items-center mt-0.5'>
-                  {dive.difficulty_code ? (
-                    <span
-                      className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${getDifficultyColorClasses(dive.difficulty_code)}`}
-                    >
-                      {dive.difficulty_label || getDifficultyLabel(dive.difficulty_code)}
-                    </span>
-                  ) : (
-                    <span className='text-sm text-gray-500'>-</span>
-                  )}
+                  <DifficultyBadge
+                    code={dive.difficulty_code}
+                    label={dive.difficulty_label}
+                    showUnspecified
+                  />
                 </div>
               </div>
             </Grid.Item>
@@ -245,15 +242,11 @@ const DiveInfoGrid = ({ dive, hasDeco, isMobile, formatDate, formatTime }) => {
                     Difficulty
                   </span>
                   <div className='flex items-center mt-0.5'>
-                    {dive.difficulty_code ? (
-                      <span
-                        className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${getDifficultyColorClasses(dive.difficulty_code)}`}
-                      >
-                        {dive.difficulty_label || getDifficultyLabel(dive.difficulty_code)}
-                      </span>
-                    ) : (
-                      <span className='text-sm text-gray-500'>-</span>
-                    )}
+                    <DifficultyBadge
+                      code={dive.difficulty_code}
+                      label={dive.difficulty_label}
+                      showUnspecified
+                    />
                   </div>
                 </div>
               </Col>

--- a/frontend/src/components/DiveSiteCard.jsx
+++ b/frontend/src/components/DiveSiteCard.jsx
@@ -3,11 +3,12 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 
 import { useResponsive } from '../hooks/useResponsive';
-import { getDifficultyLabel, getDifficultyColorClasses } from '../utils/difficultyHelpers';
 import { decodeHtmlEntities } from '../utils/htmlDecode';
 import { slugify, getDiveSiteSlug } from '../utils/slugify';
 import { getTagColor } from '../utils/tagHelpers';
 import { renderTextWithLinks } from '../utils/textHelpers';
+
+import DifficultyBadge from './ui/DifficultyBadge';
 
 export const DiveSiteListCard = ({
   site,
@@ -100,13 +101,7 @@ export const DiveSiteListCard = ({
                     </span>
                   </div>
                 )}
-                {site.difficulty_code && site.difficulty_code !== 'unspecified' && (
-                  <span
-                    className={`inline-flex items-center rounded-full px-1.5 py-0 text-xs sm:text-sm font-medium ${getDifficultyColorClasses(site.difficulty_code)}`}
-                  >
-                    {site.difficulty_label || getDifficultyLabel(site.difficulty_code)}
-                  </span>
-                )}
+                <DifficultyBadge code={site.difficulty_code} label={site.difficulty_label} />
                 {site.route_count > 0 && (
                   <div className='flex items-center gap-1'>
                     <Route className='w-3 h-3 text-blue-400' />
@@ -189,13 +184,11 @@ export const DiveSiteGridCard = ({
 
         {/* Floating Badges */}
         <div className='absolute top-3 left-3 flex flex-wrap gap-2'>
-          {site.difficulty_code && (
-            <span
-              className={`px-2 py-0.5 rounded-full text-xs font-bold uppercase tracking-wider shadow-sm ${getDifficultyColorClasses(site.difficulty_code)}`}
-            >
-              {site.difficulty_label || getDifficultyLabel(site.difficulty_code)}
-            </span>
-          )}
+          <DifficultyBadge
+            code={site.difficulty_code}
+            label={site.difficulty_label}
+            className='uppercase tracking-wider shadow-sm'
+          />
         </div>
 
         {/* Floating Rating */}

--- a/frontend/src/components/DiveSitesMap.jsx
+++ b/frontend/src/components/DiveSitesMap.jsx
@@ -284,7 +284,7 @@ const MarkerClusterGroup = ({
           <h3 class="font-semibold text-gray-900 mb-1">${escape(marker.name)}</h3>
           ${marker.description ? `<p class="text-sm text-gray-600 mb-2 line-clamp-2">${escape(marker.description)}</p>` : ''}
           <div class="flex items-center justify-between mb-2">
-            <span class="px-2 py-1 text-xs font-medium rounded-full             ${getDifficultyColorClasses(marker.difficulty_code)}">
+            <span class="px-2 py-1 text-xs font-medium rounded             ${getDifficultyColorClasses(marker.difficulty_code)}">
               ${marker.difficulty_label || getDifficultyLabel(marker.difficulty_code)}
             </span>
             ${
@@ -341,7 +341,7 @@ const MarkerClusterGroup = ({
                     ${
                       markerData.difficulty_code
                         ? `
-                      <span class="px-2 py-1 text-xs font-medium rounded-full ${getDifficultyColorClasses(markerData.difficulty_code)}">
+                      <span class="px-2 py-1 text-xs font-medium rounded ${getDifficultyColorClasses(markerData.difficulty_code)}">
                         ${markerData.difficulty_label || getDifficultyLabel(markerData.difficulty_code)}
                       </span>
                     `
@@ -738,17 +738,9 @@ const DiveSitesMap = ({ diveSites, onViewportChange }) => {
 
                     <div className='flex flex-col gap-0.5 mb-2 mt-0.5'>
                       {site.difficulty_code && (
-                        <div className='flex items-center text-[8px] font-bold uppercase tracking-tight'>
+                        <div className='flex items-center mt-0.5'>
                           <span
-                            className={
-                              site.difficulty_code === 'OPEN_WATER'
-                                ? 'text-green-700'
-                                : site.difficulty_code === 'ADVANCED_OPEN_WATER'
-                                  ? 'text-amber-700'
-                                  : site.difficulty_code === 'DEEP_NITROX'
-                                    ? 'text-orange-700'
-                                    : 'text-red-700'
-                            }
+                            className={`px-1.5 py-0.5 text-[10px] font-bold uppercase rounded ${getDifficultyColorClasses(site.difficulty_code)}`}
                           >
                             {site.difficulty_label || getDifficultyLabel(site.difficulty_code)}
                           </span>

--- a/frontend/src/components/DivesMap.jsx
+++ b/frontend/src/components/DivesMap.jsx
@@ -14,6 +14,8 @@ import { formatDate, formatTime } from '../utils/dateHelpers';
 import { getDifficultyLabel, getDifficultyColorClasses } from '../utils/difficultyHelpers';
 import { slugify } from '../utils/slugify';
 
+import DifficultyBadge from './ui/DifficultyBadge';
+
 // Fix default marker icons
 delete L.Icon.Default.prototype._getIconUrl;
 L.Icon.Default.mergeOptions({
@@ -165,7 +167,7 @@ const MarkerClusterGroup = ({ markers, createIcon, onClusterClick }) => {
                     ${
                       markerData.difficulty_code
                         ? `
-                      <span class="px-1 py-0.5 text-xs font-medium rounded-full bg-green-100 text-green-800">
+                      <span class="px-1 py-0.5 text-xs font-medium rounded ${getDifficultyColorClasses(markerData.difficulty_code)}">
                         ${markerData.difficulty_label || getDifficultyLabel(markerData.difficulty_code)}
                       </span>
                     `
@@ -360,11 +362,11 @@ const DivesMap = ({ dives = [], onViewportChange }) => {
 
                     {dive.difficulty_code && (
                       <div className='flex items-center'>
-                        <span
-                          className={`px-2 py-1 rounded-full text-xs font-medium ${getDifficultyColorClasses(dive.difficulty_code)}`}
-                        >
-                          {dive.difficulty_label || getDifficultyLabel(dive.difficulty_code)}
-                        </span>
+                        <DifficultyBadge
+                          code={dive.difficulty_code}
+                          label={dive.difficulty_label}
+                          size='sm'
+                        />
                       </div>
                     )}
 

--- a/frontend/src/components/LeafletMapView.jsx
+++ b/frontend/src/components/LeafletMapView.jsx
@@ -485,16 +485,10 @@ const MapContent = ({ markers, selectedEntityType, viewport, onViewportChange, r
                     <div class="flex flex-col gap-1 mt-0.5 mb-1.5">
                       ${
                         marker.data.difficulty_code
-                          ? `<div class="flex items-center text-[8px] font-bold uppercase tracking-tight">
-                              <span class="${
-                                marker.data.difficulty_code === 'OPEN_WATER'
-                                  ? 'text-green-700'
-                                  : marker.data.difficulty_code === 'ADVANCED_OPEN_WATER'
-                                    ? 'text-amber-700'
-                                    : marker.data.difficulty_code === 'DEEP_NITROX'
-                                      ? 'text-orange-700'
-                                      : 'text-red-700'
-                              }">${marker.data.difficulty_label || getDifficultyLabel(marker.data.difficulty_code)}</span>
+                          ? `<div class="flex items-center mt-0.5 mb-1.5">
+                              <span class="px-1.5 py-0.5 text-[9px] font-bold uppercase rounded ${getDifficultyColorClasses(marker.data.difficulty_code)}">
+                                ${marker.data.difficulty_label || getDifficultyLabel(marker.data.difficulty_code)}
+                              </span>
                             </div>`
                           : ''
                       }

--- a/frontend/src/components/TripCard.jsx
+++ b/frontend/src/components/TripCard.jsx
@@ -21,6 +21,8 @@ import { slugify, getDiveSiteSlug, getDivingCenterSlug } from '../utils/slugify'
 import { getStatusColorClasses, getDisplayStatus } from '../utils/tripHelpers';
 import { generateTripName } from '../utils/tripNameGenerator';
 
+import DifficultyBadge from './ui/DifficultyBadge';
+
 /**
  * Reusable Trip Card component for both list and grid views.
  * Handles mobile-first responsive layout and management actions.
@@ -96,36 +98,6 @@ const TripCard = ({
     );
   };
   const isGrid = viewMode === 'grid';
-
-  const getDifficultyColorClasses = code => {
-    switch (code) {
-      case 'OPEN_WATER':
-        return 'bg-green-100 text-green-800';
-      case 'ADVANCED_OPEN_WATER':
-        return 'bg-blue-100 text-blue-800';
-      case 'DEEP_NITROX':
-        return 'bg-purple-100 text-purple-800';
-      case 'TECHNICAL_DIVING':
-        return 'bg-red-100 text-red-800';
-      default:
-        return 'bg-gray-100 text-gray-800';
-    }
-  };
-
-  const getDifficultyLabel = code => {
-    switch (code) {
-      case 'OPEN_WATER':
-        return 'Open Water';
-      case 'ADVANCED_OPEN_WATER':
-        return 'Advanced';
-      case 'DEEP_NITROX':
-        return 'Deep/Nitrox';
-      case 'TECHNICAL_DIVING':
-        return 'Technical';
-      default:
-        return code?.replace(/_/g, ' ') || 'Unspecified';
-    }
-  };
 
   const tripName = generateTripName(trip);
   const tripSlug = slugify(tripName);
@@ -248,13 +220,12 @@ const TripCard = ({
           </div>
 
           <div className='flex items-center gap-2 flex-wrap sm:flex-nowrap shrink-0'>
-            {trip.trip_difficulty_code && (
-              <span
-                className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${getDifficultyColorClasses(trip.trip_difficulty_code)} shrink-0`}
-              >
-                {trip.trip_difficulty_label || getDifficultyLabel(trip.trip_difficulty_code)}
-              </span>
-            )}
+            <DifficultyBadge
+              code={trip.trip_difficulty_code}
+              label={trip.trip_difficulty_label}
+              size='xs'
+              className='shrink-0'
+            />
             {!isGrid && displayStatus && (
               <span
                 className={`sm:hidden inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${getStatusColorClasses(displayStatus, false)} shrink-0`}

--- a/frontend/src/components/tables/AdminDiveSitesTable.jsx
+++ b/frontend/src/components/tables/AdminDiveSitesTable.jsx
@@ -18,8 +18,8 @@ import {
 } from 'lucide-react';
 import PropTypes from 'prop-types';
 
-import { getDifficultyLabel, getDifficultyColorClasses } from '../../utils/difficultyHelpers';
 import { decodeHtmlEntities } from '../../utils/htmlDecode';
+import DifficultyBadge from '../ui/DifficultyBadge';
 import Pagination from '../ui/Pagination';
 
 /**
@@ -279,13 +279,14 @@ const AdminDiveSitesTable = ({
                       <span className='text-gray-500'>Creator:</span>{' '}
                       <span className='text-gray-900'>{site.created_by_username || 'Unknown'}</span>
                     </div>
-                    <div>
+                    <div className='flex items-center gap-2'>
                       <span className='text-gray-500'>Difficulty:</span>{' '}
-                      <span
-                        className={`px-2 py-0.5 text-xs font-medium rounded-full inline-block ${getDifficultyColorClasses(site.difficulty_code)}`}
-                      >
-                        {site.difficulty_label || getDifficultyLabel(site.difficulty_code)}
-                      </span>
+                      <DifficultyBadge
+                        code={site.difficulty_code}
+                        label={site.difficulty_label}
+                        size='xs'
+                        className='inline-block'
+                      />
                     </div>
                     <div>
                       <span className='text-gray-500'>Rating:</span>{' '}

--- a/frontend/src/components/ui/DifficultyBadge.jsx
+++ b/frontend/src/components/ui/DifficultyBadge.jsx
@@ -1,0 +1,50 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import { getDifficultyLabel, getDifficultyColorClasses } from '../../utils/difficultyHelpers';
+
+/**
+ * A reusable badge component for displaying dive difficulty levels.
+ * Replaces the old "pill" style with a "rectangle box" style.
+ */
+const DifficultyBadge = ({ code, label, className = '', size = 'sm', showUnspecified = false }) => {
+  const displayLabel = label || getDifficultyLabel(code);
+
+  if (!showUnspecified && displayLabel === 'Unspecified') {
+    return null;
+  }
+
+  const colorClasses = getDifficultyColorClasses(code);
+
+  const sizeClasses = {
+    xs: 'px-1 py-0 text-[10px]',
+    sm: 'px-1.5 py-0.5 text-xs',
+    md: 'px-2 py-1 text-sm',
+    lg: 'px-2.5 py-1.5 text-base',
+  };
+
+  const selectedSize = sizeClasses[size] || sizeClasses.sm;
+
+  return (
+    <span
+      className={`inline-flex items-center font-medium rounded border ${colorClasses} ${selectedSize} ${className}`}
+    >
+      {displayLabel}
+    </span>
+  );
+};
+
+DifficultyBadge.propTypes = {
+  /** The difficulty code (e.g., 'OPEN_WATER', 'ADVANCED_OPEN_WATER') */
+  code: PropTypes.string,
+  /** Optional manual label. If not provided, it will be derived from the code. */
+  label: PropTypes.string,
+  /** Additional Tailwind CSS classes */
+  className: PropTypes.string,
+  /** Badge size: 'xs', 'sm', 'md', 'lg' */
+  size: PropTypes.oneOf(['xs', 'sm', 'md', 'lg']),
+  /** Whether to show the badge if difficulty is 'Unspecified' */
+  showUnspecified: PropTypes.bool,
+};
+
+export default DifficultyBadge;

--- a/frontend/src/pages/AdminDiveSites.jsx
+++ b/frontend/src/pages/AdminDiveSites.jsx
@@ -29,15 +29,12 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import api from '../api';
 import SEO from '../components/SEO';
 import AdminDiveSitesTable from '../components/tables/AdminDiveSitesTable';
+import DifficultyBadge from '../components/ui/DifficultyBadge';
 import Select from '../components/ui/Select';
 import { useAuth } from '../contexts/AuthContext';
 import { approveDiveSite, rejectDiveSite } from '../services/diveSites';
 import { formatDate } from '../utils/dateHelpers';
-import {
-  getDifficultyLabel,
-  getDifficultyColorClasses,
-  getDifficultyOptions,
-} from '../utils/difficultyHelpers';
+import { getDifficultyLabel, getDifficultyOptions } from '../utils/difficultyHelpers';
 import { decodeHtmlEntities } from '../utils/htmlDecode';
 
 const AdminDiveSites = () => {
@@ -483,11 +480,7 @@ const AdminDiveSites = () => {
         cell: ({ row }) => {
           const site = row.original;
           return (
-            <span
-              className={`px-2 py-1 text-xs font-medium rounded-full ${getDifficultyColorClasses(site.difficulty_code)}`}
-            >
-              {site.difficulty_label || getDifficultyLabel(site.difficulty_code)}
-            </span>
+            <DifficultyBadge code={site.difficulty_code} label={site.difficulty_label} size='xs' />
           );
         },
       },

--- a/frontend/src/pages/DiveDetail.jsx
+++ b/frontend/src/pages/DiveDetail.jsx
@@ -72,7 +72,6 @@ import {
 import { extractErrorMessage } from '../utils/apiErrors';
 import { getRouteTypeColor } from '../utils/colorPalette';
 import { formatDate, formatTime } from '../utils/dateHelpers';
-import { getDifficultyLabel, getDifficultyColorClasses } from '../utils/difficultyHelpers';
 import { decodeHtmlEntities } from '../utils/htmlDecode';
 import { handleRateLimitError } from '../utils/rateLimitHandler';
 import { calculateRouteBearings, formatBearing } from '../utils/routeUtils';

--- a/frontend/src/pages/DiveSiteDetail.jsx
+++ b/frontend/src/pages/DiveSiteDetail.jsx
@@ -53,6 +53,7 @@ import SEO from '../components/SEO';
 import ShareButton from '../components/ShareButton';
 import StickyRateBar from '../components/StickyRateBar';
 import Button from '../components/ui/Button';
+import DifficultyBadge from '../components/ui/DifficultyBadge';
 import RichText from '../components/ui/RichText';
 import ShellRating from '../components/ui/ShellRating';
 import YouTubePreview from '../components/YouTubePreview';
@@ -61,7 +62,7 @@ import useFlickrImages from '../hooks/useFlickrImages';
 import { extractErrorMessage } from '../utils/apiErrors';
 import { formatCost, DEFAULT_CURRENCY } from '../utils/currency';
 import { formatDate } from '../utils/dateHelpers';
-import { getDifficultyLabel, getDifficultyColorClasses } from '../utils/difficultyHelpers';
+import { getDifficultyLabel } from '../utils/difficultyHelpers';
 import { decodeHtmlEntities } from '../utils/htmlDecode';
 import { handleRateLimitError } from '../utils/rateLimitHandler';
 import { slugify, getDiveSiteSlug } from '../utils/slugify';
@@ -594,11 +595,11 @@ const DiveSiteDetail = () => {
 
                 {dive.difficulty_code && (
                   <div className='flex items-center gap-1'>
-                    <span
-                      className={`px-1.5 py-0.5 text-[9px] font-bold uppercase rounded border ${getDifficultyColorClasses(dive.difficulty_code)}`}
-                    >
-                      {dive.difficulty_label || getDifficultyLabel(dive.difficulty_code)}
-                    </span>
+                    <DifficultyBadge
+                      code={dive.difficulty_code}
+                      label={dive.difficulty_label}
+                      size='xs'
+                    />
                   </div>
                 )}
               </div>
@@ -844,11 +845,10 @@ const DiveSiteDetail = () => {
                   Difficulty
                 </span>
                 <div className='flex items-center mt-0.5'>
-                  <span
-                    className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] sm:text-xs font-semibold ${getDifficultyColorClasses(diveSite.difficulty_code)}`}
-                  >
-                    {diveSite.difficulty_label || getDifficultyLabel(diveSite.difficulty_code)}
-                  </span>
+                  <DifficultyBadge
+                    code={diveSite.difficulty_code}
+                    label={diveSite.difficulty_label}
+                  />
                 </div>
               </div>
 

--- a/frontend/src/pages/DiveSites.jsx
+++ b/frontend/src/pages/DiveSites.jsx
@@ -46,7 +46,6 @@ import { useCompactLayout } from '../hooks/useCompactLayout';
 import useFlickrImages from '../hooks/useFlickrImages';
 import { useResponsive } from '../hooks/useResponsive';
 import useSorting from '../hooks/useSorting';
-import { getDifficultyLabel, getDifficultyColorClasses } from '../utils/difficultyHelpers';
 import { decodeHtmlEntities } from '../utils/htmlDecode';
 import { handleRateLimitError } from '../utils/rateLimitHandler';
 import { slugify } from '../utils/slugify';

--- a/frontend/src/pages/DiveTrips.jsx
+++ b/frontend/src/pages/DiveTrips.jsx
@@ -44,7 +44,6 @@ import useSorting from '../hooks/useSorting';
 import { getParsedTrips } from '../services/newsletters';
 import { formatCost } from '../utils/currency';
 import { formatDate } from '../utils/dateHelpers';
-import { getDifficultyLabel, getDifficultyColorClasses } from '../utils/difficultyHelpers';
 import { handleRateLimitError } from '../utils/rateLimitHandler';
 import { slugify } from '../utils/slugify';
 import { getSortOptions } from '../utils/sortOptions';

--- a/frontend/src/pages/Dives.jsx
+++ b/frontend/src/pages/Dives.jsx
@@ -44,6 +44,7 @@ import PageHeader from '../components/PageHeader';
 import RateLimitError from '../components/RateLimitError';
 import ResponsiveFilterBar from '../components/ResponsiveFilterBar';
 import SEO from '../components/SEO';
+import DifficultyBadge from '../components/ui/DifficultyBadge';
 import InfiniteScrollTrigger from '../components/ui/InfiniteScrollTrigger';
 import { useAuth } from '../contexts/AuthContext';
 import { useCompactLayout } from '../hooks/useCompactLayout';
@@ -52,7 +53,6 @@ import useSorting from '../hooks/useSorting';
 import { deleteDive } from '../services/dives';
 import { getDiveSite, getDiveSites } from '../services/diveSites';
 import { formatDate, formatTime } from '../utils/dateHelpers';
-import { getDifficultyLabel, getDifficultyColorClasses } from '../utils/difficultyHelpers';
 import { handleRateLimitError } from '../utils/rateLimitHandler';
 import { slugify } from '../utils/slugify';
 import { getSortOptions } from '../utils/sortOptions';
@@ -960,11 +960,10 @@ const Dives = () => {
                             </span>
                           </div>
                         )}
-                        <span
-                          className={`inline-flex items-center rounded-full px-1.5 py-0 text-xs sm:text-sm font-medium ${getDifficultyColorClasses(dive.difficulty_code)}`}
-                        >
-                          {dive.difficulty_label || getDifficultyLabel(dive.difficulty_code)}
-                        </span>
+                        <DifficultyBadge
+                          code={dive.difficulty_code}
+                          label={dive.difficulty_label}
+                        />
                       </div>
 
                       {/* FOOTER: Tags & Buddies - Only show icons/counts on mobile */}
@@ -1121,11 +1120,11 @@ const Dives = () => {
                               </span>
                             </div>
                           )}
-                          <span
-                            className={`text-xs font-medium px-2 py-0.5 rounded-full ${getDifficultyColorClasses(dive.difficulty_code)}`}
-                          >
-                            {dive.difficulty_label || getDifficultyLabel(dive.difficulty_code)}
-                          </span>
+                          <DifficultyBadge
+                            code={dive.difficulty_code}
+                            label={dive.difficulty_label}
+                            size='xs'
+                          />
                         </div>
                       </div>
                     </div>


### PR DESCRIPTION
Introduce a reusable DifficultyBadge component to standardize the representation of dive difficulty levels across the frontend.

Replaces the previous "pill" design (rounded-full) with a consistent "rectangle box" style (rounded) as requested. This update unifies difficulty badges in cards, detail pages, admin tables, and map popups while centralizing styling logic to improve maintainability and reduce code duplication.