### PR TITLE
Optimize Search, Filter State, and Growth Visualizations

### DIFF
--- a/backend/app/routers/dive_sites.py
+++ b/backend/app/routers/dive_sites.py
@@ -422,7 +422,7 @@ def apply_sorting(query, sort_by, sort_order, current_user, ratings_subquery=Non
     return query
 
 
-def search_dive_sites_with_fuzzy(query: str, exact_results: List[DiveSite], db: Session, similarity_threshold: float = 0.2, max_fuzzy_results: int = 10, **filters):
+def search_dive_sites_with_fuzzy(query: str, exact_results: List[DiveSite], db: Session, similarity_threshold: float = 0.2, max_fuzzy_results: int = 10, sort_by: str = None, sort_order: str = 'asc', **filters):
     """
     Enhance search results with fuzzy matching when exact results are insufficient.
 
@@ -432,26 +432,85 @@ def search_dive_sites_with_fuzzy(query: str, exact_results: List[DiveSite], db: 
         db: Database session
         similarity_threshold: Minimum similarity score (0.0 to 1.0)
         max_fuzzy_results: Maximum number of fuzzy results to return
+        sort_by: Field to sort by
+        sort_order: Sort order ('asc' or 'desc')
         **filters: Additional filters to apply (tag_ids, difficulty_code, etc.)
 
     Returns:
         List of dive sites with exact results first, followed by fuzzy matches
     """
-    # If we have enough exact results, return them with match type info
+    # Convert exact results to the expected format with phrase-aware scoring
+    exact_results_with_scores = []
+    for site in exact_results:
+        # Get tags for this dive site for scoring
+        site_tags = []
+        if hasattr(site, 'tags') and site.tags:
+            site_tags = [tag.name if hasattr(tag, 'name') else str(tag) for tag in site.tags]
+        else:
+            from app.models import DiveSiteTag, AvailableTag
+            tags = db.query(AvailableTag).join(DiveSiteTag).filter(
+                DiveSiteTag.dive_site_id == site.id
+            ).all()
+            site_tags = [tag.name for tag in tags]
+            
+        score = calculate_unified_phrase_aware_score(
+            query.lower(),
+            site.name,
+            site.description,
+            site.country,
+            site.region,
+            None,
+            site_tags
+        )
+        
+        exact_results_with_scores.append({
+            'site': site,
+            'match_type': 'exact' if score >= 0.9 else 'exact_words' if score >= 0.7 else 'partial_words',
+            'score': score,
+            'name_contains': query.lower() in site.name.lower(),
+            'country_contains': site.country and query.lower() in site.country.lower(),
+            'region_contains': site.region and query.lower() in site.region.lower(),
+            'description_contains': site.description and query.lower() in site.description.lower()
+        })
+        
+    # Sort exact results with scores according to the specified sort criteria
+    if sort_by == 'name':
+        exact_results_with_scores.sort(key=lambda x: x['site'].name.lower(), reverse=(sort_order == 'desc'))
+    elif sort_by == 'created_at':
+        exact_results_with_scores.sort(key=lambda x: x['site'].created_at, reverse=(sort_order == 'desc'))
+    elif sort_by == 'updated_at':
+        exact_results_with_scores.sort(key=lambda x: x['site'].updated_at, reverse=(sort_order == 'desc'))
+    elif sort_by == 'view_count':
+        exact_results_with_scores.sort(key=lambda x: x['site'].view_count, reverse=(sort_order == 'desc'))
+    elif sort_by == 'average_rating':
+        site_ids = [result['site'].id for result in exact_results_with_scores]
+        ratings_map = {}
+        if site_ids:
+            from app.models import SiteRating
+            ratings_data = db.query(
+                SiteRating.dive_site_id,
+                func.avg(SiteRating.score).label("avg_rating")
+            ).filter(SiteRating.dive_site_id.in_(site_ids)).group_by(SiteRating.dive_site_id).all()
+            ratings_map = {row[0]: float(row[1]) if row[1] is not None else 0.0 for row in ratings_data}
+        exact_results_with_scores.sort(key=lambda x: ratings_map.get(x['site'].id, 0.0), reverse=(sort_order == 'desc'))
+    elif sort_by == 'comment_count':
+        site_ids = [result['site'].id for result in exact_results_with_scores]
+        comments_map = {}
+        if site_ids:
+            from app.models import SiteComment
+            comments_data = db.query(
+                SiteComment.dive_site_id,
+                func.count(SiteComment.id).label("comment_count")
+            ).filter(SiteComment.dive_site_id.in_(site_ids)).group_by(SiteComment.dive_site_id).all()
+            comments_map = {row[0]: row[1] or 0 for row in comments_data}
+        exact_results_with_scores.sort(key=lambda x: comments_map.get(x['site'].id, 0), reverse=(sort_order == 'desc'))
+    else:
+        # Default fallback (relevance-based): sort by score descending
+        exact_results_with_scores.sort(key=lambda x: x['score'], reverse=True)
+
+    # If we have enough exact results, return them
     if len(exact_results) >= 10:
-        # Convert exact results to the expected format
-        final_results = []
-        for site in exact_results:
-            final_results.append({
-                'site': site,
-                'match_type': 'exact',
-                'score': 1.0,
-                'name_contains': query.lower() in site.name.lower(),
-                'country_contains': site.country and query.lower() in site.country.lower(),
-                'region_contains': site.region and query.lower() in site.region.lower(),
-                'description_contains': site.description and query.lower() in site.description.lower()
-            })
-        return final_results
+        return exact_results_with_scores
 
     # Build a filtered query that respects the same filters as the main query
     filtered_query = db.query(DiveSite)
@@ -574,17 +633,8 @@ def search_dive_sites_with_fuzzy(query: str, exact_results: List[DiveSite], db: 
     # Create final results with match type information
     final_results = []
 
-    # Add exact results first with match type
-    for site in exact_results:
-        final_results.append({
-            'site': site,
-            'match_type': 'exact',
-            'score': 1.0,
-            'name_contains': query_lower in site.name.lower(),
-            'country_contains': site.country and query.lower() in site.country.lower(),
-            'region_contains': site.region and query.lower() in site.region.lower(),
-            'description_contains': site.description and query.lower() in site.description.lower()
-        })
+    # Add exact results first with match type (already sorted by user sorting criteria or relevance)
+    final_results.extend(exact_results_with_scores)
 
     # Add fuzzy matches
     for match in fuzzy_matches:
@@ -1291,6 +1341,8 @@ async def get_dive_sites(
                 db,
                 similarity_threshold=UNIFIED_TYPO_TOLERANCE['overall_threshold'],
                 max_fuzzy_results=10,
+                sort_by=sort_by if sort_by != 'name' else None,
+                sort_order=sort_order,
                 tag_ids=tag_ids,
                 difficulty_code=difficulty_code,
                 country=country,

--- a/backend/app/routers/diving_centers.py
+++ b/backend/app/routers/diving_centers.py
@@ -203,21 +203,9 @@ def search_diving_centers_with_fuzzy(query: str, exact_results: List[DivingCente
     Returns:
         List of diving centers with exact results first, followed by fuzzy matches
     """
-    # Always apply phrase-aware scoring to exact results for consistent ranking
-    # Sort exact results according to the specified sort criteria
-    if sort_by == 'name':
-        exact_results_sorted = sorted(exact_results, key=lambda x: x.name.lower(), reverse=(sort_order == 'desc'))
-    elif sort_by == 'created_at':
-        exact_results_sorted = sorted(exact_results, key=lambda x: x.created_at, reverse=(sort_order == 'desc'))
-    elif sort_by == 'updated_at':
-        exact_results_sorted = sorted(exact_results, key=lambda x: x.updated_at, reverse=(sort_order == 'desc'))
-    else:
-        # Default: sort by name ascending (case-insensitive)
-        exact_results_sorted = sorted(exact_results, key=lambda x: x.name.lower())
-    
     # Convert exact results to the expected format with phrase-aware scoring
     exact_results_with_scores = []
-    for center in exact_results_sorted:
+    for center in exact_results:
         # Get tags for this diving center for scoring
         center_tags = []
         if hasattr(center, 'tags') and center.tags:
@@ -233,6 +221,41 @@ def search_diving_centers_with_fuzzy(query: str, exact_results: List[DivingCente
             'country_contains': False, # No longer used
             'region_contains': False # No longer used
         })
+        
+    # Sort exact results with scores according to the specified sort criteria
+    if sort_by == 'name':
+        exact_results_with_scores.sort(key=lambda x: x['center'].name.lower(), reverse=(sort_order == 'desc'))
+    elif sort_by == 'created_at':
+        exact_results_with_scores.sort(key=lambda x: x['center'].created_at, reverse=(sort_order == 'desc'))
+    elif sort_by == 'updated_at':
+        exact_results_with_scores.sort(key=lambda x: x['center'].updated_at, reverse=(sort_order == 'desc'))
+    elif sort_by == 'view_count':
+        exact_results_with_scores.sort(key=lambda x: x['center'].view_count, reverse=(sort_order == 'desc'))
+    elif sort_by == 'average_rating':
+        center_ids = [result['center'].id for result in exact_results_with_scores]
+        ratings_map = {}
+        if center_ids:
+            from app.models import CenterRating
+            ratings_data = db.query(
+                CenterRating.diving_center_id,
+                func.avg(CenterRating.score).label("avg_rating")
+            ).filter(CenterRating.diving_center_id.in_(center_ids)).group_by(CenterRating.diving_center_id).all()
+            ratings_map = {row[0]: float(row[1]) if row[1] is not None else 0.0 for row in ratings_data}
+        exact_results_with_scores.sort(key=lambda x: ratings_map.get(x['center'].id, 0.0), reverse=(sort_order == 'desc'))
+    elif sort_by == 'comment_count':
+        center_ids = [result['center'].id for result in exact_results_with_scores]
+        comments_map = {}
+        if center_ids:
+            from app.models import CenterComment
+            comments_data = db.query(
+                CenterComment.diving_center_id,
+                func.count(CenterComment.id).label("comment_count")
+            ).filter(CenterComment.diving_center_id.in_(center_ids)).group_by(CenterComment.diving_center_id).all()
+            comments_map = {row[0]: row[1] or 0 for row in comments_data}
+        exact_results_with_scores.sort(key=lambda x: comments_map.get(x['center'].id, 0), reverse=(sort_order == 'desc'))
+    else:
+        # Default fallback (e.g. when sorting by relevance / sort_by is None): sort by score descending
+        exact_results_with_scores.sort(key=lambda x: x['score'], reverse=True)
     
     # If we have enough exact results and no fuzzy search needed, return them
     if len(exact_results) >= 10:
@@ -288,17 +311,6 @@ def search_diving_centers_with_fuzzy(query: str, exact_results: List[DivingCente
     
     # Combine exact and fuzzy results
     final_results = []
-    
-    # Sort exact results according to the specified sort criteria
-    if sort_by == 'name':
-        exact_results_sorted = sorted(exact_results, key=lambda x: x.name.lower(), reverse=(sort_order == 'desc'))
-    elif sort_by == 'created_at':
-        exact_results_sorted = sorted(exact_results, key=lambda x: x.created_at, reverse=(sort_order == 'desc'))
-    elif sort_by == 'updated_at':
-        exact_results_sorted = sorted(exact_results, key=lambda x: x.updated_at, reverse=(sort_order == 'desc'))
-    else:
-        # Default: sort by name ascending (case-insensitive)
-        exact_results_sorted = sorted(exact_results, key=lambda x: x.name.lower())
     
     # Add scored exact results first
     final_results.extend(exact_results_with_scores)
@@ -795,12 +807,14 @@ async def get_diving_centers(
     # Apply dynamic sorting based on parameters
     if sort_by:
         # All valid sort fields (including admin-only ones)
-        # Exclude comment_count if reviews are disabled
+        # Exclude comment_count and rating if reviews are disabled
         valid_sort_fields = {
             'name', 'view_count', 'created_at', 'updated_at', 'country', 'region', 'city'
         }
         if reviews_enabled:
             valid_sort_fields.add('comment_count')
+            valid_sort_fields.add('rating')
+            valid_sort_fields.add('average_rating')
         
         if sort_by not in valid_sort_fields:
             raise HTTPException(
@@ -818,6 +832,17 @@ async def get_diving_centers(
         # Apply sorting based on field
         if sort_by == 'name':
             sort_field = func.lower(DivingCenter.name)
+        elif sort_by in ['rating', 'average_rating']:
+            ratings_sort_subquery = db.query(
+                CenterRating.diving_center_id,
+                func.avg(CenterRating.score).label('avg_rating')
+            ).group_by(CenterRating.diving_center_id).subquery()
+            
+            query = query.outerjoin(
+                ratings_sort_subquery,
+                DivingCenter.id == ratings_sort_subquery.c.diving_center_id
+            )
+            sort_field = ratings_sort_subquery.c.avg_rating
         elif sort_by == 'view_count':
             # Only admin users can sort by view_count
             if not current_user or not current_user.is_admin:
@@ -921,7 +946,7 @@ async def get_diving_centers(
             db, 
             similarity_threshold=UNIFIED_TYPO_TOLERANCE['overall_threshold'], 
             max_fuzzy_results=10,
-            sort_by=sort_by,
+            sort_by=sort_by if sort_by != 'name' else None,
             sort_order=sort_order
         )
         

--- a/backend/app/routers/system.py
+++ b/backend/app/routers/system.py
@@ -1050,7 +1050,7 @@ async def get_growth_data(
                 "end_date": now.date().isoformat()
             }
         
-        # OPTIMIZATION: Query all items once instead of per date point (5 queries total vs 5*N queries)
+        # OPTIMIZATION: Query all items once instead of per date point (6 queries total vs 6*N queries)
         # Get all created_at dates for each entity type and sort them for efficient counting
         dive_sites_dates = sorted([
             item[0].date() for item in db.query(DiveSite.created_at).all()
@@ -1074,6 +1074,10 @@ async def get_growth_data(
             item[0].date() for item in db.query(ParsedDiveTrip.created_at).all()
             if item[0] and item[0].date()
         ])
+        users_dates = sorted([
+            item[0].date() for item in db.query(User.created_at).all()
+            if item[0] and item[0].date()
+        ])
         
         # Helper function to count items <= date using binary search
         def count_up_to_date(sorted_dates, target_date):
@@ -1087,7 +1091,8 @@ async def get_growth_data(
             "diving_centers": [],
             "dives": [],
             "dive_routes": [],
-            "dive_trips": []
+            "dive_trips": [],
+            "users": []
         }
         
         for date_point in date_points:
@@ -1097,6 +1102,7 @@ async def get_growth_data(
             dives_count = count_up_to_date(dives_dates, date_point)
             dive_routes_count = count_up_to_date(dive_routes_dates, date_point)
             dive_trips_count = count_up_to_date(dive_trips_dates, date_point)
+            users_count = count_up_to_date(users_dates, date_point)
             
             growth_data["dive_sites"].append({
                 "date": date_point.isoformat(),
@@ -1118,6 +1124,10 @@ async def get_growth_data(
                 "date": date_point.isoformat(),
                 "count": dive_trips_count
             })
+            growth_data["users"].append({
+                "date": date_point.isoformat(),
+                "count": users_count
+            })
         
         # Calculate growth rates using data already collected (no duplicate queries)
         if len(date_points) >= 2:
@@ -1136,12 +1146,16 @@ async def get_growth_data(
             dive_trips_start = growth_data["dive_trips"][0]["count"]
             dive_trips_end = growth_data["dive_trips"][-1]["count"]
             
+            users_start = growth_data["users"][0]["count"]
+            users_end = growth_data["users"][-1]["count"]
+            
             growth_rates = {
                 "dive_sites": calculate_growth_rate(dive_sites_start, dive_sites_end),
                 "diving_centers": calculate_growth_rate(diving_centers_start, diving_centers_end),
                 "dives": calculate_growth_rate(dives_start, dives_end),
                 "dive_routes": calculate_growth_rate(dive_routes_start, dive_routes_end),
-                "dive_trips": calculate_growth_rate(dive_trips_start, dive_trips_end)
+                "dive_trips": calculate_growth_rate(dive_trips_start, dive_trips_end),
+                "users": calculate_growth_rate(users_start, users_end)
             }
         else:
             growth_rates = {
@@ -1149,7 +1163,8 @@ async def get_growth_data(
                 "diving_centers": 0.0,
                 "dives": 0.0,
                 "dive_routes": 0.0,
-                "dive_trips": 0.0
+                "dive_trips": 0.0,
+                "users": 0.0
             }
         
         return {

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -1346,6 +1346,7 @@ class GrowthDataResponse(BaseModel):
     dives: List[GrowthDataPoint]
     dive_routes: List[GrowthDataPoint]
     dive_trips: List[GrowthDataPoint]
+    users: Optional[List[GrowthDataPoint]] = None
 
 
 class GrowthRatesResponse(BaseModel):
@@ -1355,6 +1356,7 @@ class GrowthRatesResponse(BaseModel):
     dives: float
     dive_routes: float
     dive_trips: float
+    users: Optional[float] = 0.0
 
 
 class GrowthResponse(BaseModel):

--- a/frontend/src/components/ResponsiveFilterBar.jsx
+++ b/frontend/src/components/ResponsiveFilterBar.jsx
@@ -256,6 +256,13 @@ const ResponsiveFilterBar = ({
     if (filters.buddy_id) {
       active.push({ key: 'buddy_id', label: 'Buddy', value: `User #${filters.buddy_id}` });
     }
+    if (filters.created_by_username) {
+      active.push({
+        key: 'created_by_username',
+        label: 'Creator',
+        value: filters.created_by_username,
+      });
+    }
     if (filters.country) active.push({ key: 'country', label: 'Country', value: filters.country });
     if (filters.region) active.push({ key: 'region', label: 'Region', value: filters.region });
     if (filters.difficulty_code) {
@@ -693,14 +700,32 @@ const ResponsiveFilterBar = ({
                   <UserSearchDropdown
                     label='User/Owner'
                     placeholder='Search users...'
-                    value={{ id: filters.owner_id, name: filters.owner_name }}
+                    value={{ id: filters.owner_id, name: filters.username }}
                     onChange={user => {
                       if (user) {
                         onFilterChange('owner_id', user.id);
-                        onFilterChange('owner_name', user.name);
+                        onFilterChange('username', user.username);
                       } else {
                         onFilterChange('owner_id', '');
-                        onFilterChange('owner_name', '');
+                        onFilterChange('username', '');
+                      }
+                    }}
+                  />
+                )}
+
+                {/* Creator Filter - Searchable for dive sites page */}
+                {pageType === 'dive-sites' && (
+                  <UserSearchDropdown
+                    label='Owner/Creator'
+                    placeholder='Search creators...'
+                    value={{ id: filters.created_by_id, name: filters.created_by_username }}
+                    onChange={user => {
+                      if (user) {
+                        onFilterChange('created_by_id', user.id);
+                        onFilterChange('created_by_username', user.username);
+                      } else {
+                        onFilterChange('created_by_id', '');
+                        onFilterChange('created_by_username', '');
                       }
                     }}
                   />
@@ -1138,14 +1163,33 @@ const ResponsiveFilterBar = ({
                 <UserSearchDropdown
                   label='User/Owner'
                   placeholder='Search users...'
-                  value={{ id: filters.owner_id, name: filters.owner_name }}
+                  value={{ id: filters.owner_id, name: filters.username }}
                   onChange={user => {
                     if (user) {
                       onFilterChange('owner_id', user.id);
-                      onFilterChange('owner_name', user.name);
+                      onFilterChange('username', user.username);
                     } else {
                       onFilterChange('owner_id', '');
-                      onFilterChange('owner_name', '');
+                      onFilterChange('username', '');
+                    }
+                  }}
+                />
+              )}
+
+              {/* Creator Filter - Searchable for dive sites page (mobile) */}
+
+              {pageType === 'dive-sites' && (
+                <UserSearchDropdown
+                  label='Owner/Creator'
+                  placeholder='Search creators...'
+                  value={{ id: filters.created_by_id, name: filters.created_by_username }}
+                  onChange={user => {
+                    if (user) {
+                      onFilterChange('created_by_id', user.id);
+                      onFilterChange('created_by_username', user.username);
+                    } else {
+                      onFilterChange('created_by_id', '');
+                      onFilterChange('created_by_username', '');
                     }
                   }}
                 />

--- a/frontend/src/components/ui/UserSearchDropdown.jsx
+++ b/frontend/src/components/ui/UserSearchDropdown.jsx
@@ -42,8 +42,8 @@ export const UserSearchDropdown = ({
     <AutocompleteDropdown
       label={label}
       placeholder={placeholder}
-      value={value}
-      onChange={selectedUser => onChange(selectedUser ? selectedUser.username : '')}
+      value={value ? (typeof value === 'object' ? value.name || value.username || '' : value) : ''}
+      onChange={selectedUser => onChange(selectedUser)}
       fetchData={fetchUsers}
       renderItem={renderUserItem}
       keyExtractor={user => user.id}

--- a/frontend/src/pages/AdminGrowthVisualizations.jsx
+++ b/frontend/src/pages/AdminGrowthVisualizations.jsx
@@ -85,6 +85,7 @@ const AdminGrowthVisualizations = () => {
 
   // Chart colors constants
   const CHART_COLORS = {
+    users: '#f43f5e',
     dive_sites: '#0072B2',
     diving_centers: '#10b981',
     dives: '#f59e0b',
@@ -263,6 +264,8 @@ const AdminGrowthVisualizations = () => {
         {/* Growth Charts */}
         {growthData && !isLoading && growthData.growth_data && (
           <>
+            {growthData.growth_data.users &&
+              renderChart(growthData.growth_data.users, 'User Growth', CHART_COLORS.users, 'users')}
             {growthData.growth_data.dive_sites &&
               renderChart(
                 growthData.growth_data.dive_sites,

--- a/frontend/src/pages/DiveRoutes.jsx
+++ b/frontend/src/pages/DiveRoutes.jsx
@@ -43,8 +43,17 @@ const DiveRoutes = () => {
 
   // State for filters
   const [search, setSearch] = useState(searchParams.get('search') || '');
+  const [debouncedSearch, setDebouncedSearch] = useState(searchParams.get('search') || '');
   const [routeType, setRouteType] = useState(searchParams.get('route_type') || '');
   const [poiTypes, setPoiTypes] = useState(searchParams.getAll('poi_types') || []);
+
+  // Debounce search input for React Query key
+  useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      setDebouncedSearch(search);
+    }, 500); // 500ms debounce
+    return () => clearTimeout(timeoutId);
+  }, [search]);
 
   // Sorting
   const { sortBy, sortOrder, handleSortChange, resetSorting } = useSorting('dive-routes');
@@ -71,10 +80,10 @@ const DiveRoutes = () => {
     hasNextPage,
     error,
   } = useInfiniteQuery(
-    ['dive-routes', search, routeType, poiTypes, pageSize, sortBy, sortOrder],
+    ['dive-routes', debouncedSearch, routeType, poiTypes, pageSize, sortBy, sortOrder],
     ({ pageParam = 1 }) =>
       getDiveRoutes({
-        search,
+        search: debouncedSearch,
         route_type: routeType,
         poi_types: poiTypes,
         page: pageParam,
@@ -109,12 +118,10 @@ const DiveRoutes = () => {
     if (poiTypes.length > 0) {
       poiTypes.forEach(t => urlParams.append('poi_types', t));
     }
-    if (sortBy) urlParams.append('sort_by', sortBy);
-    if (sortOrder) urlParams.append('sort_order', sortOrder);
     if (viewMode !== 'list') urlParams.append('view', viewMode);
 
     setSearchParams(urlParams, { replace: true });
-  }, [search, routeType, poiTypes, sortBy, sortOrder, viewMode, setSearchParams]);
+  }, [search, routeType, poiTypes, viewMode, setSearchParams]);
 
   const handleSearchChange = value => {
     setSearch(value);

--- a/frontend/src/pages/DiveSites.jsx
+++ b/frontend/src/pages/DiveSites.jsx
@@ -98,6 +98,8 @@ const DiveSites = () => {
       difficulty_code: searchParams.get('difficulty_code') || '',
       exclude_unspecified_difficulty: searchParams.get('exclude_unspecified_difficulty') === 'true',
       min_rating: searchParams.get('min_rating') || '',
+      created_by_id: '',
+      created_by_username: searchParams.get('created_by_username') || '',
       tag_ids: searchParams
         .getAll('tag_ids')
         .map(id => parseInt(id))
@@ -191,6 +193,10 @@ const DiveSites = () => {
         newSearchParams.set('min_rating', newFilters.min_rating.trim());
       }
 
+      if (newFilters.created_by_username && newFilters.created_by_username.trim()) {
+        newSearchParams.set('created_by_username', newFilters.created_by_username.trim());
+      }
+
       if (newFilters.tag_ids && Array.isArray(newFilters.tag_ids)) {
         newFilters.tag_ids.forEach(tagId => {
           if (tagId && tagId.toString && tagId.toString().trim()) {
@@ -261,6 +267,10 @@ const DiveSites = () => {
         newSearchParams.set('min_rating', newFilters.min_rating.trim());
       }
 
+      if (newFilters.created_by_username && newFilters.created_by_username.trim()) {
+        newSearchParams.set('created_by_username', newFilters.created_by_username.trim());
+      }
+
       if (newFilters.tag_ids && Array.isArray(newFilters.tag_ids)) {
         newFilters.tag_ids.forEach(tagId => {
           if (tagId && tagId.toString && tagId.toString().trim()) {
@@ -294,6 +304,8 @@ const DiveSites = () => {
     filters.difficulty_code,
     filters.exclude_unspecified_difficulty,
     filters.min_rating,
+    filters.created_by_id,
+    filters.created_by_username,
     filters.tag_ids,
     filters.my_dive_sites,
     immediateUpdateURL,
@@ -348,6 +360,7 @@ const DiveSites = () => {
       filters.difficulty_code,
       filters.exclude_unspecified_difficulty,
       filters.min_rating,
+      filters.created_by_username,
       filters.tag_ids,
       filters.my_dive_sites,
       pageSize,
@@ -366,6 +379,8 @@ const DiveSites = () => {
       if (filters.min_rating) params.append('min_rating', filters.min_rating);
       if (debouncedSearchTerms.country) params.append('country', debouncedSearchTerms.country);
       if (debouncedSearchTerms.region) params.append('region', debouncedSearchTerms.region);
+      if (filters.created_by_username)
+        params.append('created_by_username', filters.created_by_username);
 
       // Add sorting parameters
       if (sortBy) params.append('sort_by', sortBy);
@@ -460,6 +475,8 @@ const DiveSites = () => {
       region: '',
       tag_ids: [],
       my_dive_sites: false,
+      created_by_id: '',
+      created_by_username: '',
     };
     setFilters(clearedFilters);
     resetSorting();
@@ -556,6 +573,7 @@ const DiveSites = () => {
     if (filters.difficulty_code) count++;
     if (filters.exclude_unspecified_difficulty) count++;
     if (filters.min_rating) count++;
+    if (filters.created_by_username) count++;
     if (filters.tag_ids && filters.tag_ids.length > 0) count++;
     return count;
   };

--- a/frontend/src/pages/DiveSites.jsx
+++ b/frontend/src/pages/DiveSites.jsx
@@ -300,6 +300,18 @@ const DiveSites = () => {
     viewMode,
   ]);
 
+  // Debounce search terms for React Query key
+  useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      setDebouncedSearchTerms({
+        search_query: filters.search_query,
+        country: filters.country,
+        region: filters.region,
+      });
+    }, 500); // 500ms debounce
+    return () => clearTimeout(timeoutId);
+  }, [filters.search_query, filters.country, filters.region]);
+
   // Invalidate query when sorting changes to ensure fresh data
   useEffect(() => {
     queryClient.invalidateQueries(['dive-sites']);

--- a/frontend/src/pages/DiveTrips.jsx
+++ b/frontend/src/pages/DiveTrips.jsx
@@ -22,7 +22,7 @@ import {
   Compass,
   Plus,
 } from 'lucide-react';
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { useInfiniteQuery } from 'react-query';
 import { Link, useNavigate, useSearchParams, useLocation } from 'react-router-dom';
 
@@ -81,20 +81,96 @@ const DiveTrips = () => {
   const { compactLayout, handleDisplayOptionChange } = useCompactLayout();
 
   const [showFilters, setShowFilters] = useState(false);
-  const [filters, setFilters] = useState({
-    start_date: '',
-    end_date: '',
-    diving_center_id: '',
-    dive_site_id: '',
-    trip_status: '',
-    min_price: '',
-    max_price: '',
-    difficulty_code: '',
-    exclude_unspecified_difficulty: false,
-    search_query: '',
-    country: '',
-    region: '',
+  const getInitialFilters = () => {
+    return {
+      start_date: searchParams.get('start_date') || '',
+      end_date: searchParams.get('end_date') || '',
+      diving_center_id: searchParams.get('diving_center_id') || '',
+      dive_site_id: searchParams.get('dive_site_id') || '',
+      trip_status: searchParams.get('trip_status') || '',
+      min_price: searchParams.get('min_price') || '',
+      max_price: searchParams.get('max_price') || '',
+      difficulty_code: searchParams.get('difficulty_code') || '',
+      exclude_unspecified_difficulty: searchParams.get('exclude_unspecified_difficulty') === 'true',
+      search_query: searchParams.get('search') || '',
+      country: searchParams.get('country') || '',
+      region: searchParams.get('region') || '',
+    };
+  };
+
+  const [filters, setFilters] = useState(getInitialFilters);
+
+  const [debouncedSearchTerms, setDebouncedSearchTerms] = useState({
+    search_query: getInitialFilters().search_query,
+    country: getInitialFilters().country,
+    region: getInitialFilters().region,
   });
+
+  // Debounced URL update for search inputs
+  const debouncedUpdateURL = useCallback(
+    (() => {
+      let timeoutId;
+      return (newFilters, newViewMode) => {
+        clearTimeout(timeoutId);
+        timeoutId = setTimeout(() => {
+          const newSearchParams = new URLSearchParams();
+
+          // Add view mode
+          if (newViewMode && newViewMode !== 'list') {
+            newSearchParams.set('view', newViewMode);
+          }
+
+          // Add filters
+          Object.entries(newFilters).forEach(([key, value]) => {
+            if (value !== null && value !== undefined && value !== '' && value !== false) {
+              const urlKey = key === 'search_query' ? 'search' : key;
+              newSearchParams.set(urlKey, value.toString());
+            }
+          });
+
+          // Update URL without triggering a page reload
+          navigate(`?${newSearchParams.toString()}`, { replace: true });
+        }, 800); // 800ms debounce delay
+      };
+    })(),
+    [navigate]
+  );
+
+  // Immediate URL update for non-search filters
+  const immediateUpdateURL = useCallback(
+    (newFilters, newViewMode) => {
+      const newSearchParams = new URLSearchParams();
+
+      // Add view mode
+      if (newViewMode && newViewMode !== 'list') {
+        newSearchParams.set('view', newViewMode);
+      }
+
+      // Add filters
+      Object.entries(newFilters).forEach(([key, value]) => {
+        if (value !== null && value !== undefined && value !== '' && value !== false) {
+          const urlKey = key === 'search_query' ? 'search' : key;
+          newSearchParams.set(urlKey, value.toString());
+        }
+      });
+
+      // Update URL without triggering a page reload
+      navigate(`?${newSearchParams.toString()}`, { replace: true });
+    },
+    [navigate]
+  );
+
+  // Debounce search terms for React Query key
+  useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      setDebouncedSearchTerms({
+        search_query: filters.search_query,
+        country: filters.country,
+        region: filters.region,
+      });
+    }, 500); // 500ms debounce
+    return () => clearTimeout(timeoutId);
+  }, [filters.search_query, filters.country, filters.region]);
   // Sorting
   const { sortBy, sortOrder, handleSortChange, resetSorting, getSortParams } =
     useSorting('dive-trips');
@@ -268,7 +344,18 @@ const DiveTrips = () => {
   } = useInfiniteQuery(
     [
       'parsedTrips',
-      filters,
+      debouncedSearchTerms.search_query,
+      debouncedSearchTerms.country,
+      debouncedSearchTerms.region,
+      filters.start_date,
+      filters.end_date,
+      filters.diving_center_id,
+      filters.dive_site_id,
+      filters.trip_status,
+      filters.min_price,
+      filters.max_price,
+      filters.difficulty_code,
+      filters.exclude_unspecified_difficulty,
       sortBy,
       sortOrder,
       sortBy === 'distance' ? userLocation : null,
@@ -277,20 +364,17 @@ const DiveTrips = () => {
     ({ pageParam = 1 }) => {
       // Route search terms intelligently (only for authenticated users)
       const { search_query, location_query } = user
-        ? routeSearchTerms(filters.search_query)
+        ? routeSearchTerms(debouncedSearchTerms.search_query)
         : { search_query: '', location_query: '' };
 
       // Only include filters that have actual values
       const validFilters = {};
       Object.entries(filters).forEach(([key, value]) => {
-        if (key === 'search_query') {
-          // Handle search_query separately since we're routing it
-          // Only include search queries for authenticated users
-          if (user) {
-            if (search_query) validFilters.search_query = search_query;
-            if (location_query) validFilters.location_query = location_query;
-          }
-        } else if (value !== null && value !== undefined && value !== '') {
+        if (key === 'search_query' || key === 'country' || key === 'region') {
+          // Handle these separately using debounced versions
+          return;
+        }
+        if (value !== null && value !== undefined && value !== '') {
           // For strings, also check for whitespace-only
           if (typeof value === 'string') {
             if (value.trim() !== '') {
@@ -302,6 +386,14 @@ const DiveTrips = () => {
           }
         }
       });
+
+      // Add debounced search and location queries
+      if (user) {
+        if (search_query) validFilters.search_query = search_query;
+        if (location_query) validFilters.location_query = location_query;
+      }
+      if (debouncedSearchTerms.country) validFilters.country = debouncedSearchTerms.country;
+      if (debouncedSearchTerms.region) validFilters.region = debouncedSearchTerms.region;
 
       // Add sorting parameters and pagination
       const sortParams = getSortParams();
@@ -419,14 +511,18 @@ const DiveTrips = () => {
   }, [displayTrips]);
 
   const handleFilterChange = (key, value) => {
-    setFilters(prev => ({
-      ...prev,
-      [key]: value,
-    }));
+    const newFilters = { ...filters, [key]: value };
+    setFilters(newFilters);
+
+    if (key === 'search_query' || key === 'country' || key === 'region') {
+      debouncedUpdateURL(newFilters, viewMode);
+    } else {
+      immediateUpdateURL(newFilters, viewMode);
+    }
   };
 
   const clearFilters = () => {
-    setFilters({
+    const clearedFilters = {
       start_date: '',
       end_date: '',
       diving_center_id: '',
@@ -439,7 +535,9 @@ const DiveTrips = () => {
       search_query: '',
       country: '',
       region: '',
-    });
+    };
+    setFilters(clearedFilters);
+    immediateUpdateURL(clearedFilters, viewMode);
   };
 
   const toggleFilters = () => {

--- a/frontend/src/pages/Dives.jsx
+++ b/frontend/src/pages/Dives.jsx
@@ -384,7 +384,7 @@ const Dives = () => {
       setDebouncedSearchTerms({
         search: filters.search,
       });
-    }, 800);
+    }, 500);
     return () => clearTimeout(timeoutId);
   }, [filters.search]);
 

--- a/frontend/src/pages/DivingCenters.jsx
+++ b/frontend/src/pages/DivingCenters.jsx
@@ -87,6 +87,17 @@ const DivingCenters = () => {
     name: getInitialFilters().name,
   });
 
+  // Debounce search terms for React Query key
+  useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      setDebouncedSearchTerms({
+        search: filters.search,
+        name: filters.name,
+      });
+    }, 500); // 500ms debounce
+    return () => clearTimeout(timeoutId);
+  }, [filters.search, filters.name]);
+
   const [activeFiltersCount, setActiveFiltersCount] = useState(0);
 
   // Debounced URL update for search inputs
@@ -108,17 +119,12 @@ const DivingCenters = () => {
             if (value) newSearchParams.set(key, value.toString());
           });
 
-          // Add sorting parameters
-          const sortParams = getSortParams();
-          if (sortParams.sort_by) newSearchParams.set('sort_by', sortParams.sort_by);
-          if (sortParams.sort_order) newSearchParams.set('sort_order', sortParams.sort_order);
-
           // Update URL without triggering a page reload
           navigate(`?${newSearchParams.toString()}`, { replace: true });
         }, 800); // 800ms debounce delay
       };
     })(),
-    [navigate, sortBy, sortOrder]
+    [navigate]
   );
 
   // Immediate URL update for non-search filters
@@ -136,15 +142,10 @@ const DivingCenters = () => {
         if (value) newSearchParams.set(key, value.toString());
       });
 
-      // Add sorting parameters
-      const sortParams = getSortParams();
-      if (sortParams.sort_by) newSearchParams.set('sort_by', sortParams.sort_by);
-      if (sortParams.sort_order) newSearchParams.set('sort_order', sortParams.sort_order);
-
       // Update URL without triggering a page reload
       navigate(`?${newSearchParams.toString()}`, { replace: true });
     },
-    [navigate, sortBy, sortOrder]
+    [navigate]
   );
 
   // Map sort labels to API fields
@@ -174,7 +175,19 @@ const DivingCenters = () => {
     hasNextPage,
     error,
   } = useInfiniteQuery(
-    ['diving-centers', filters, sortBy, sortOrder, pageSize],
+    [
+      'diving-centers',
+      debouncedSearchTerms.search,
+      debouncedSearchTerms.name,
+      filters.min_rating,
+      filters.services,
+      filters.country,
+      filters.region,
+      filters.city,
+      sortBy,
+      sortOrder,
+      pageSize,
+    ],
     ({ pageParam = 1 }) => {
       const params = new URLSearchParams();
       params.append('page', pageParam.toString());
@@ -185,9 +198,13 @@ const DivingCenters = () => {
       params.append('sort_order', sortOrder);
 
       // Add filters
-      Object.entries(filters).forEach(([key, value]) => {
-        if (value) params.append(key, value.toString());
-      });
+      if (debouncedSearchTerms.search) params.append('search', debouncedSearchTerms.search);
+      if (debouncedSearchTerms.name) params.append('name', debouncedSearchTerms.name);
+      if (filters.min_rating) params.append('min_rating', filters.min_rating.toString());
+      if (filters.services) params.append('services', filters.services.toString());
+      if (filters.country) params.append('country', filters.country.toString());
+      if (filters.region) params.append('region', filters.region.toString());
+      if (filters.city) params.append('city', filters.city.toString());
 
       return api.get(`/api/v1/diving-centers/?${params.toString()}`).then(res => res.data);
     },
@@ -245,7 +262,6 @@ const DivingCenters = () => {
 
     // Update URL - use debounced for search/name, immediate for others
     if (name === 'search' || name === 'name') {
-      setDebouncedSearchTerms(prev => ({ ...prev, [name]: value }));
       debouncedUpdateURL(newFilters, viewMode);
     } else {
       immediateUpdateURL(newFilters, viewMode);
@@ -297,13 +313,19 @@ const DivingCenters = () => {
     immediateUpdateURL(newFilters, viewMode);
   };
 
-  const sortOptions = [
-    { value: 'name', label: 'Name', defaultOrder: 'asc' },
-    { value: 'city', label: 'City', defaultOrder: 'asc' },
-    { value: 'country', label: 'Country', defaultOrder: 'asc' },
-    { value: 'rating', label: 'Rating', defaultOrder: 'desc' },
-    { value: 'created_at', label: 'Date Added', defaultOrder: 'desc' },
-  ];
+  const sortOptions = useMemo(() => {
+    const baseOptions = [
+      { value: 'name', label: 'Name', defaultOrder: 'asc' },
+      { value: 'city', label: 'City', defaultOrder: 'asc' },
+      { value: 'country', label: 'Country', defaultOrder: 'asc' },
+      { value: 'created_at', label: 'Date Added', defaultOrder: 'desc' },
+    ];
+    if (reviewsEnabled) {
+      // Insert rating after country
+      baseOptions.splice(3, 0, { value: 'rating', label: 'Rating', defaultOrder: 'desc' });
+    }
+    return baseOptions;
+  }, [reviewsEnabled]);
 
   return (
     <>
@@ -341,7 +363,10 @@ const DivingCenters = () => {
               <DivingCentersDesktopSearchBar
                 searchValue={filters.search}
                 onSearchChange={val => handleFilterChange('search', val.target.value)}
-                onSearchSelect={() => {}}
+                onSearchSelect={selectedItem => {
+                  handleFilterChange('search', selectedItem.name);
+                }}
+                data={divingCenters || []}
               />
             </div>
 


### PR DESCRIPTION
## Summary
This pull request introduces comprehensive optimizations, state debouncing, and consistency fixes across the Divemap search pages, introduces a new user-growth analytics chart to the admin dashboard, and implements a searchable Owner/Creator filter for dive sites.

---

## 🛠️ Changes Made

### 🔍 1. Search Debouncing & state Harmonization (All Listing Pages)
* **`/dive-sites`**: Fixed a dead state hook where typing would never update `debouncedSearchTerms`. Introduced a correct debounced `useEffect` that synchronizes search and metadata inputs 500ms after typing pauses, triggering clean React Query fetches to the backend.
* **`/diving-centers`**: Added proper debounce state updates, replacing immediate API queries on every single keystroke.
* **`/dive-routes`**: Added `debouncedSearch` state and synced query triggers. Removed default sort parameters from cluttering the active URL string.
* **`/dive-trips`**: Added complete URL-state persistence and query parameters sync, making trip search states fully copy-paste friendly.
* **`/dives`**: Unified search debounce interval to `500ms` for seamless cross-page snappiness.

### 🌟 2. Relevance-based Matching & Dynamic Sorting Fallback (Backend & Frontend)
* **Relevance Fallback (`/dive-sites` & `/diving-centers`)**: Updated backend controllers to calculate real phrase-aware matching scores for exact database results. In active searches, the engine now automatically falls back to **relevance score descending** by default (instead of sorting alphabetically by name). This ensures 100% exact matches consistently rank first.
* **Settings-Driven UI Filtering (`/diving-centers`)**: Configured the frontend `sortOptions` to monitor whether center reviews are enabled, dynamically hiding the "Rating" sorting choice from the UI when disabled, while preserving clean `400 Bad Request` API validation on the backend.

### 👤 3. New Owner/Creator Filters (`/dive-sites` & `/dives`)
* Added searchable **"Owner/Creator"** filters to both layouts using the `UserSearchDropdown` input.
* Refactored `UserSearchDropdown` to propagate full user objects down so caller elements on both `/dives` and `/dive-sites` correctly resolve selection IDs and username details.
* Implemented clean query parameter sync so visiting `?created_by_username=admin` cleanly initializes and displays the search text without URL clutter.

### 📈 4. Admin User Growth Visualizations (`/admin/growth-visualizations`)
* Added a new **"User Growth"** area-spline chart utilizing Pydantic growth schemas and daily/weekly cumulative counting in the backend system router.
* Integrated the rose-pink color scheme for User Growth, rendering it at the top of the growth dashboard.

---

## 🧪 Testing

### Manual Verification
All changes were thoroughly tested in a live browser session using Chrome DevTools:
* **Dropdown Autocomplete:** Verified that typing in `/diving-centers` or `/dive-sites` displays the correct autocomplete results with accurate highlight matches instantly.
* **Relevance Ranking:** Verified searching `"Kalymnos"` or `"Naxos"` correctly ranks 100% matches first.
* **URL Persistence:** Confirmed filters and searches elegantly sync with browser address bar state.
* **Admin Verification:** Confirmed that the admin-level User Growth chart displays correct cumulative numbers and percentage rates over 1-week, 1-month, 3-month, 6-month, and 1-year intervals.

### Automated Tests
* Ran `make lint-frontend` — **Passed with 0 errors/warnings**.
* Executed the integration test suite — **All main page tests passed with 0 errors**.

---

## 📌 Related Issues
* Resolves the broken autocomplete search on `/dive-sites`.
* Resolves alphabetical sort override bug on active searches.
* Resolves missing "User/Owner" filter on `/dive-sites` and broken mapping on `/dives`.
* Implements the requested Admin User Growth visualization card.