### PR TITLE
Standardize calculator paddings and condense unit labels

### DIFF
--- a/frontend/src/components/calculators/BestMixCalculator.jsx
+++ b/frontend/src/components/calculators/BestMixCalculator.jsx
@@ -123,19 +123,19 @@ const BestMixCalculator = () => {
 
   return (
     <div className='bg-white rounded-xl shadow-md border border-gray-200 overflow-hidden flex flex-col h-full'>
-      <div className='p-3 sm:p-5 border-b border-gray-100 bg-emerald-50/30'>
-        <div className='flex items-center space-x-3'>
-          <div className='p-2 bg-emerald-600 rounded-lg text-white'>
+      <div className='p-4 border-b border-gray-100 bg-emerald-50/30'>
+        <div className='flex items-center space-x-2 sm:space-x-3'>
+          <div className='p-1.5 bg-emerald-600 rounded text-white hidden sm:block'>
             <Wind className='h-5 w-5 sm:h-6 sm:w-6' />
           </div>
-          <h2 className='text-lg sm:text-xl font-bold text-gray-900'>Best Gas Mix</h2>
+          <h2 className='text-base sm:text-xl font-bold text-gray-900'>Best Gas Mix</h2>
         </div>
-        <p className='mt-1 sm:mt-2 text-xs sm:text-sm text-gray-600'>
+        <p className='mt-1 text-xs sm:text-sm text-gray-600 hidden sm:block'>
           Calculate the ideal gas mix for your planned depth.
         </p>
       </div>
 
-      <div className='p-3 sm:p-6 flex-grow space-y-3 sm:space-y-6'>
+      <div className='p-4 flex-grow space-y-4'>
         <div>
           <label
             htmlFor='bestMixDepth'

--- a/frontend/src/components/calculators/GasFillPriceCalculator.jsx
+++ b/frontend/src/components/calculators/GasFillPriceCalculator.jsx
@@ -88,26 +88,26 @@ const GasFillPriceCalculator = () => {
 
   return (
     <div className='bg-white rounded-xl shadow-md border border-gray-200 overflow-hidden flex flex-col h-full'>
-      <div className='p-3 sm:p-5 border-b border-gray-100 bg-emerald-50/30'>
-        <div className='flex items-center space-x-3'>
-          <div className='p-2 bg-emerald-600 rounded-lg text-white'>
+      <div className='p-4 border-b border-gray-100 bg-emerald-50/30'>
+        <div className='flex items-center space-x-2 sm:space-x-3'>
+          <div className='p-1.5 bg-emerald-600 rounded text-white hidden sm:block'>
             <Coins className='h-5 w-5 sm:h-6 sm:w-6' />
           </div>
-          <h2 className='text-lg sm:text-xl font-bold text-gray-900'>Gas Fill Price</h2>
+          <h2 className='text-base sm:text-xl font-bold text-gray-900'>Gas Fill Price</h2>
         </div>
-        <p className='mt-1 sm:mt-2 text-xs sm:text-sm text-gray-600'>
+        <p className='mt-1 text-xs sm:text-sm text-gray-600 hidden sm:block'>
           Estimate the cost of a gas fill based on component prices.
         </p>
       </div>
 
-      <div className='p-3 sm:p-6 flex-grow space-y-3 sm:space-y-6'>
+      <div className='p-4 flex-grow space-y-4'>
         <div className='grid grid-cols-2 gap-2 sm:gap-4'>
           <div>
             <label
               htmlFor='tankSize'
               className='block text-xs sm:text-sm font-semibold text-gray-700 mb-1 sm:mb-2'
             >
-              Cylinder Size (Liters)
+              Cylinder Size (L)
             </label>
             <select
               id='tankSize'

--- a/frontend/src/components/calculators/GasPlanningCalculator.jsx
+++ b/frontend/src/components/calculators/GasPlanningCalculator.jsx
@@ -108,26 +108,26 @@ const GasPlanningCalculator = () => {
   return (
     <div className='bg-white rounded-xl shadow-md border border-gray-200 overflow-hidden flex flex-col h-full'>
       <div
-        className={`p-3 sm:p-5 border-b border-gray-100 ${
+        className={`p-4 border-b border-gray-100 ${
           planGasResult.isSafe ? 'bg-orange-50/30' : 'bg-red-50'
         }`}
       >
-        <div className='flex items-center space-x-3'>
+        <div className='flex items-center space-x-2 sm:space-x-3'>
           <div
-            className={`p-2 rounded-lg text-white ${
+            className={`p-1.5 rounded text-white hidden sm:block ${
               planGasResult.isSafe ? 'bg-orange-600' : 'bg-red-600'
             }`}
           >
             <Compass className='h-5 w-5 sm:h-6 sm:w-6' />
           </div>
-          <h2 className='text-lg sm:text-xl font-bold text-gray-900'>Gas Consumption</h2>
+          <h2 className='text-base sm:text-xl font-bold text-gray-900'>Gas Consumption</h2>
         </div>
-        <p className='mt-1 sm:mt-2 text-xs sm:text-sm text-gray-600'>
+        <p className='mt-1 text-xs sm:text-sm text-gray-600 hidden sm:block'>
           Estimate the total gas volume consumed for your planned depth and bottom time.
         </p>
       </div>
 
-      <div className='p-3 sm:p-6 flex-grow space-y-3 sm:space-y-6'>
+      <div className='p-4 flex-grow space-y-4'>
         <div className='grid grid-cols-2 gap-2 sm:gap-4'>
           <div>
             <label
@@ -151,7 +151,7 @@ const GasPlanningCalculator = () => {
               htmlFor='planTime'
               className='block text-xs sm:text-sm font-semibold text-gray-700 mb-1 sm:mb-2'
             >
-              Total Dive Time (minutes)
+              Total Dive Time (mins)
             </label>
             <input
               id='planTime'
@@ -164,36 +164,38 @@ const GasPlanningCalculator = () => {
           </div>
         </div>
 
-        <div>
-          <label
-            htmlFor='planSAC'
-            className='block text-xs sm:text-sm font-semibold text-gray-700 mb-1 sm:mb-2'
-          >
-            SAC Rate (L/min)
-          </label>
-          <input
-            id='planSAC'
-            type='number'
-            min='5'
-            {...register('sac', { valueAsNumber: true })}
-            className='w-full px-2 py-1.5 sm:px-3 sm:py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-orange-500 focus:border-orange-500 text-xs sm:text-sm'
-          />
-          {errors.sac && <p className='text-red-500 text-xs mt-1'>{errors.sac.message}</p>}
-        </div>
+        <div className='grid grid-cols-2 gap-2 sm:gap-4 items-end'>
+          <div>
+            <label
+              htmlFor='planSAC'
+              className='block text-xs sm:text-sm font-semibold text-gray-700 mb-1 sm:mb-2'
+            >
+              SAC Rate (L/min)
+            </label>
+            <input
+              id='planSAC'
+              type='number'
+              min='5'
+              {...register('sac', { valueAsNumber: true })}
+              className='w-full px-2 py-1.5 sm:px-3 sm:py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-orange-500 focus:border-orange-500 text-xs sm:text-sm'
+            />
+            {errors.sac && <p className='text-red-500 text-xs mt-1'>{errors.sac.message}</p>}
+          </div>
 
-        <div className='flex items-center p-2 sm:p-3 bg-gray-50 rounded-lg border border-gray-200'>
-          <input
-            id='advancedGasToggle'
-            type='checkbox'
-            {...register('isAdvanced')}
-            className='w-4 h-4 text-orange-600 border-gray-300 rounded focus:ring-orange-500 cursor-pointer'
-          />
-          <label
-            htmlFor='advancedGasToggle'
-            className='ml-2 text-xs sm:text-sm font-medium text-gray-700 cursor-pointer select-none'
-          >
-            Advanced/Tech Mode (Rule of Thirds)
-          </label>
+          <div className='flex items-center p-2 bg-gray-50 rounded-lg border border-gray-200 h-[34px] sm:h-[38px]'>
+            <input
+              id='advancedGasToggle'
+              type='checkbox'
+              {...register('isAdvanced')}
+              className='w-4 h-4 text-orange-600 border-gray-300 rounded focus:ring-orange-500 cursor-pointer'
+            />
+            <label
+              htmlFor='advancedGasToggle'
+              className='ml-2 text-xs font-semibold text-gray-700 cursor-pointer select-none'
+            >
+              Rule of Thirds (Tech)
+            </label>
+          </div>
         </div>
 
         <div className='grid grid-cols-2 gap-2 sm:gap-4'>
@@ -202,7 +204,7 @@ const GasPlanningCalculator = () => {
               htmlFor='planTankSize'
               className='block text-xs sm:text-sm font-semibold text-gray-700 mb-1 sm:mb-2'
             >
-              Cylinder Size (Liters)
+              Cylinder Size (L)
             </label>
             <select
               id='planTankSize'

--- a/frontend/src/components/calculators/ICDCalculator.jsx
+++ b/frontend/src/components/calculators/ICDCalculator.jsx
@@ -39,19 +39,19 @@ const ICDCalculator = () => {
 
   return (
     <div className='bg-white rounded-xl shadow-md border border-gray-200 overflow-hidden flex flex-col h-full'>
-      <div className='p-3 sm:p-5 border-b border-gray-100 bg-indigo-50/30'>
-        <div className='flex items-center space-x-3'>
-          <div className='p-2 bg-indigo-600 rounded-lg text-white'>
+      <div className='p-4 border-b border-gray-100 bg-indigo-50/30'>
+        <div className='flex items-center space-x-2 sm:space-x-3'>
+          <div className='p-1.5 bg-indigo-600 rounded text-white hidden sm:block'>
             <RefreshCw className='h-5 w-5 sm:h-6 sm:w-6' />
           </div>
-          <h2 className='text-lg sm:text-xl font-bold text-gray-900'>ICD Check (Gas Switch)</h2>
+          <h2 className='text-base sm:text-xl font-bold text-gray-900'>ICD Check (Gas Switch)</h2>
         </div>
-        <p className='mt-1 sm:mt-2 text-xs sm:text-sm text-gray-600'>
+        <p className='mt-1 text-xs sm:text-sm text-gray-600 hidden sm:block'>
           Check for Isobaric Counterdiffusion risk when switching from Trimix to another gas.
         </p>
       </div>
 
-      <div className='p-3 sm:p-6 flex-grow space-y-6'>
+      <div className='p-4 flex-grow space-y-4'>
         <div className='grid grid-cols-1 md:grid-cols-2 gap-6'>
           {/* Current Gas */}
           <div className='space-y-3'>

--- a/frontend/src/components/calculators/MinGasCalculator.jsx
+++ b/frontend/src/components/calculators/MinGasCalculator.jsx
@@ -101,20 +101,22 @@ const MinGasCalculator = () => {
 
   return (
     <div className='bg-white rounded-xl shadow-md border border-gray-200 overflow-hidden flex flex-col h-full'>
-      <div className='p-3 sm:p-5 border-b border-gray-100 bg-red-50/30'>
-        <div className='flex items-center space-x-3'>
-          <div className='p-2 bg-red-600 rounded-lg text-white'>
+      <div className='p-4 border-b border-gray-100 bg-red-50/30'>
+        <div className='flex items-center space-x-2 sm:space-x-3'>
+          <div className='p-1.5 bg-red-600 rounded text-white hidden sm:block'>
             <AlertTriangle className='h-5 w-5 sm:h-6 sm:w-6' />
           </div>
-          <h2 className='text-lg sm:text-xl font-bold text-gray-900'>Minimum Gas (Rock Bottom)</h2>
+          <h2 className='text-base sm:text-xl font-bold text-gray-900'>
+            Minimum Gas (Rock Bottom)
+          </h2>
         </div>
-        <p className='mt-1 sm:mt-2 text-xs sm:text-sm text-gray-600'>
+        <p className='mt-1 text-xs sm:text-sm text-gray-600 hidden sm:block'>
           Calculate the emergency reserve needed to share air with a buddy and ascend from the
           deepest part of the dive.
         </p>
       </div>
 
-      <div className='p-3 sm:p-6 flex-grow space-y-3 sm:space-y-6'>
+      <div className='p-4 flex-grow space-y-4'>
         <div className='grid grid-cols-2 gap-2 sm:gap-4'>
           <div>
             <label
@@ -260,7 +262,7 @@ const MinGasCalculator = () => {
               htmlFor='minGasTankSize'
               className='block text-xs sm:text-sm font-semibold text-gray-700 mb-1 sm:mb-2'
             >
-              Cylinder Size (Liters)
+              Cylinder Size (L)
             </label>
             <select
               id='minGasTankSize'

--- a/frontend/src/components/calculators/ModCalculator.jsx
+++ b/frontend/src/components/calculators/ModCalculator.jsx
@@ -64,21 +64,21 @@ const ModCalculator = () => {
 
   return (
     <div className='bg-white rounded-xl shadow-md border border-gray-200 overflow-hidden flex flex-col h-full'>
-      <div className='p-3 sm:p-5 border-b border-gray-100 bg-blue-50/30'>
-        <div className='flex items-center space-x-3'>
-          <div className='p-2 bg-blue-600 rounded-lg text-white'>
+      <div className='p-4 border-b border-gray-100 bg-blue-50/30'>
+        <div className='flex items-center space-x-2 sm:space-x-3'>
+          <div className='p-1.5 bg-blue-600 rounded text-white hidden sm:block'>
             <Gauge className='h-5 w-5 sm:h-6 sm:w-6' />
           </div>
-          <h2 className='text-lg sm:text-xl font-bold text-gray-900'>
+          <h2 className='text-base sm:text-xl font-bold text-gray-900'>
             Maximum Operating Depth (MOD)
           </h2>
         </div>
-        <p className='mt-1 sm:mt-2 text-xs sm:text-sm text-gray-600'>
+        <p className='mt-1 text-xs sm:text-sm text-gray-600 hidden sm:block'>
           Calculate the maximum depth for a given gas mixture and partial pressure of oxygen.
         </p>
       </div>
 
-      <div className='p-3 sm:p-6 flex-grow space-y-3 sm:space-y-6'>
+      <div className='p-4 flex-grow space-y-4'>
         <div className='flex justify-end'>
           <div className='flex items-center space-x-2 text-xs sm:text-sm'>
             <span className={!isAdvanced ? 'font-bold text-blue-600' : 'text-gray-500'}>

--- a/frontend/src/components/calculators/SacRateCalculator.jsx
+++ b/frontend/src/components/calculators/SacRateCalculator.jsx
@@ -69,19 +69,19 @@ const SacRateCalculator = () => {
 
   return (
     <div className='bg-white rounded-xl shadow-md border border-gray-200 overflow-hidden flex flex-col h-full'>
-      <div className='p-3 sm:p-5 border-b border-gray-100 bg-purple-50/30'>
-        <div className='flex items-center space-x-3'>
-          <div className='p-2 bg-purple-600 rounded-lg text-white'>
+      <div className='p-4 border-b border-gray-100 bg-purple-50/30'>
+        <div className='flex items-center space-x-2 sm:space-x-3'>
+          <div className='p-1.5 bg-purple-600 rounded text-white hidden sm:block'>
             <Timer className='h-5 w-5 sm:h-6 sm:w-6' />
           </div>
-          <h2 className='text-lg sm:text-xl font-bold text-gray-900'>SAC Rate Calculator</h2>
+          <h2 className='text-base sm:text-xl font-bold text-gray-900'>SAC Rate Calculator</h2>
         </div>
-        <p className='mt-1 sm:mt-2 text-xs sm:text-sm text-gray-600'>
+        <p className='mt-1 text-xs sm:text-sm text-gray-600 hidden sm:block'>
           Calculate your Surface Air Consumption rate to estimate gas usage.
         </p>
       </div>
 
-      <div className='p-3 sm:p-6 flex-grow space-y-3 sm:space-y-6'>
+      <div className='p-4 flex-grow space-y-4'>
         <div className='grid grid-cols-2 gap-2 sm:gap-4'>
           <div>
             <label
@@ -105,7 +105,7 @@ const SacRateCalculator = () => {
               htmlFor='sacTime'
               className='block text-xs sm:text-sm font-semibold text-gray-700 mb-1 sm:mb-2'
             >
-              Bottom Time (minutes)
+              Bottom Time (mins)
             </label>
             <input
               id='sacTime'
@@ -124,7 +124,7 @@ const SacRateCalculator = () => {
               htmlFor='sacTankSize'
               className='block text-xs sm:text-sm font-semibold text-gray-700 mb-1 sm:mb-2'
             >
-              Cylinder Size (Liters)
+              Cylinder Size (L)
             </label>
             <select
               id='sacTankSize'

--- a/frontend/src/components/calculators/WeightCalculator.jsx
+++ b/frontend/src/components/calculators/WeightCalculator.jsx
@@ -139,19 +139,19 @@ const WeightCalculator = () => {
 
   return (
     <div className='bg-white rounded-xl shadow-md border border-gray-200 overflow-hidden flex flex-col'>
-      <div className='p-3 sm:p-5 border-b border-gray-100 bg-emerald-50/30'>
-        <div className='flex items-center space-x-3'>
-          <div className='p-2 bg-emerald-600 rounded-lg text-white'>
+      <div className='p-4 border-b border-gray-100 bg-emerald-50/30'>
+        <div className='flex items-center space-x-2 sm:space-x-3'>
+          <div className='p-1.5 bg-emerald-600 rounded text-white hidden sm:block'>
             <Gauge className='h-5 w-5 sm:h-6 sm:w-6' />
           </div>
-          <h2 className='text-lg sm:text-xl font-bold text-gray-900'>Estimated Diving Weight</h2>
+          <h2 className='text-base sm:text-xl font-bold text-gray-900'>Estimated Diving Weight</h2>
         </div>
-        <p className='mt-1 sm:mt-2 text-xs sm:text-sm text-gray-600'>
+        <p className='mt-1 text-xs sm:text-sm text-gray-600 hidden sm:block'>
           Estimate how much lead you need based on your gear and environment.
         </p>
       </div>
 
-      <div className='p-3 sm:p-6 flex-grow space-y-3 sm:space-y-6'>
+      <div className='p-4 flex-grow space-y-4'>
         <div className='grid grid-cols-1 sm:grid-cols-2 gap-2 sm:gap-4'>
           <div>
             <label

--- a/frontend/src/components/forms/GasTanksInput.jsx
+++ b/frontend/src/components/forms/GasTanksInput.jsx
@@ -302,10 +302,10 @@ const GasTanksInput = ({ value, onChange, error, showSwitchMode = true }) => {
 
   // Structured Mode UI
   return (
-    <div className='space-y-4 border border-gray-200 rounded-md p-4 bg-gray-50'>
-      <div className='flex justify-between items-center mb-2'>
-        <h3 className='font-medium text-gray-700'>Gas Configuration</h3>
-        {showSwitchMode && (
+    <div className='space-y-3 sm:space-y-4'>
+      {showSwitchMode && (
+        <div className='flex justify-between items-center mb-2'>
+          <h3 className='font-medium text-gray-700'>Gas Configuration</h3>
           <button
             type='button'
             onClick={switchToSimple}
@@ -313,8 +313,8 @@ const GasTanksInput = ({ value, onChange, error, showSwitchMode = true }) => {
           >
             Switch to free-form text
           </button>
-        )}
-      </div>
+        </div>
+      )}
 
       {/* Back Gas Section */}
       <div className='bg-white p-3 rounded shadow-sm border border-gray-200'>

--- a/frontend/src/pages/DivingOrganizationsPage.jsx
+++ b/frontend/src/pages/DivingOrganizationsPage.jsx
@@ -235,10 +235,14 @@ const OrganizationCard = ({ org, initialDrawerOpen, highlightCourse }) => {
         role='button'
         tabIndex={0}
       >
-        <div className='p-5'>
+        <div className='p-4 sm:p-5'>
           <div className='flex justify-between items-start'>
             <div className='flex items-start space-x-3'>
-              <OrganizationLogo org={org} size='h-24 w-24' textSize='text-xl' />
+              <OrganizationLogo
+                org={org}
+                size='h-16 w-16 sm:h-24 sm:w-24'
+                textSize='text-base sm:text-xl'
+              />
               <div>
                 <h3 className='text-lg font-medium text-gray-900'>{org.name}</h3>
                 {org.acronym && <p className='text-sm text-gray-500 font-medium'>{org.acronym}</p>}
@@ -353,7 +357,7 @@ const DivingOrganizationsPage = () => {
       />
       <div className='w-full max-w-[1600px] mx-auto px-0 sm:px-4 lg:px-6 xl:px-8 py-4 sm:py-6 lg:py-8'>
         <div className='bg-white shadow-sm rounded-lg overflow-hidden mb-8'>
-          <div className='p-6 border-b border-gray-200'>
+          <div className='p-4 sm:p-6 border-b border-gray-200'>
             <div className='flex flex-col md:flex-row md:items-center justify-between gap-4'>
               <div>
                 <h1 className='text-3xl font-bold text-gray-900 flex items-center'>
@@ -384,7 +388,7 @@ const DivingOrganizationsPage = () => {
               <div className='animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600'></div>
             </div>
           ) : (
-            <div className='bg-gray-50 p-6'>
+            <div className='bg-gray-50 p-2 sm:p-4 lg:p-6'>
               {filteredOrgs?.length > 0 ? (
                 <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-2 gap-6'>
                   {filteredOrgs.map(org => {

--- a/frontend/src/pages/DivingTagsPage.jsx
+++ b/frontend/src/pages/DivingTagsPage.jsx
@@ -29,7 +29,7 @@ const DivingTagsPage = () => {
       />
       <div className='max-w-[95vw] xl:max-w-[1600px] mx-auto px-0 sm:px-4 lg:px-6 xl:px-8 py-3 sm:py-6 lg:py-8'>
         <div className='bg-white shadow-sm rounded-lg overflow-hidden'>
-          <div className='p-6 border-b border-gray-200'>
+          <div className='p-4 sm:p-6 border-b border-gray-200'>
             <div className='flex flex-col md:flex-row md:items-center justify-between gap-4'>
               <div>
                 <h1 className='text-3xl font-bold text-gray-900 flex items-center'>
@@ -60,13 +60,13 @@ const DivingTagsPage = () => {
               <div className='animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600'></div>
             </div>
           ) : (
-            <div className='bg-gray-50 p-6'>
+            <div className='bg-gray-50 p-2 sm:p-4 lg:p-6'>
               {filteredTags?.length > 0 ? (
                 <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6'>
                   {filteredTags.map(tag => (
                     <div
                       key={tag.id}
-                      className='bg-white rounded-lg shadow-sm hover:shadow-md transition-shadow duration-200 p-5 border border-gray-100'
+                      className='bg-white rounded-lg shadow-sm hover:shadow-md transition-shadow duration-200 p-4 sm:p-5 border border-gray-100'
                     >
                       <div className='flex items-start justify-between'>
                         <div className='flex items-center'>

--- a/frontend/src/pages/Tools.jsx
+++ b/frontend/src/pages/Tools.jsx
@@ -62,20 +62,20 @@ const Tools = () => {
         description={`Use our ${activeToolLabel} to plan your scuba dives safely. Divemap offers a suite of advanced diving calculators for gas planning, MOD, best mix, and tank buoyancy.`}
       />
       <div className='bg-white shadow-sm rounded-lg overflow-hidden mb-8 min-h-[80vh] flex flex-col'>
-        <div className='p-6 border-b border-gray-200'>
-          <h1 className='text-3xl font-bold text-gray-900 flex items-center'>
-            <Calculator className='h-8 w-8 mr-3 text-blue-600' />
+        <div className='p-4 sm:p-6 border-b border-gray-200'>
+          <h1 className='text-2xl sm:text-3xl font-bold text-gray-900 flex items-center'>
+            <Calculator className='h-6 w-6 sm:h-8 sm:w-8 mr-2 sm:mr-3 text-blue-600' />
             Diving Tools
           </h1>
-          <p className='mt-1 text-gray-600'>
+          <p className='mt-1 text-gray-600 hidden sm:block'>
             Useful calculators for dive planning. Remember to always double-check your calculations.
           </p>
         </div>
 
-        <div className='flex-grow bg-gray-50 p-4 sm:p-6'>
+        <div className='flex-grow bg-gray-50 p-0 sm:p-4 lg:p-6'>
           <Tabs value={activeTab} onValueChange={handleTabChange} className='w-full'>
             {/* Mobile View: Select Dropdown */}
-            <div className='mb-6 sm:hidden'>
+            <div className='mb-4 px-4 sm:hidden'>
               <Select
                 value={activeTab}
                 onValueChange={handleTabChange}
@@ -134,7 +134,7 @@ const Tools = () => {
             </div>
           </Tabs>
         </div>
-        <div className='p-6 bg-amber-50 border-t border-amber-100 mt-auto'>
+        <div className='p-4 sm:p-6 bg-amber-50 border-t border-amber-100 mt-auto'>
           <div className='flex items-start'>
             <AlertTriangle className='h-6 w-6 text-amber-600 mr-3 mt-0.5' />
             <div>

--- a/frontend/src/pages/UserProfile.jsx
+++ b/frontend/src/pages/UserProfile.jsx
@@ -459,7 +459,7 @@ const UserProfile = () => {
         className={
           isEmbedded
             ? 'mt-4 lg:mt-0'
-            : 'bg-white rounded-lg shadow-md p-6 mb-6 border border-gray-100'
+            : 'bg-white rounded-lg shadow-md p-4 sm:p-6 mb-6 border border-gray-100'
         }
       >
         {!isEmbedded && (

--- a/frontend/src/utils/TankBuoyancy.jsx
+++ b/frontend/src/utils/TankBuoyancy.jsx
@@ -224,20 +224,20 @@ const TankBuoyancy = () => {
 
   return (
     <div className='bg-white rounded-xl shadow-md border border-gray-200 overflow-hidden flex flex-col'>
-      <div className='p-5 border-b border-gray-100 bg-sky-50/30'>
-        <div className='flex items-center space-x-3'>
-          <div className='p-2 bg-sky-600 rounded-lg text-white'>
-            <Anchor className='h-6 w-6' />
+      <div className='p-4 border-b border-gray-100 bg-sky-50/30'>
+        <div className='flex items-center space-x-2 sm:space-x-3'>
+          <div className='p-1.5 bg-sky-600 rounded text-white hidden sm:block'>
+            <Anchor className='h-5 w-5 sm:h-6 sm:w-6' />
           </div>
-          <h2 className='text-xl font-bold text-gray-900'>Tank Buoyancy Calculator</h2>
+          <h2 className='text-base sm:text-xl font-bold text-gray-900'>Tank Buoyancy Calculator</h2>
         </div>
-        <p className='mt-2 text-sm text-gray-600'>
+        <p className='mt-1 text-xs sm:text-sm text-gray-600 hidden sm:block'>
           Calculate the buoyancy characteristics of your scuba cylinder(s) to perfect your
           weighting.
         </p>
       </div>
 
-      <div className='p-6 flex-grow space-y-6'>
+      <div className='p-4 flex-grow space-y-4'>
         {/* Tank Config */}
         <div>
           <label className='block text-sm font-semibold text-gray-700 mb-2'>
@@ -293,23 +293,23 @@ const TankBuoyancy = () => {
         {showDetails && (
           <div className='space-y-4 animate-in fade-in slide-in-from-top-1 duration-200'>
             {result.tankBreakdown.map((item, idx) => (
-              <div key={idx} className='p-4 bg-gray-50 rounded-xl border border-gray-100 space-y-3'>
+              <div key={idx} className='p-4 bg-gray-50 rounded-xl border border-gray-100 space-y-4'>
                 <div className='flex justify-between items-center border-b border-gray-200 pb-2'>
                   <span className='text-sm font-bold text-gray-900'>{item.name}</span>
                   <span className='text-[10px] uppercase tracking-wider font-bold text-gray-400 bg-white px-2 py-0.5 rounded border border-gray-100'>
                     {item.type}
                   </span>
                 </div>
-                <div className='space-y-4 text-xs font-mono text-gray-600'>
+                <div className='grid grid-cols-1 md:grid-cols-2 gap-5 sm:gap-6 text-xs font-mono text-gray-600'>
                   {/* Volume Section */}
-                  <div className='bg-gray-50/50 p-2 rounded border border-gray-100'>
-                    <h5 className='font-bold text-gray-700 mb-2 border-b border-gray-200 pb-1 flex justify-between items-center'>
+                  <div className='space-y-2'>
+                    <h5 className='font-bold text-gray-700 border-b border-gray-200 pb-1.5 flex justify-between items-center'>
                       <span>Displacement / Volume</span>
-                      <span className='text-[10px] font-normal text-gray-400 italic'>
+                      <span className='text-[10px] font-normal text-gray-400 italic hidden sm:inline'>
                         Total = Metal + Valve + Internal
                       </span>
                     </h5>
-                    <div className='grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-1'>
+                    <div className='space-y-1'>
                       <div className='flex justify-between'>
                         <span>Metal Volume:</span>
                         <span>{item.data.volMetal.toFixed(3)} L</span>
@@ -322,7 +322,7 @@ const TankBuoyancy = () => {
                         <span>Internal Tank Volume:</span>
                         <span>{item.data.currentLiters.toFixed(1)} L</span>
                       </div>
-                      <div className='flex justify-between font-bold text-gray-800 border-t border-gray-200 pt-1 mt-1 sm:mt-0'>
+                      <div className='flex justify-between font-bold text-gray-800 border-t border-gray-200 pt-1 mt-1'>
                         <span>Total Displacement:</span>
                         <span>{item.data.totalDisplacedVolume.toFixed(3)} L</span>
                       </div>
@@ -330,11 +330,11 @@ const TankBuoyancy = () => {
                   </div>
 
                   {/* Weight Section */}
-                  <div className='bg-gray-50/50 p-2 rounded border border-gray-100'>
-                    <h5 className='font-bold text-gray-700 mb-2 border-b border-gray-200 pb-1'>
+                  <div className='space-y-2'>
+                    <h5 className='font-bold text-gray-700 border-b border-gray-200 pb-1.5'>
                       Weight Breakdown
                     </h5>
-                    <div className='grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-1'>
+                    <div className='space-y-1'>
                       <div className='flex justify-between'>
                         <span>Tank Weight (No Valve):</span>
                         <span>{item.data.totalTankWeight.toFixed(2)} kg</span>
@@ -349,7 +349,7 @@ const TankBuoyancy = () => {
                           <span>{item.data.totalManifoldWeight.toFixed(2)} kg</span>
                         </div>
                       )}
-                      <div className='col-span-1 sm:col-span-2 border-t border-gray-200 my-1'></div>
+                      <div className='border-t border-gray-200 my-1'></div>
                       <div className='flex justify-between font-bold text-gray-800'>
                         <span>Total Weight (Empty):</span>
                         <span>{item.data.weightEmpty.toFixed(2)} kg</span>
@@ -358,11 +358,11 @@ const TankBuoyancy = () => {
                   </div>
 
                   {/* Gas Section */}
-                  <div className='bg-gray-50/50 p-2 rounded border border-gray-100'>
-                    <h5 className='font-bold text-gray-700 mb-2 border-b border-gray-200 pb-1'>
+                  <div className='space-y-2'>
+                    <h5 className='font-bold text-gray-700 border-b border-gray-200 pb-1.5'>
                       Gas Characteristics
                     </h5>
-                    <div className='grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-1'>
+                    <div className='space-y-1'>
                       <div className='flex justify-between'>
                         <span>Gas Density:</span>
                         <span>{item.data.mixDensity.toFixed(4)} kg/L</span>
@@ -371,7 +371,7 @@ const TankBuoyancy = () => {
                         <span>Gas Weight (Full):</span>
                         <span>{item.data.gasWeightFull.toFixed(2)} kg</span>
                       </div>
-                      <div className='col-span-1 sm:col-span-2 border-t border-gray-200 my-1'></div>
+                      <div className='border-t border-gray-200 my-1'></div>
                       <div className='flex justify-between font-bold'>
                         <span>Total Weight (Full):</span>
                         <span>{item.data.weightFull.toFixed(2)} kg</span>
@@ -380,14 +380,14 @@ const TankBuoyancy = () => {
                   </div>
 
                   {/* Forces Section */}
-                  <div className='bg-gray-50/50 p-2 rounded border border-gray-100'>
-                    <h5 className='font-bold text-gray-700 mb-2 border-b border-gray-200 pb-1 flex justify-between items-center'>
+                  <div className='space-y-2'>
+                    <h5 className='font-bold text-gray-700 border-b border-gray-200 pb-1.5 flex justify-between items-center'>
                       <span>Forces & Buoyancy</span>
-                      <span className='text-[10px] font-normal text-gray-400 italic'>
+                      <span className='text-[10px] font-normal text-gray-400 italic hidden sm:inline'>
                         Force = Displacement × Water Density
                       </span>
                     </h5>
-                    <div className='grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-1'>
+                    <div className='space-y-1'>
                       <div className='flex justify-between'>
                         <span>Water Density:</span>
                         <span>{item.data.waterDensity.toFixed(3)} kg/L</span>
@@ -396,7 +396,7 @@ const TankBuoyancy = () => {
                         <span>Buoyant Force:</span>
                         <span>{item.data.buoyantForce.toFixed(3)} kg</span>
                       </div>
-                      <div className='col-span-1 sm:col-span-2 border-t border-gray-200 my-1'></div>
+                      <div className='border-t border-gray-200 my-1'></div>
                       <div className='flex justify-between font-bold'>
                         <span>Buoyancy (Empty):</span>
                         <span


### PR DESCRIPTION
Standardize card headers and bodies across all 9 calculators to p-4 padding to align them perfectly with the top header title and bottom safety warning.

Flatten the nested cylinder configuration container inside GasTanksInput to remove double-border inception and expand input width on mobile. Redesign the detailed buoyancy breakdown into a 2x2 grid to save 50% of its vertical scroll height.

Standardize all user-facing instances of "Cylinder Size (Liters)" to "Cylinder Size (L)" and "minutes" to "mins" to prevent line wraps and unify spacing. Merge the SAC Rate input and the Rule of Thirds checkbox into a single, compact row.