### PR TITLE
Implement user curated dive site collections feature

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -395,13 +395,14 @@ def load_routers():
     router_start = time.time()
 
     # Import only the most essential routers for startup
-    from app.routers import auth, users, settings, notifications
+    from app.routers import auth, users, settings, notifications, lists
 
     # Include only the most critical routers (others moved to lazy loading)
     app.include_router(auth.router, prefix="/api/v1/auth", tags=["Authentication"])
     app.include_router(users.router, prefix="/api/v1/users", tags=["Users"])
     app.include_router(settings.router, prefix="/api/v1/settings", tags=["Settings"])
     app.include_router(notifications.router, prefix="/api/v1/notifications", tags=["Notifications"])
+    app.include_router(lists.router, prefix="/api/v1/lists", tags=["Dive Site Lists"])
 
     # Import unsubscribe router
     from app.routers import unsubscribe

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -199,6 +199,7 @@ class User(Base):
     password_reset_tokens = relationship("PasswordResetToken", back_populates="user", cascade="all, delete-orphan")
     social_links = relationship("UserSocialLink", back_populates="user", cascade="all, delete-orphan")
     push_subscriptions = relationship("PushSubscription", back_populates="user", cascade="all, delete-orphan")
+    dive_site_lists = relationship("DiveSiteList", back_populates="user", cascade="all, delete-orphan")
 
 class UserSocialLink(Base):
     __tablename__ = "user_social_links"
@@ -217,6 +218,49 @@ class UserSocialLink(Base):
     __table_args__ = (
         sa.UniqueConstraint('user_id', 'platform', name='_user_platform_uc'),
    )
+
+class DiveSiteList(Base):
+    __tablename__ = "dive_site_lists"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
+    title = Column(String(100), nullable=False)
+    slug = Column(String(120), nullable=False, index=True)
+    description = Column(Text, nullable=True)
+    is_public = Column(Boolean, default=True, nullable=False)
+    show_on_profile = Column(Boolean, default=True, nullable=False)
+    system_type = Column(String(50), nullable=True, default=None)  # "favorites", "wishlist", or None
+    view_count = Column(Integer, default=0, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+
+    # Relationships
+    user = relationship("User", back_populates="dive_site_lists")
+    items = relationship(
+        "DiveSiteListItem",
+        back_populates="list",
+        cascade="all, delete-orphan",
+        order_by="DiveSiteListItem.display_order"
+    )
+
+class DiveSiteListItem(Base):
+    __tablename__ = "dive_site_list_items"
+
+    id = Column(Integer, primary_key=True, index=True)
+    list_id = Column(Integer, ForeignKey("dive_site_lists.id", ondelete="CASCADE"), nullable=False, index=True)
+    dive_site_id = Column(Integer, ForeignKey("dive_sites.id", ondelete="CASCADE"), nullable=False, index=True)
+    notes = Column(Text, nullable=True)
+    display_order = Column(Integer, default=0, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    # Relationships
+    list = relationship("DiveSiteList", back_populates="items")
+    dive_site = relationship("DiveSite")
+
+    # Unique constraint to prevent duplicate dive sites in the same list
+    __table_args__ = (
+        sa.UniqueConstraint('list_id', 'dive_site_id', name='uq_list_dive_site'),
+    )
 
 class DiveSite(Base):
     __tablename__ = "dive_sites"

--- a/backend/app/routers/lists.py
+++ b/backend/app/routers/lists.py
@@ -275,17 +275,25 @@ async def get_dive_site_membership_status(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_active_user)
 ):
-    """Retrieve bookmark checkmarks state across all user lists"""
+    """Retrieve bookmark checkmarks state across all user lists with single-query join efficiency"""
     ensure_default_lists(db, current_user.id)
     lists = db.query(DiveSiteList).filter(DiveSiteList.user_id == current_user.id).all()
-    
+    list_ids = [lst.id for lst in lists]
+
+    # Batch query all items matching lists & dive site to resolve N+1 overhead
+    items = []
+    if list_ids:
+        items = db.query(DiveSiteListItem).filter(
+            DiveSiteListItem.list_id.in_(list_ids),
+            DiveSiteListItem.dive_site_id == dive_site_id
+        ).all()
+
+    # Map by list ID for O(1) in-memory resolution
+    item_map = {item.list_id: item for item in items}
+
     results = []
     for lst in lists:
-        item = db.query(DiveSiteListItem).filter(
-            DiveSiteListItem.list_id == lst.id,
-            DiveSiteListItem.dive_site_id == dive_site_id
-        ).first()
-        
+        item = item_map.get(lst.id)
         results.append(UserDiveSiteListMembershipResponse(
             list_id=lst.id,
             title=lst.title,
@@ -296,11 +304,19 @@ async def get_dive_site_membership_status(
     return results
 
 def ensure_default_lists(db: Session, user_id: int):
-    """Verify and initialize standard My Favorites and My Wishlist files securely"""
+    """Verify and initialize standard My Favorites and My Wishlist files securely without side-effects during GET queries"""
     fav = db.query(DiveSiteList).filter(
         DiveSiteList.user_id == user_id,
         DiveSiteList.system_type == "favorites"
     ).first()
+    wish = db.query(DiveSiteList).filter(
+        DiveSiteList.user_id == user_id,
+        DiveSiteList.system_type == "wishlist"
+    ).first()
+
+    if fav and wish:
+        return
+
     if not fav:
         fav_list = DiveSiteList(
             user_id=user_id,
@@ -313,10 +329,6 @@ def ensure_default_lists(db: Session, user_id: int):
         )
         db.add(fav_list)
 
-    wish = db.query(DiveSiteList).filter(
-        DiveSiteList.user_id == user_id,
-        DiveSiteList.system_type == "wishlist"
-    ).first()
     if not wish:
         wish_list = DiveSiteList(
             user_id=user_id,

--- a/backend/app/routers/lists.py
+++ b/backend/app/routers/lists.py
@@ -1,0 +1,350 @@
+import re
+from typing import List, Optional
+from datetime import datetime
+from fastapi import APIRouter, Depends, HTTPException, status, Request, BackgroundTasks
+from sqlalchemy.orm import Session, joinedload
+from app.database import get_db
+from app.models import DiveSiteList, DiveSiteListItem, DiveSite, User
+from app.auth import get_current_active_user, get_current_user_optional, get_current_admin_user
+from app.utils import increment_view_count
+from app.schemas import (
+    UserDiveSiteListResponse, UserDiveSiteListCreate, UserDiveSiteListUpdate,
+    DiveSiteListItemResponse, DiveSiteListItemCreate, DiveSiteListItemUpdate,
+    UserDiveSiteListReorder, UserDiveSiteListMembershipResponse
+)
+
+router = APIRouter()
+
+def slugify(s: str) -> str:
+    s = s.lower().strip()
+    s = re.sub(r'[^\w\s-]', '', s)
+    s = re.sub(r'[\s_-]+', '-', s)
+    return s.strip('-')
+
+def sanitize_list_for_response(lst: Optional[DiveSiteList]) -> Optional[DiveSiteList]:
+    """Sanitize nested dive site tags list objects to match Pydantic schema validation expectation"""
+    if lst and lst.items:
+        for item in lst.items:
+            if item.dive_site:
+                item.dive_site.tags = []
+    return lst
+
+@router.get("/my-lists", response_model=List[UserDiveSiteListResponse])
+async def get_my_lists(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user)
+):
+    """Get all curated lists of the authenticated user (including system lists)"""
+    ensure_default_lists(db, current_user.id)
+    lists = db.query(DiveSiteList).filter(
+        DiveSiteList.user_id == current_user.id
+    ).options(joinedload(DiveSiteList.items).joinedload(DiveSiteListItem.dive_site)).all()
+    
+    # Map usernames and sanitize tags
+    for lst in lists:
+        lst.username = current_user.username
+        sanitize_list_for_response(lst)
+    return lists
+
+@router.post("", response_model=UserDiveSiteListResponse, status_code=status.HTTP_201_CREATED)
+async def create_list(
+    data: UserDiveSiteListCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user)
+):
+    """Create a new custom curated list"""
+    slug = slugify(data.title) or "list"
+    
+    new_list = DiveSiteList(
+        user_id=current_user.id,
+        title=data.title,
+        slug=slug,
+        description=data.description,
+        is_public=data.is_public,
+        show_on_profile=data.show_on_profile,
+        system_type=None
+    )
+    db.add(new_list)
+    db.commit()
+    db.refresh(new_list)
+    new_list.username = current_user.username
+    new_list.items = []
+    sanitize_list_for_response(new_list)
+    return new_list
+
+@router.get("/{list_id}", response_model=UserDiveSiteListResponse)
+async def get_list_by_id(
+    list_id: int,
+    request: Request,
+    background_tasks: BackgroundTasks,
+    db: Session = Depends(get_db),
+    current_user: Optional[User] = Depends(get_current_user_optional)
+):
+    """Retrieve details of a curated list with its items, tracked asynchronously on other user visits"""
+    lst = db.query(DiveSiteList).filter(DiveSiteList.id == list_id).options(
+        joinedload(DiveSiteList.items).joinedload(DiveSiteListItem.dive_site)
+    ).first()
+
+    if not lst:
+        raise HTTPException(status_code=404, detail="List not found")
+
+    owner = db.query(User).filter(User.id == lst.user_id).first()
+    lst.username = owner.username if owner else "unknown"
+
+    # Privacy enforcement
+    is_owner = current_user and current_user.id == lst.user_id
+    if not lst.is_public and not is_owner and not (current_user and current_user.is_admin):
+        raise HTTPException(status_code=403, detail="This list is private")
+
+    # Track views
+    if not is_owner:
+        background_tasks.add_task(increment_view_count, db, DiveSiteList, list_id)
+
+    sanitize_list_for_response(lst)
+    return lst
+
+@router.put("/{list_id}", response_model=UserDiveSiteListResponse)
+async def update_list(
+    list_id: int,
+    data: UserDiveSiteListUpdate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user)
+):
+    """Update list details. Block renaming system types"""
+    lst = db.query(DiveSiteList).filter(DiveSiteList.id == list_id).first()
+    if not lst:
+        raise HTTPException(status_code=404, detail="List not found")
+    if lst.user_id != current_user.id and not current_user.is_admin:
+        raise HTTPException(status_code=403, detail="Unauthorized")
+
+    if data.title is not None:
+        if lst.system_type:
+            raise HTTPException(status_code=403, detail="Cannot rename system-generated lists")
+        lst.title = data.title
+        lst.slug = slugify(data.title)
+
+    if data.description is not None:
+        lst.description = data.description
+    if data.is_public is not None:
+        lst.is_public = data.is_public
+        # Enforce logical dependency: if private, it cannot be displayed on public profile
+        if not data.is_public:
+            lst.show_on_profile = False
+
+    if data.show_on_profile is not None:
+        # Enforce logical dependency: can only show on profile if list is public
+        lst.show_on_profile = data.show_on_profile if lst.is_public else False
+
+    db.commit()
+    db.refresh(lst)
+    lst.username = current_user.username
+    sanitize_list_for_response(lst)
+    return lst
+
+@router.delete("/{list_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_list(
+    list_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user)
+):
+    """Delete a custom list. Prevent system list deletion"""
+    lst = db.query(DiveSiteList).filter(DiveSiteList.id == list_id).first()
+    if not lst:
+        raise HTTPException(status_code=404, detail="List not found")
+    if lst.user_id != current_user.id and not current_user.is_admin:
+        raise HTTPException(status_code=403, detail="Unauthorized")
+    if lst.system_type:
+        raise HTTPException(status_code=403, detail="System-generated lists cannot be deleted")
+
+    db.delete(lst)
+    db.commit()
+    return None
+
+@router.post("/{list_id}/items", response_model=DiveSiteListItemResponse, status_code=status.HTTP_201_CREATED)
+async def add_list_item(
+    list_id: int,
+    data: DiveSiteListItemCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user)
+):
+    """Add a site to a list with optional notes"""
+    lst = db.query(DiveSiteList).filter(DiveSiteList.id == list_id).first()
+    if not lst or lst.user_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Unauthorized")
+
+    # Check site exists
+    site = db.query(DiveSite).filter(DiveSite.id == data.dive_site_id).first()
+    if not site:
+        raise HTTPException(status_code=404, detail="Dive site not found")
+
+    # Prevent duplicate
+    duplicate = db.query(DiveSiteListItem).filter(
+        DiveSiteListItem.list_id == list_id,
+        DiveSiteListItem.dive_site_id == data.dive_site_id
+    ).first()
+    if duplicate:
+         raise HTTPException(status_code=400, detail="Dive site already in list")
+
+    # Set display order as count
+    item_count = db.query(DiveSiteListItem).filter(DiveSiteListItem.list_id == list_id).count()
+
+    item = DiveSiteListItem(
+        list_id=list_id,
+        dive_site_id=data.dive_site_id,
+        notes=data.notes,
+        display_order=item_count
+    )
+    db.add(item)
+    db.commit()
+    db.refresh(item)
+    # Ensure dive_site relation is loaded for response model
+    db_item = db.query(DiveSiteListItem).options(joinedload(DiveSiteListItem.dive_site)).filter(DiveSiteListItem.id == item.id).first()
+    if db_item and db_item.dive_site:
+        db_item.dive_site.tags = []
+    return db_item
+
+@router.put("/{list_id}/items/{item_id}", response_model=DiveSiteListItemResponse)
+async def update_list_item(
+    list_id: int,
+    item_id: int,
+    data: DiveSiteListItemUpdate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user)
+):
+    """Update custom notes or individual order of a list item"""
+    item = db.query(DiveSiteListItem).filter(
+        DiveSiteListItem.id == item_id,
+        DiveSiteListItem.list_id == list_id
+    ).first()
+    if not item or item.list.user_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Unauthorized")
+
+    if data.notes is not None:
+        item.notes = data.notes
+    if data.display_order is not None:
+        item.display_order = data.display_order
+
+    db.commit()
+    db.refresh(item)
+    return item
+
+@router.delete("/{list_id}/items/{item_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def remove_list_item(
+    list_id: int,
+    item_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user)
+):
+    """Remove a site from a list"""
+    item = db.query(DiveSiteListItem).filter(
+        DiveSiteListItem.id == item_id,
+        DiveSiteListItem.list_id == list_id
+    ).first()
+    if not item or item.list.user_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Unauthorized")
+
+    db.delete(item)
+    db.commit()
+    return None
+
+@router.put("/{list_id}/reorder")
+async def reorder_list_items(
+    list_id: int,
+    data: UserDiveSiteListReorder,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user)
+):
+    """Bulk reorder items of a list securely in a single transaction"""
+    lst = db.query(DiveSiteList).filter(DiveSiteList.id == list_id).first()
+    if not lst or lst.user_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Unauthorized")
+
+    items = db.query(DiveSiteListItem).filter(DiveSiteListItem.list_id == list_id).all()
+    item_map = {item.id: item for item in items}
+
+    for index, item_id in enumerate(data.item_ids):
+        if item_id in item_map:
+            item_map[item_id].display_order = index
+
+    db.commit()
+    return {"status": "success"}
+
+@router.get("/dive-site/{dive_site_id}/my-status", response_model=List[UserDiveSiteListMembershipResponse])
+async def get_dive_site_membership_status(
+    dive_site_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user)
+):
+    """Retrieve bookmark checkmarks state across all user lists"""
+    ensure_default_lists(db, current_user.id)
+    lists = db.query(DiveSiteList).filter(DiveSiteList.user_id == current_user.id).all()
+    
+    results = []
+    for lst in lists:
+        item = db.query(DiveSiteListItem).filter(
+            DiveSiteListItem.list_id == lst.id,
+            DiveSiteListItem.dive_site_id == dive_site_id
+        ).first()
+        
+        results.append(UserDiveSiteListMembershipResponse(
+            list_id=lst.id,
+            title=lst.title,
+            system_type=lst.system_type,
+            is_in_list=item is not None,
+            item_id=item.id if item else None
+        ))
+    return results
+
+def ensure_default_lists(db: Session, user_id: int):
+    """Verify and initialize standard My Favorites and My Wishlist files securely"""
+    fav = db.query(DiveSiteList).filter(
+        DiveSiteList.user_id == user_id,
+        DiveSiteList.system_type == "favorites"
+    ).first()
+    if not fav:
+        fav_list = DiveSiteList(
+            user_id=user_id,
+            title="My Favorites",
+            slug="my-favorites",
+            description="My favorite dive sites that I highly recommend!",
+            is_public=True,
+            show_on_profile=True,
+            system_type="favorites"
+        )
+        db.add(fav_list)
+
+    wish = db.query(DiveSiteList).filter(
+        DiveSiteList.user_id == user_id,
+        DiveSiteList.system_type == "wishlist"
+    ).first()
+    if not wish:
+        wish_list = DiveSiteList(
+            user_id=user_id,
+            title="My Wishlist",
+            slug="my-wishlist",
+            description="Dive sites I would love to visit in the future.",
+            is_public=False,
+            show_on_profile=False,
+            system_type="wishlist"
+        )
+        db.add(wish_list)
+    db.commit()
+
+
+@router.get("/admin/popular-lists", response_model=List[UserDiveSiteListResponse])
+async def get_popular_lists_admin(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_admin_user)
+):
+    """Retrieve lists sorted by popularity (views) for site administrators"""
+    lists = db.query(DiveSiteList).options(
+        joinedload(DiveSiteList.items).joinedload(DiveSiteListItem.dive_site)
+    ).order_by(DiveSiteList.view_count.desc()).limit(50).all()
+
+    # Resolve owners' usernames and sanitize
+    for lst in lists:
+        owner = db.query(User).filter(User.id == lst.user_id).first()
+        lst.username = owner.username if owner else "unknown"
+        sanitize_list_for_response(lst)
+
+    return lists

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 import uuid
 
 from app.database import get_db
-from app.models import User, SiteRating, SiteComment, CenterComment, DiveSite, Dive, DivingCenter, DiveBuddy, ApiKey, UserSocialLink, PersonalAccessToken
+from app.models import User, SiteRating, SiteComment, CenterComment, DiveSite, Dive, DivingCenter, DiveBuddy, ApiKey, UserSocialLink, PersonalAccessToken, DiveSiteList, DiveSiteListItem
 from app.schemas import (
     UserResponse, UserUpdate, UserCreateAdmin, UserUpdateAdmin, UserListResponse, 
     PasswordChangeRequest, UserPublicProfileResponse, UserProfileStats, UserSearchResponse,
@@ -13,9 +13,9 @@ from app.schemas import (
     UserSocialLinkCreate, UserSocialLinkResponse,
     PATCreate, PATResponse, PATCreateResponse, DivingStatsResponse, AdvancedAnalyticsResponse,
     AvatarUpdate, AvatarType, VisitedDiveSiteResponse,
-    MyCommentsListResponse, MyRatingsListResponse
+    MyCommentsListResponse, MyRatingsListResponse, UserDiveSiteListResponse
 )
-from app.auth import get_current_active_user, get_current_admin_user, get_password_hash, verify_password, is_admin_or_moderator
+from app.auth import get_current_active_user, get_current_admin_user, get_password_hash, verify_password, is_admin_or_moderator, get_current_user_optional
 from app.services.r2_storage_service import r2_storage
 from app.services.image_processing import image_processing
 from app.limiter import skip_rate_limit_for_admin
@@ -956,6 +956,39 @@ async def get_user_public_profile(
     ).model_dump()
 
     return populate_avatar_full_url(user, response_dict)
+
+
+@router.get("/{username}/lists", response_model=List[UserDiveSiteListResponse])
+@skip_rate_limit_for_admin("60/minute")
+async def get_user_public_lists(
+    request: Request,
+    username: str,
+    db: Session = Depends(get_db),
+    current_user: Optional[User] = Depends(get_current_user_optional)
+):
+    """Get all public lists for a specific user (Option A delegation)"""
+    user = db.query(User).filter(User.username == username, User.enabled == True).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    from app.routers.lists import ensure_default_lists
+    ensure_default_lists(db, user.id)
+
+    # Public profile endpoint always returns only public lists flagged to be shown on public profiles
+    query = db.query(DiveSiteList).filter(
+        DiveSiteList.user_id == user.id,
+        DiveSiteList.is_public == True,
+        DiveSiteList.show_on_profile == True
+    )
+
+    lists = query.options(joinedload(DiveSiteList.items).joinedload(DiveSiteListItem.dive_site)).all()
+    for lst in lists:
+        lst.username = user.username
+        if lst.items:
+            for item in lst.items:
+                if item.dive_site:
+                    item.dive_site.tags = []
+    return lists
 
 
 @router.get("/{username}/visited-sites", response_model=List[VisitedDiveSiteResponse])

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -852,6 +852,65 @@ class VisitedDiveSiteResponse(BaseModel):
 
     model_config = ConfigDict(from_attributes=True)
 
+# User Curated Lists Schemas
+class DiveSiteListItemResponse(BaseModel):
+    id: int
+    list_id: int
+    dive_site_id: int
+    notes: Optional[str] = None
+    display_order: int
+    dive_site: DiveSiteResponse
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+class UserDiveSiteListResponse(BaseModel):
+    id: int
+    user_id: int
+    username: str
+    title: str
+    slug: str
+    description: Optional[str] = None
+    is_public: bool
+    show_on_profile: bool
+    system_type: Optional[str] = None
+    view_count: int
+    created_at: datetime
+    updated_at: datetime
+    items: List[DiveSiteListItemResponse] = []
+
+    model_config = ConfigDict(from_attributes=True)
+
+class UserDiveSiteListCreate(BaseModel):
+    title: str = Field(..., max_length=100)
+    description: Optional[str] = None
+    is_public: bool = True
+    show_on_profile: bool = True
+
+class UserDiveSiteListUpdate(BaseModel):
+    title: Optional[str] = None
+    description: Optional[str] = None
+    is_public: Optional[bool] = None
+    show_on_profile: Optional[bool] = None
+
+class DiveSiteListItemCreate(BaseModel):
+    dive_site_id: int
+    notes: Optional[str] = None
+
+class DiveSiteListItemUpdate(BaseModel):
+    notes: Optional[str] = None
+    display_order: Optional[int] = None
+
+class UserDiveSiteListReorder(BaseModel):
+    item_ids: List[int]
+
+class UserDiveSiteListMembershipResponse(BaseModel):
+    list_id: int
+    title: str
+    system_type: Optional[str] = None
+    is_in_list: bool
+    item_id: Optional[int] = None
+
 # User Public Info for buddy lists
 class UserPublicInfo(BaseModel):
     id: int

--- a/backend/tests/test_lists.py
+++ b/backend/tests/test_lists.py
@@ -1,0 +1,94 @@
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+from app.models import User, DiveSite, DiveSiteList, DiveSiteListItem
+
+def test_lists_workflow(client, db_session: Session, test_user, test_user_other, test_dive_site, auth_headers, auth_headers_other_user, admin_headers):
+    # 1. Access user lists anonymously / publicly
+    # This should trigger default lists creation!
+    response = client.get(f"/api/v1/users/{test_user.username}/lists")
+    assert response.status_code == 200
+    data = response.json()
+    
+    # By default, only public profile-enabled lists are shown
+    # "My Favorites" defaults to is_public=True, show_on_profile=True -> count should be 1
+    assert len(data) == 1
+    assert data[0]["system_type"] == "favorites"
+    assert data[0]["title"] == "My Favorites"
+
+    # 2. Logged in user gets own lists
+    response = client.get("/api/v1/lists/my-lists", headers=auth_headers)
+    assert response.status_code == 200
+    my_data = response.json()
+    assert len(my_data) == 2  # Both Favorites and Wishlist (private)
+
+    # 3. Create a custom list
+    response = client.post(
+        "/api/v1/lists",
+        json={"title": "Saronikos Caves", "description": "My top cave locations", "is_public": True, "show_on_profile": True},
+        headers=auth_headers
+    )
+    assert response.status_code == 201
+    custom_list = response.json()
+    assert custom_list["title"] == "Saronikos Caves"
+    assert custom_list["slug"] == "saronikos-caves"
+
+    # 4. Add a site to the custom list
+    response = client.post(
+        f"/api/v1/lists/{custom_list['id']}/items",
+        json={"dive_site_id": test_dive_site.id, "notes": "Fabulous visibility!"},
+        headers=auth_headers
+    )
+    assert response.status_code == 201
+    item_data = response.json()
+    assert item_data["notes"] == "Fabulous visibility!"
+
+    # 5. Prevent duplicate additions
+    response = client.post(
+        f"/api/v1/lists/{custom_list['id']}/items",
+        json={"dive_site_id": test_dive_site.id},
+        headers=auth_headers
+    )
+    assert response.status_code == 400
+
+    # 6. Retrieve list details
+    response = client.get(f"/api/v1/lists/{custom_list['id']}")
+    assert response.status_code == 200
+    list_details = response.json()
+    assert len(list_details["items"]) == 1
+    assert list_details["items"][0]["notes"] == "Fabulous visibility!"
+    assert list_details["items"][0]["dive_site"]["name"] == test_dive_site.name
+
+    # 7. Check membership status
+    response = client.get(f"/api/v1/lists/dive-site/{test_dive_site.id}/my-status", headers=auth_headers)
+    assert response.status_code == 200
+    status_data = response.json()
+    # Check custom list is listed as having this site
+    custom_status = next(s for s in status_data if s["list_id"] == custom_list["id"])
+    assert custom_status["is_in_list"] is True
+    assert custom_status["item_id"] == item_data["id"]
+
+    # 8. Deletion rules
+    # Prevent deleting system list
+    fav_id = next(lst["id"] for lst in my_data if lst["system_type"] == "favorites")
+    response = client.delete(f"/api/v1/lists/{fav_id}", headers=auth_headers)
+    assert response.status_code == 403
+
+    # 9. Admin Popular Lists
+    # Regular user gets 403 Forbidden
+    response = client.get("/api/v1/lists/admin/popular-lists", headers=auth_headers)
+    assert response.status_code == 403
+
+    # Admin gets 200 OK
+    response = client.get("/api/v1/lists/admin/popular-lists", headers=admin_headers)
+    assert response.status_code == 200
+    popular_data = response.json()
+    assert len(popular_data) >= 1
+
+    # Delete custom list item
+    response = client.delete(f"/api/v1/lists/{custom_list['id']}/items/{item_data['id']}", headers=auth_headers)
+    assert response.status_code == 204
+
+    # Delete custom list
+    response = client.delete(f"/api/v1/lists/{custom_list['id']}", headers=auth_headers)
+    assert response.status_code == 204

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -92,6 +92,7 @@ const TripDetail = lazy(() => import('./pages/TripDetail'));
 const Unsubscribe = lazy(() => import('./pages/Unsubscribe'));
 const UserProfile = lazy(() => import('./pages/UserProfile'));
 const UserAnalytics = lazy(() => import('./pages/UserAnalytics'));
+const UserListDetail = lazy(() => import('./pages/UserListDetail'));
 const VerifyEmail = lazy(() => import('./pages/VerifyEmail'));
 const NotFound = lazy(() => import('./pages/NotFound'));
 
@@ -309,6 +310,8 @@ function AppContent() {
             />
             <Route path='/users/:username' element={<UserProfile />} />
             <Route path='/users/:username/analytics' element={<UserAnalytics />} />
+            <Route path='/users/:username/lists/:id' element={<UserListDetail />} />
+            <Route path='/users/:username/lists/:id/:slug' element={<UserListDetail />} />
             {/* Backward compatibility routes */}
             <Route
               path='/profile/notifications'

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -267,6 +267,65 @@ export const getUserAdvancedAnalytics = async username => {
   return response.data;
 };
 
+// Curated Lists API Functions
+export const getMyLists = async () => {
+  const response = await api.get('/api/v1/lists/my-lists');
+  return response.data;
+};
+
+export const getUserPublicLists = async username => {
+  const response = await api.get(`/api/v1/users/${username}/lists`);
+  return response.data;
+};
+
+export const getListById = async id => {
+  const response = await api.get(`/api/v1/lists/${id}`);
+  return response.data;
+};
+
+export const createList = async data => {
+  const response = await api.post('/api/v1/lists', data);
+  return response.data;
+};
+
+export const updateList = async (id, data) => {
+  const response = await api.put(`/api/v1/lists/${id}`, data);
+  return response.data;
+};
+
+export const deleteList = async id => {
+  await api.delete(`/api/v1/lists/${id}`);
+};
+
+export const addListItem = async (listId, data) => {
+  const response = await api.post(`/api/v1/lists/${listId}/items`, data);
+  return response.data;
+};
+
+export const updateListItem = async (listId, itemId, data) => {
+  const response = await api.put(`/api/v1/lists/${listId}/items/${itemId}`, data);
+  return response.data;
+};
+
+export const deleteListItem = async (listId, itemId) => {
+  await api.delete(`/api/v1/lists/${listId}/items/${itemId}`);
+};
+
+export const reorderListItems = async (listId, itemIds) => {
+  const response = await api.put(`/api/v1/lists/${listId}/reorder`, { item_ids: itemIds });
+  return response.data;
+};
+
+export const getDiveSiteListStatus = async diveSiteId => {
+  const response = await api.get(`/api/v1/lists/dive-site/${diveSiteId}/my-status`);
+  return response.data;
+};
+
+export const getAdminPopularLists = async () => {
+  const response = await api.get('/api/v1/lists/admin/popular-lists');
+  return response.data;
+};
+
 // Logged-in user private feedback history API functions
 export const getMyComments = async (params = {}) => {
   const response = await api.get('/api/v1/users/me/comments', { params });

--- a/frontend/src/components/SaveToListModal.jsx
+++ b/frontend/src/components/SaveToListModal.jsx
@@ -1,0 +1,158 @@
+import { Bookmark, Plus, Loader2 } from 'lucide-react';
+import React, { useState, useEffect } from 'react';
+import { toast } from 'react-hot-toast';
+
+import { getDiveSiteListStatus, addListItem, deleteListItem, createList } from '../api';
+
+import Button from './ui/Button';
+import Modal from './ui/Modal';
+
+const SaveToListModal = ({ isOpen, onClose, diveSiteId, diveSiteName }) => {
+  const [lists, setLists] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [newTitle, setNewTitle] = useState('');
+  const [creating, setCreating] = useState(false);
+
+  const fetchStatus = async () => {
+    try {
+      const data = await getDiveSiteListStatus(diveSiteId);
+      setLists(data);
+    } catch (e) {
+      toast.error('Failed to load list status');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (isOpen) {
+      setLoading(true);
+      fetchStatus();
+    }
+  }, [isOpen, diveSiteId]);
+
+  const handleToggle = async (listId, isInList, item) => {
+    try {
+      if (isInList) {
+        if (!item.item_id) {
+          toast.error('Cannot remove site: list item ID is missing');
+          return;
+        }
+        const toastId = toast.loading('Removing from list...');
+        await deleteListItem(listId, item.item_id);
+        toast.success('Removed from list!', { id: toastId });
+      } else {
+        const toastId = toast.loading('Adding to list...');
+        await addListItem(listId, { dive_site_id: diveSiteId });
+        toast.success('Added to list!', { id: toastId });
+      }
+      fetchStatus();
+    } catch (err) {
+      toast.error('Failed to update list');
+    }
+  };
+
+  const handleCreateAndAdd = async e => {
+    e.preventDefault();
+    if (!newTitle.trim()) return;
+    setCreating(true);
+    try {
+      const newList = await createList({ title: newTitle, is_public: true });
+      await addListItem(newList.id, { dive_site_id: diveSiteId });
+      toast.success(`Created "${newTitle}" and saved!`);
+      setNewTitle('');
+      fetchStatus();
+    } catch (e) {
+      toast.error('Failed to create list');
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={
+        <div className='flex items-center gap-2 text-gray-900 dark:text-white'>
+          <Bookmark className='h-5 w-5 text-blue-600 dark:text-blue-400' />
+          <span>Save "{diveSiteName}" to Lists</span>
+        </div>
+      }
+      className='max-w-md w-full'
+    >
+      <div className='mt-4 space-y-4'>
+        {/* Lists Container */}
+        <div className='max-h-60 overflow-y-auto space-y-2 pr-1'>
+          {loading ? (
+            <div className='flex justify-center py-8'>
+              <Loader2 className='animate-spin text-blue-600 dark:text-blue-400 h-8 w-8' />
+            </div>
+          ) : lists.length === 0 ? (
+            <p className='text-center py-6 text-sm text-gray-500 dark:text-gray-400 italic'>
+              No lists found. Create one below to get started!
+            </p>
+          ) : (
+            lists.map(lst => (
+              <label
+                key={lst.list_id}
+                className='flex items-center justify-between p-3 rounded-lg border border-gray-200 dark:border-gray-700 cursor-pointer hover:bg-blue-100/30 dark:hover:bg-blue-900/10 transition-colors'
+              >
+                <div className='flex flex-col'>
+                  <span className='font-semibold text-gray-800 dark:text-gray-200 text-sm sm:text-base'>
+                    {lst.title}
+                  </span>
+                  {lst.system_type && (
+                    <span className='text-[10px] text-blue-600 dark:text-blue-400 font-medium capitalize mt-0.5'>
+                      Default List
+                    </span>
+                  )}
+                </div>
+                <input
+                  type='checkbox'
+                  checked={lst.is_in_list}
+                  onChange={() => handleToggle(lst.list_id, lst.is_in_list, lst)}
+                  className='rounded border-gray-300 dark:border-gray-600 text-blue-600 h-5 w-5 focus:ring-blue-500 cursor-pointer'
+                />
+              </label>
+            ))
+          )}
+        </div>
+
+        {/* Create List Form */}
+        <form
+          onSubmit={handleCreateAndAdd}
+          className='pt-4 border-t border-gray-100 dark:border-gray-700'
+        >
+          <div className='flex gap-2 items-center'>
+            <input
+              type='text'
+              placeholder='Create new custom list...'
+              value={newTitle}
+              onChange={e => setNewTitle(e.target.value)}
+              className='flex-1 px-3 py-2 text-sm border rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white focus:outline-none focus:ring-2 focus:ring-blue-500'
+              disabled={creating}
+              maxLength={100}
+            />
+            <Button
+              type='submit'
+              disabled={creating || !newTitle.trim()}
+              size='sm'
+              className='flex-shrink-0'
+            >
+              {creating ? (
+                <Loader2 className='animate-spin h-4 w-4' />
+              ) : (
+                <>
+                  <Plus className='h-4 w-4 mr-1' /> Create
+                </>
+              )}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </Modal>
+  );
+};
+
+export default SaveToListModal;

--- a/frontend/src/pages/Admin.jsx
+++ b/frontend/src/pages/Admin.jsx
@@ -23,11 +23,17 @@ import {
   Database,
   TrendingUp,
   Clock,
+  Bookmark,
+  Eye,
+  Globe,
+  Lock,
+  Loader2,
 } from 'lucide-react';
 import { useState } from 'react';
 import { useQuery } from 'react-query';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, Link } from 'react-router-dom';
 
+import { getAdminPopularLists } from '../api';
 import ChatbotIcon from '../components/Chat/ChatbotIcon';
 import SEO from '../components/SEO';
 import { useAuth } from '../contexts/AuthContext';
@@ -69,6 +75,15 @@ const Admin = () => {
     getModerationPendingCounts,
     {
       refetchInterval: 15000, // Refetch every 15 seconds to keep counts fresh
+      enabled: !!user?.is_admin,
+    }
+  );
+
+  const { data: popularLists, isLoading: listsLoading } = useQuery(
+    ['admin-popular-lists', refreshKey],
+    getAdminPopularLists,
+    {
+      refetchInterval: 60000,
       enabled: !!user?.is_admin,
     }
   );
@@ -305,6 +320,81 @@ const Admin = () => {
               </div>
             </div>
           </div>
+        </div>
+
+        {/* Popular User Curated Lists */}
+        <div className='bg-white rounded-lg shadow-sm border border-gray-200 p-6 mt-6 md:mt-8'>
+          <h3 className='text-xl font-bold text-gray-900 mb-6 flex items-center gap-2'>
+            <Bookmark className='h-5 w-5 text-blue-600' />
+            Popular Curated Collections
+          </h3>
+          {listsLoading ? (
+            <div className='flex justify-center py-8'>
+              <Loader2 className='animate-spin text-blue-600 h-8 w-8' />
+            </div>
+          ) : !popularLists || popularLists.length === 0 ? (
+            <p className='text-center py-8 text-sm text-gray-500 italic'>
+              No collections created yet.
+            </p>
+          ) : (
+            <div className='overflow-x-auto'>
+              <table className='min-w-full divide-y divide-gray-200 text-sm'>
+                <thead className='bg-gray-50 font-semibold text-gray-700 text-xs uppercase tracking-wider text-left'>
+                  <tr>
+                    <th className='px-6 py-3'>List Title</th>
+                    <th className='px-6 py-3'>Owner</th>
+                    <th className='px-6 py-3'>Visibility</th>
+                    <th className='px-6 py-3 text-right'>Sites Count</th>
+                    <th className='px-6 py-3 text-right'>Views</th>
+                  </tr>
+                </thead>
+                <tbody className='divide-y divide-gray-100 text-gray-800 font-medium'>
+                  {popularLists.map(lst => (
+                    <tr key={lst.id} className='hover:bg-blue-50/20 transition-colors'>
+                      <td className='px-6 py-4'>
+                        <Link
+                          to={`/users/${lst.username}/lists/${lst.id}/${lst.slug}`}
+                          className='text-blue-600 hover:underline font-bold text-sm sm:text-base'
+                        >
+                          {lst.title}
+                        </Link>
+                        {lst.system_type && (
+                          <span className='ml-2 inline-flex items-center px-1.5 py-0.5 rounded text-[8px] font-bold bg-blue-50 text-blue-700 uppercase tracking-tighter'>
+                            SYSTEM
+                          </span>
+                        )}
+                      </td>
+                      <td className='px-6 py-4'>
+                        <Link
+                          to={`/users/${lst.username}`}
+                          className='text-gray-900 hover:underline font-bold'
+                        >
+                          @{lst.username}
+                        </Link>
+                      </td>
+                      <td className='px-6 py-4'>
+                        {lst.is_public ? (
+                          <span className='inline-flex items-center px-2 py-0.5 rounded-full text-xs font-bold bg-green-50 text-green-700 border border-green-100 gap-1'>
+                            <Globe size={11} /> Public
+                          </span>
+                        ) : (
+                          <span className='inline-flex items-center px-2 py-0.5 rounded-full text-xs font-bold bg-amber-50 text-amber-700 border border-amber-100 gap-1'>
+                            <Lock size={11} /> Private
+                          </span>
+                        )}
+                      </td>
+                      <td className='px-6 py-4 text-right text-gray-900 font-bold'>
+                        {lst.items?.length || 0}
+                      </td>
+                      <td className='px-6 py-4 text-right text-blue-600 font-extrabold flex items-center justify-end gap-1.5'>
+                        <Eye size={14} className='text-gray-400' /> {lst.view_count || 0}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
         </div>
       </div>
     </>

--- a/frontend/src/pages/DiveSiteDetail.jsx
+++ b/frontend/src/pages/DiveSiteDetail.jsx
@@ -22,6 +22,7 @@ import {
   CloudSun,
   Route,
   User,
+  Bookmark,
 } from 'lucide-react';
 import { useState, useEffect, useCallback, lazy, Suspense } from 'react';
 import { toast } from 'react-hot-toast';
@@ -50,6 +51,7 @@ import ReactImage from '../components/Lightbox/ReactImage';
 import WeatherConditionsCard from '../components/MarineConditionsCard';
 import MaskedEmail from '../components/MaskedEmail';
 import RateLimitError from '../components/RateLimitError';
+import SaveToListModal from '../components/SaveToListModal';
 import SEO from '../components/SEO';
 import ShareButton from '../components/ShareButton';
 import StickyRateBar from '../components/StickyRateBar';
@@ -92,6 +94,7 @@ const DiveSiteDetail = () => {
   const [comment, setComment] = useState('');
   const [showCommentForm, setShowCommentForm] = useState(false);
   const [isMapMaximized, setIsMapMaximized] = useState(false);
+  const [isSaveOpen, setIsSaveOpen] = useState(false);
   const [activeMediaTab, setActiveMediaTab] = useState('photos');
   const [activeContentTab, setActiveContentTab] = useState('description');
   const [lightboxIndex, setLightboxIndex] = useState(0);
@@ -701,6 +704,16 @@ const DiveSiteDetail = () => {
               entityData={diveSite}
               className='inline-flex items-center px-3 py-1.5 text-xs sm:text-sm font-medium rounded-md shadow-sm'
             />
+          )}
+          {diveSite && !diveSite.deleted_at && user && (
+            <Button
+              onClick={() => setIsSaveOpen(true)}
+              variant='primary'
+              size='sm'
+              icon={<Bookmark className='h-3.5 w-3.5 sm:h-4 sm:w-4' />}
+            >
+              Save to List
+            </Button>
           )}
           {(() => {
             const isOwner = user?.id === diveSite?.created_by;
@@ -1516,6 +1529,15 @@ const DiveSiteDetail = () => {
           setIsNearbyExpanded={setIsNearbyExpanded}
         />
       </div>
+
+      {diveSite && (
+        <SaveToListModal
+          isOpen={isSaveOpen}
+          onClose={() => setIsSaveOpen(false)}
+          diveSiteId={diveSite.id}
+          diveSiteName={diveSite.name}
+        />
+      )}
     </div>
   );
 };

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -31,6 +31,11 @@ import {
   Map,
   Star,
   Gauge,
+  Bookmark,
+  Eye,
+  Globe,
+  FolderHeart,
+  Loader2,
 } from 'lucide-react';
 import { useState, useEffect } from 'react';
 import { useForm, FormProvider } from 'react-hook-form';
@@ -38,7 +43,7 @@ import toast from 'react-hot-toast';
 import { useQuery, useMutation } from 'react-query';
 import { Link, useNavigate } from 'react-router-dom';
 
-import api, { getUserPublicProfile } from '../api';
+import api, { getUserPublicProfile, getMyLists, createList } from '../api';
 import Avatar from '../components/Avatar';
 import AvatarEditor from '../components/AvatarEditor';
 import { FormField } from '../components/forms/FormField';
@@ -73,6 +78,58 @@ const Profile = () => {
   const [editingCertification, setEditingCertification] = useState(null);
   const [availableLevels, setAvailableLevels] = useState([]);
   const [isAddingSocialLink, setIsAddingSocialLink] = useState(false);
+
+  const [lists, setLists] = useState([]);
+  const [loadingLists, setLoadingLists] = useState(true);
+  const [isAddingList, setIsAddingList] = useState(false);
+  const [newListTitle, setNewListTitle] = useState('');
+  const [newListDescription, setNewListDescription] = useState('');
+  const [newListIsPublic, setNewListIsPublic] = useState(true);
+  const [newListShowOnProfile, setNewListShowOnProfile] = useState(true);
+  const [creatingList, setCreatingList] = useState(false);
+
+  const fetchLists = async () => {
+    try {
+      setLoadingLists(true);
+      const data = await getMyLists();
+      setLists(data);
+    } catch (err) {
+      console.error('Failed to load lists:', err);
+    } finally {
+      setLoadingLists(false);
+    }
+  };
+
+  useEffect(() => {
+    if (user) {
+      fetchLists();
+    }
+  }, [user]);
+
+  const handleCreateList = async e => {
+    e.preventDefault();
+    if (!newListTitle.trim()) return;
+    setCreatingList(true);
+    try {
+      await createList({
+        title: newListTitle,
+        description: newListDescription,
+        is_public: newListIsPublic,
+        show_on_profile: newListShowOnProfile,
+      });
+      toast.success('Curated list created successfully!');
+      setNewListTitle('');
+      setNewListDescription('');
+      setNewListIsPublic(true);
+      setNewListShowOnProfile(true);
+      setIsAddingList(false);
+      fetchLists();
+    } catch (err) {
+      toast.error(`Failed to create list: ${err.message || 'An error occurred'}`);
+    } finally {
+      setCreatingList(false);
+    }
+  };
 
   // Profile Form
   const profileMethods = useForm({
@@ -807,10 +864,10 @@ const Profile = () => {
                   </form>
                 </FormProvider>
               ) : (
-                <div className='grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-6'>
+                <div className='grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-3.5 sm:gap-y-4'>
                   <div className='flex items-start'>
-                    <div className='bg-gray-100 p-2 rounded-lg mr-3 shrink-0'>
-                      <User className='h-5 w-5 text-blue-600' />
+                    <div className='bg-gray-100 p-1.5 rounded-lg mr-3 shrink-0'>
+                      <User className='h-4 w-4 text-blue-600' />
                     </div>
                     <div className='min-w-0'>
                       <span className='text-[10px] font-bold text-gray-500 uppercase tracking-wider block mb-0.5'>
@@ -821,8 +878,8 @@ const Profile = () => {
                   </div>
 
                   <div className='flex items-start'>
-                    <div className='bg-gray-100 p-2 rounded-lg mr-3 shrink-0'>
-                      <User className='h-5 w-5 text-blue-600' />
+                    <div className='bg-gray-100 p-1.5 rounded-lg mr-3 shrink-0'>
+                      <User className='h-4 w-4 text-blue-600' />
                     </div>
                     <div className='min-w-0'>
                       <span className='text-[10px] font-bold text-gray-500 uppercase tracking-wider block mb-0.5'>
@@ -835,8 +892,8 @@ const Profile = () => {
                   </div>
 
                   <div className='flex items-start'>
-                    <div className='bg-gray-100 p-2 rounded-lg mr-3 shrink-0'>
-                      <Mail className='h-5 w-5 text-blue-600' />
+                    <div className='bg-gray-100 p-1.5 rounded-lg mr-3 shrink-0'>
+                      <Mail className='h-4 w-4 text-blue-600' />
                     </div>
                     <div className='min-w-0'>
                       <span className='text-[10px] font-bold text-gray-500 uppercase tracking-wider block mb-0.5'>
@@ -849,15 +906,15 @@ const Profile = () => {
                   </div>
 
                   <div className='flex items-start'>
-                    <div className='bg-gray-100 p-2 rounded-lg mr-3 shrink-0'>
-                      <Activity className='h-5 w-5 text-blue-600' />
+                    <div className='bg-gray-100 p-1.5 rounded-lg mr-3 shrink-0'>
+                      <Activity className='h-4 w-4 text-blue-600' />
                     </div>
                     <div className='min-w-0'>
                       <span className='text-[10px] font-bold text-gray-500 uppercase tracking-wider block mb-0.5'>
                         Total Dives
                       </span>
                       <div className='flex items-baseline gap-2'>
-                        <p className='text-gray-900 font-bold text-lg'>
+                        <p className='text-gray-900 font-bold text-base sm:text-lg leading-tight'>
                           {(user?.number_of_dives || 0) +
                             (userStats?.dives_created || 0) +
                             (userStats?.buddy_dives_count || 0)}
@@ -871,8 +928,8 @@ const Profile = () => {
                   </div>
 
                   <div className='flex items-start'>
-                    <div className='bg-gray-100 p-2 rounded-lg mr-3 shrink-0'>
-                      <Shield className='h-5 w-5 text-blue-600' />
+                    <div className='bg-gray-100 p-1.5 rounded-lg mr-3 shrink-0'>
+                      <Shield className='h-4 w-4 text-blue-600' />
                     </div>
                     <div>
                       <span className='text-[10px] font-bold text-gray-500 uppercase tracking-wider block mb-0.5'>
@@ -890,8 +947,8 @@ const Profile = () => {
 
                   {ownedDivingCenters && ownedDivingCenters.length > 0 && (
                     <div className='flex items-start'>
-                      <div className='bg-gray-100 p-2 rounded-lg mr-3 shrink-0'>
-                        <Building2 className='h-5 w-5 text-blue-600' />
+                      <div className='bg-gray-100 p-1.5 rounded-lg mr-3 shrink-0'>
+                        <Building2 className='h-4 w-4 text-blue-600' />
                       </div>
                       <div className='flex-1 min-w-0'>
                         <span className='text-[10px] font-bold text-gray-500 uppercase tracking-wider block mb-0.5'>
@@ -913,8 +970,8 @@ const Profile = () => {
                   )}
 
                   <div className='flex items-start'>
-                    <div className='bg-gray-100 p-2 rounded-lg mr-3 shrink-0'>
-                      <Calendar className='h-5 w-5 text-blue-600' />
+                    <div className='bg-gray-100 p-1.5 rounded-lg mr-3 shrink-0'>
+                      <Calendar className='h-4 w-4 text-blue-600' />
                     </div>
                     <div>
                       <span className='text-[10px] font-bold text-gray-500 uppercase tracking-wider block mb-0.5'>
@@ -927,8 +984,8 @@ const Profile = () => {
                   </div>
 
                   <div className='flex items-start'>
-                    <div className='bg-gray-100 p-2 rounded-lg mr-3 shrink-0'>
-                      <Shield className='h-5 w-5 text-blue-600' />
+                    <div className='bg-gray-100 p-1.5 rounded-lg mr-3 shrink-0'>
+                      <Shield className='h-4 w-4 text-blue-600' />
                     </div>
                     <div>
                       <span className='text-[10px] font-bold text-gray-500 uppercase tracking-wider block mb-0.5'>
@@ -1091,6 +1148,165 @@ const Profile = () => {
               )}
             </div>
 
+            {/* My Curated Lists Section */}
+            <div className='bg-white p-4 sm:p-6 rounded-lg shadow-md mt-6'>
+              <div className='flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-6'>
+                <h2 className='text-lg sm:text-xl font-bold text-gray-900 uppercase tracking-tight flex items-center gap-2'>
+                  <Bookmark className='h-5 w-5 text-blue-600' />
+                  My Curated Lists
+                </h2>
+                <button
+                  onClick={() => setIsAddingList(!isAddingList)}
+                  className='flex items-center justify-center px-4 py-2.5 bg-blue-600 text-white rounded-md hover:bg-blue-700 font-semibold shadow-sm transition-all w-full sm:w-auto text-sm'
+                >
+                  <Plus className='h-4 w-4 mr-2' />
+                  Create List
+                </button>
+              </div>
+
+              {isAddingList && (
+                <form
+                  onSubmit={handleCreateList}
+                  className='mb-6 p-4 border border-gray-200 rounded-lg space-y-4 bg-gray-50/20'
+                >
+                  <div>
+                    <label className='block text-xs font-bold text-gray-500 uppercase tracking-wider mb-1'>
+                      List Title
+                    </label>
+                    <input
+                      type='text'
+                      placeholder='e.g., Summer 2026 Trip, Shipwrecks I Love...'
+                      value={newListTitle}
+                      onChange={e => setNewListTitle(e.target.value)}
+                      className='w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-blue-500 focus:border-blue-500 text-sm'
+                      maxLength={100}
+                      required
+                      disabled={creatingList}
+                    />
+                  </div>
+                  <div>
+                    <label className='block text-xs font-bold text-gray-500 uppercase tracking-wider mb-1'>
+                      Description (Optional)
+                    </label>
+                    <textarea
+                      placeholder='What is this collection about?'
+                      value={newListDescription}
+                      onChange={e => setNewListDescription(e.target.value)}
+                      className='w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-blue-500 focus:border-blue-500 focus:border-gray-500 dark:bg-gray-700 dark:border-gray-600 dark:text-white'
+                      disabled={creatingList}
+                    />
+                  </div>
+                  <div className='flex flex-wrap gap-4 sm:gap-8'>
+                    <label className='flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300 cursor-pointer'>
+                      <input
+                        type='checkbox'
+                        checked={newListIsPublic}
+                        onChange={e => {
+                          const checked = e.target.checked;
+                          setNewListIsPublic(checked);
+                          if (!checked) {
+                            setNewListShowOnProfile(false);
+                          }
+                        }}
+                        className='rounded border-gray-300 text-blue-600 focus:ring-blue-500'
+                        disabled={creatingList}
+                      />
+                      <span>Publicly viewable</span>
+                    </label>
+                    <label
+                      className={`flex items-center gap-2 text-sm font-semibold ${
+                        !newListIsPublic
+                          ? 'text-gray-400 dark:text-gray-600 cursor-not-allowed'
+                          : 'text-gray-700 dark:text-gray-300 cursor-pointer'
+                      }`}
+                    >
+                      <input
+                        type='checkbox'
+                        checked={newListIsPublic && newListShowOnProfile}
+                        onChange={e => setNewListShowOnProfile(e.target.checked)}
+                        className='rounded border-gray-300 text-blue-600 focus:ring-blue-500'
+                        disabled={creatingList || !newListIsPublic}
+                      />
+                      <span>Show on Public Profile</span>
+                    </label>
+                  </div>
+                  <div className='flex justify-end gap-2 pt-2 border-t border-gray-100'>
+                    <button
+                      type='button'
+                      onClick={() => setIsAddingList(false)}
+                      className='px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50 font-semibold text-sm'
+                      disabled={creatingList}
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      type='submit'
+                      className='px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 font-semibold text-sm flex items-center gap-1 shadow-sm'
+                      disabled={creatingList || !newListTitle.trim()}
+                    >
+                      {creatingList ? <Loader2 className='animate-spin h-4 w-4' /> : 'Create List'}
+                    </button>
+                  </div>
+                </form>
+              )}
+
+              {loadingLists ? (
+                <div className='flex justify-center py-8'>
+                  <Loader2 className='animate-spin text-blue-600 h-8 w-8' />
+                </div>
+              ) : lists.length === 0 ? (
+                <div className='text-center py-8 border border-dashed border-gray-200 rounded-lg'>
+                  <p className='text-gray-500 text-sm italic mb-2'>
+                    You haven't created any collections yet.
+                  </p>
+                  <p className='text-gray-400 text-xs'>
+                    Your standard system favorites and wishlist folders are automatically
+                    initialized when you bookmark your first dive site!
+                  </p>
+                </div>
+              ) : (
+                <div className='grid grid-cols-1 md:grid-cols-2 gap-4'>
+                  {lists.map(lst => (
+                    <Link
+                      key={lst.id}
+                      to={`/users/${user?.username}/lists/${lst.id}/${lst.slug}`}
+                      className='block p-4 border border-gray-200 rounded-lg hover:border-blue-300 hover:shadow-sm transition-all group bg-gray-50/10'
+                    >
+                      <div className='flex justify-between items-start gap-2 mb-1'>
+                        <span className='font-bold text-gray-900 group-hover:text-blue-600 transition-colors text-sm sm:text-base'>
+                          {lst.title}
+                        </span>
+                        <div className='flex gap-1 flex-shrink-0'>
+                          {lst.system_type && (
+                            <span className='inline-flex items-center px-1.5 py-0.5 rounded text-[8px] font-bold bg-blue-50 text-blue-700 border border-blue-100 uppercase tracking-tighter'>
+                              SYSTEM
+                            </span>
+                          )}
+                          {!lst.is_public && (
+                            <span className='inline-flex items-center px-1.5 py-0.5 rounded text-[8px] font-bold bg-amber-50 text-amber-700 border border-amber-100 uppercase tracking-tighter gap-0.5'>
+                              <Lock size={8} /> PRIVATE
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                      {lst.description && (
+                        <p className='text-xs text-gray-500 line-clamp-2 mb-3'>{lst.description}</p>
+                      )}
+                      <div className='flex items-center gap-4 text-[11px] text-gray-400 font-medium'>
+                        <span className='flex items-center gap-0.5'>
+                          <FolderHeart className='h-3.5 w-3.5 text-blue-500' />
+                          {lst.items?.length || 0} sites
+                        </span>
+                        <span className='flex items-center gap-0.5'>
+                          <Eye className='h-3.5 w-3.5 text-gray-400' />
+                          {lst.view_count || 0} views
+                        </span>
+                      </div>
+                    </Link>
+                  ))}
+                </div>
+              )}
+            </div>
             {/* Certifications Section */}
             <div className='bg-white p-4 sm:p-6 rounded-lg shadow-md mt-6'>
               <div className='flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-6'>

--- a/frontend/src/pages/UserListDetail.jsx
+++ b/frontend/src/pages/UserListDetail.jsx
@@ -1,0 +1,550 @@
+import L from 'leaflet';
+import 'leaflet/dist/leaflet.css';
+import {
+  Bookmark,
+  Eye,
+  Globe,
+  Lock,
+  ArrowUp,
+  ArrowDown,
+  Trash2,
+  Calendar,
+  MessageSquare,
+  ChevronLeft,
+  Loader2,
+  MapPin,
+  FileText,
+} from 'lucide-react';
+import React, { useState, useEffect, useRef } from 'react';
+import { toast } from 'react-hot-toast';
+import { MapContainer, TileLayer, Marker, Popup, useMap } from 'react-leaflet';
+import { useParams, Link, useNavigate } from 'react-router-dom';
+
+import {
+  getListById,
+  updateList,
+  deleteList,
+  updateListItem,
+  deleteListItem,
+  reorderListItems,
+} from '../api';
+import Avatar from '../components/Avatar';
+import ShareButton from '../components/ShareButton';
+import Button from '../components/ui/Button';
+import DifficultyBadge from '../components/ui/DifficultyBadge';
+import { useAuth } from '../contexts/AuthContext';
+import { formatDate } from '../utils/dateHelpers';
+
+// Fix Leaflet marker icons
+delete L.Icon.Default.prototype._getIconUrl;
+L.Icon.Default.mergeOptions({
+  iconRetinaUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.7.1/images/marker-icon-2x.png',
+  iconUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.7.1/images/marker-icon.png',
+  shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.7.1/images/marker-shadow.png',
+});
+
+// Helper component to adjust bounds of Leaflet map dynamically
+const SetMapBounds = ({ items }) => {
+  const map = useMap();
+  useEffect(() => {
+    if (!map || items.length === 0) return;
+    const points = items
+      .filter(item => item.dive_site?.latitude && item.dive_site?.longitude)
+      .map(item => [Number(item.dive_site.latitude), Number(item.dive_site.longitude)]);
+    if (points.length > 0) {
+      const bounds = L.latLngBounds(points);
+      map.fitBounds(bounds, { padding: [40, 40], maxZoom: 14 });
+    }
+  }, [map, items]);
+  return null;
+};
+
+const UserListDetail = () => {
+  const { username, id } = useParams();
+  const navigate = useNavigate();
+  const { user } = useAuth();
+  const [list, setList] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [updatingMeta, setUpdatingMeta] = useState(false);
+  const [activeSiteId, setActiveSiteId] = useState(null);
+
+  // References for in-place edit input blurs
+  const titleInputRef = useRef(null);
+  const descInputRef = useRef(null);
+
+  const isOwner = user && list && user.id === list.user_id;
+
+  const fetchListDetails = async () => {
+    try {
+      setLoading(true);
+      const data = await getListById(id);
+      setList(data);
+    } catch (err) {
+      console.error(err);
+      toast.error('Failed to load list details. It may be private or deleted.');
+      navigate('/profile');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchListDetails();
+  }, [id]);
+
+  const handleMetaUpdate = async (field, value) => {
+    if (!isOwner) return;
+    try {
+      setUpdatingMeta(true);
+      const updated = await updateList(id, { [field]: value });
+      setList(prev => ({
+        ...prev,
+        title: updated.title,
+        description: updated.description,
+        is_public: updated.is_public,
+        show_on_profile: updated.show_on_profile,
+        slug: updated.slug,
+      }));
+    } catch (err) {
+      toast.error(err.message || 'Failed to update settings');
+    } finally {
+      setUpdatingMeta(false);
+    }
+  };
+
+  const handleItemNoteUpdate = async (itemId, notes) => {
+    if (!isOwner) return;
+    try {
+      await updateListItem(id, itemId, { notes });
+      setList(prev => ({
+        ...prev,
+        items: prev.items.map(item => (item.id === itemId ? { ...item, notes } : item)),
+      }));
+      toast.success('Note updated!');
+    } catch (err) {
+      toast.error('Failed to save note');
+    }
+  };
+
+  const handleRemoveItem = async itemId => {
+    if (!isOwner) return;
+    if (window.confirm('Are you sure you want to remove this dive site from your collection?')) {
+      try {
+        await deleteListItem(id, itemId);
+        setList(prev => ({
+          ...prev,
+          items: prev.items.filter(item => item.id !== itemId),
+        }));
+        toast.success('Site removed successfully!');
+      } catch (err) {
+        toast.error('Failed to remove site');
+      }
+    }
+  };
+
+  const handleMoveItem = async (index, direction) => {
+    if (!isOwner) return;
+    const newItems = [...list.items];
+    const targetIndex = index + direction;
+    if (targetIndex < 0 || targetIndex >= newItems.length) return;
+
+    // Swap elements
+    const temp = newItems[index];
+    newItems[index] = newItems[targetIndex];
+    newItems[targetIndex] = temp;
+
+    // Adjust orders locally
+    newItems.forEach((item, idx) => {
+      item.display_order = idx;
+    });
+
+    setList(prev => ({ ...prev, items: newItems }));
+
+    try {
+      await reorderListItems(
+        id,
+        newItems.map(it => it.id)
+      );
+    } catch (err) {
+      toast.error('Failed to save collection order');
+    }
+  };
+
+  const handleDeleteList = async () => {
+    if (!isOwner) return;
+    if (list.system_type) {
+      toast.error('System lists cannot be deleted');
+      return;
+    }
+    if (
+      window.confirm(
+        `Are you absolutely sure you want to delete the list "${list.title}"? This cannot be undone.`
+      )
+    ) {
+      try {
+        await deleteList(id);
+        toast.success('Collection deleted successfully!');
+        navigate('/profile');
+      } catch (err) {
+        toast.error('Failed to delete list');
+      }
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className='flex items-center justify-center min-h-[60vh]'>
+        <Loader2 className='animate-spin text-blue-600 dark:text-blue-400 h-10 w-10' />
+      </div>
+    );
+  }
+
+  if (!list) return null;
+
+  return (
+    <div className='min-h-screen bg-gray-50 dark:bg-gray-900 pb-12'>
+      {/* Top Banner/Navigation */}
+      <div className='bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 py-4 px-4 sm:px-6 lg:px-8 shadow-sm'>
+        <div className='max-w-7xl mx-auto flex flex-wrap items-center justify-between gap-4'>
+          <div className='flex items-center gap-2'>
+            <button
+              onClick={() => navigate(-1)}
+              className='flex items-center text-sm font-semibold text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 gap-1'
+            >
+              <ChevronLeft className='h-4 w-4' /> Back
+            </button>
+            <span className='text-gray-300 dark:text-gray-600'>|</span>
+            <div className='flex items-center gap-2'>
+              <Avatar username={username} size='xs' />
+              <Link
+                to={`/users/${username}`}
+                className='text-xs sm:text-sm font-bold text-blue-600 dark:text-blue-400 hover:underline'
+              >
+                @{username}
+              </Link>
+            </div>
+          </div>
+
+          <div className='flex items-center gap-2'>
+            {list.is_public && (
+              <ShareButton
+                entityType='list'
+                entityData={list}
+                className='inline-flex items-center text-xs font-semibold px-3 py-2 border rounded-md shadow-sm border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700'
+              />
+            )}
+            {isOwner && !list.system_type && (
+              <Button
+                variant='outline'
+                size='sm'
+                onClick={handleDeleteList}
+                className='text-red-500 hover:text-red-700 dark:text-red-400 border-red-200 hover:bg-red-50 dark:hover:bg-red-950/20'
+              >
+                <Trash2 className='h-4 w-4 mr-1' /> Delete List
+              </Button>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div className='max-w-7xl mx-auto mt-6 px-4 sm:px-6 lg:px-8'>
+        {/* Detail Header Block */}
+        <div className='bg-white dark:bg-gray-800 rounded-2xl p-6 shadow-sm border border-gray-200/50 dark:border-gray-700 space-y-4 mb-6'>
+          <div className='flex flex-col md:flex-row md:items-start justify-between gap-4'>
+            <div className='space-y-2 flex-1 min-w-0'>
+              {isOwner && !list.system_type ? (
+                <input
+                  ref={titleInputRef}
+                  type='text'
+                  defaultValue={list.title}
+                  onBlur={e => {
+                    const val = e.target.value.trim();
+                    if (val && val !== list.title) {
+                      handleMetaUpdate('title', val);
+                    }
+                  }}
+                  className='text-2xl sm:text-3xl font-display font-extrabold text-gray-900 dark:text-white bg-transparent border-b border-transparent hover:border-gray-300 focus:border-blue-500 focus:outline-none w-full pb-1'
+                  title='Click to edit title'
+                />
+              ) : (
+                <h1 className='text-2xl sm:text-3xl font-display font-extrabold text-gray-900 dark:text-white break-words leading-tight flex items-center gap-2'>
+                  <Bookmark className='h-7 w-7 text-blue-600 dark:text-blue-400 shrink-0' />
+                  {list.title}
+                </h1>
+              )}
+
+              {isOwner ? (
+                <textarea
+                  ref={descInputRef}
+                  defaultValue={list.description || ''}
+                  placeholder='Write an optional description for this collection...'
+                  onBlur={e => {
+                    const val = e.target.value.trim();
+                    if (val !== (list.description || '')) {
+                      handleMetaUpdate('description', val || null);
+                    }
+                  }}
+                  className='text-sm text-gray-500 dark:text-gray-400 bg-transparent border border-transparent hover:border-gray-200 focus:border-blue-500 focus:outline-none w-full p-1 rounded-md resize-y'
+                  rows={2}
+                />
+              ) : (
+                list.description && (
+                  <p className='text-sm text-gray-600 dark:text-gray-400 leading-relaxed font-normal whitespace-pre-wrap'>
+                    {list.description}
+                  </p>
+                )
+              )}
+            </div>
+
+            {/* List Properties & Privacy Switches */}
+            <div className='flex flex-wrap items-center gap-3 shrink-0'>
+              {isOwner ? (
+                <div className='flex flex-col sm:flex-row gap-4 p-3 bg-gray-50 dark:bg-gray-900 rounded-xl border border-gray-100 dark:border-gray-700/50'>
+                  <label className='flex items-center gap-2 text-xs font-bold text-gray-700 dark:text-gray-300 cursor-pointer'>
+                    <input
+                      type='checkbox'
+                      checked={list.is_public}
+                      onChange={e => handleMetaUpdate('is_public', e.target.checked)}
+                      className='rounded border-gray-300 text-blue-600 focus:ring-blue-500 h-4 w-4'
+                    />
+                    <span className='flex items-center gap-1 uppercase tracking-wider'>
+                      {list.is_public ? (
+                        <Globe size={13} className='text-green-500' />
+                      ) : (
+                        <Lock size={13} className='text-amber-500' />
+                      )}
+                      Public
+                    </span>
+                  </label>
+
+                  <label
+                    className={`flex items-center gap-2 text-xs font-bold uppercase tracking-wider ${
+                      !list.is_public
+                        ? 'text-gray-400 dark:text-gray-600 cursor-not-allowed'
+                        : 'text-gray-700 dark:text-gray-300 cursor-pointer'
+                    }`}
+                  >
+                    <input
+                      type='checkbox'
+                      checked={list.is_public && list.show_on_profile}
+                      onChange={e => handleMetaUpdate('show_on_profile', e.target.checked)}
+                      disabled={!list.is_public}
+                      className={`rounded border-gray-300 text-blue-600 focus:ring-blue-500 h-4 w-4 ${
+                        !list.is_public ? 'opacity-50 cursor-not-allowed' : ''
+                      }`}
+                    />
+                    <span>On Profile</span>
+                  </label>
+                </div>
+              ) : (
+                <div className='flex items-center gap-2'>
+                  <span className='inline-flex items-center px-2 py-0.5 rounded text-xs font-bold border gap-1 bg-white dark:bg-gray-800 dark:border-gray-700 text-gray-500'>
+                    {list.is_public ? (
+                      <>
+                        <Globe size={12} className='text-green-500' /> Public Collection
+                      </>
+                    ) : (
+                      <>
+                        <Lock size={12} className='text-amber-500' /> Private Collection
+                      </>
+                    )}
+                  </span>
+                </div>
+              )}
+
+              {/* Views & Metrics */}
+              <div className='flex gap-2 text-xs font-bold text-gray-400 bg-gray-50 dark:bg-gray-900 border px-3 py-1.5 rounded-lg border-gray-100 dark:border-gray-700'>
+                <span className='flex items-center gap-1'>
+                  <Calendar className='h-3.5 w-3.5' /> Created {formatDate(list.created_at)}
+                </span>
+                <span className='text-gray-200 dark:text-gray-700'>|</span>
+                <span className='flex items-center gap-1'>
+                  <Eye className='h-3.5 w-3.5' /> {list.view_count || 0} views
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Double Splitscreen Column Layout (Map + Cards List) */}
+        <div className='grid grid-cols-1 lg:grid-cols-5 gap-6 items-start'>
+          {/* Map Column (Lg: spans 2/5) */}
+          <div className='lg:col-span-2 bg-white dark:bg-gray-800 rounded-2xl shadow-sm border border-gray-200/50 dark:border-gray-700 overflow-hidden h-[300px] lg:h-[650px] lg:sticky lg:top-6 z-10'>
+            <MapContainer
+              center={[37.9838, 23.7275]} // Athens backup center
+              zoom={6}
+              className='w-full h-full'
+              style={{ zIndex: 1 }}
+            >
+              <TileLayer
+                attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+                url='https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'
+              />
+              <SetMapBounds items={list.items} />
+              {list.items
+                .filter(item => item.dive_site?.latitude && item.dive_site?.longitude)
+                .map(item => (
+                  <Marker
+                    key={item.id}
+                    position={[Number(item.dive_site.latitude), Number(item.dive_site.longitude)]}
+                    eventHandlers={{
+                      click: () => setActiveSiteId(item.dive_site.id),
+                    }}
+                  >
+                    <Popup>
+                      <div className='p-1'>
+                        <h4 className='font-bold text-sm leading-snug'>{item.dive_site.name}</h4>
+                        <p className='text-xs text-gray-500 dark:text-gray-400 mt-1 capitalize'>
+                          📍 {item.dive_site.region}, {item.dive_site.country}
+                        </p>
+                        <Link
+                          to={`/dive-sites/${item.dive_site.id}/${item.dive_site.slug || ''}`}
+                          className='text-xs text-blue-600 hover:underline font-bold block mt-2'
+                        >
+                          View Details
+                        </Link>
+                      </div>
+                    </Popup>
+                  </Marker>
+                ))}
+            </MapContainer>
+          </div>
+
+          {/* Cards Column (Lg: spans 3/5) */}
+          <div className='lg:col-span-3 space-y-4'>
+            {list.items.length === 0 ? (
+              <div className='bg-white dark:bg-gray-800 rounded-2xl p-12 shadow-sm border border-gray-200/50 dark:border-gray-700 text-center space-y-2'>
+                <MapPin className='h-12 w-12 text-gray-300 mx-auto' />
+                <h3 className='text-lg font-bold text-gray-800 dark:text-gray-200'>
+                  Empty Collection
+                </h3>
+                <p className='text-sm text-gray-500 dark:text-gray-400 max-w-sm mx-auto'>
+                  No dive sites have been added to this list yet. Discover top dive sites on Divemap
+                  and save them to list!
+                </p>
+                <div className='pt-2'>
+                  <Link to='/dive-sites'>
+                    <Button size='sm'>Browse Dive Sites</Button>
+                  </Link>
+                </div>
+              </div>
+            ) : (
+              list.items.map((item, index) => {
+                const site = item.dive_site;
+                const isActive = activeSiteId === site.id;
+
+                return (
+                  <div
+                    key={item.id}
+                    id={`list-item-${site.id}`}
+                    className={`bg-white dark:bg-gray-800 rounded-2xl p-5 shadow-sm border transition-all duration-300 relative ${
+                      isActive
+                        ? 'border-blue-500 ring-2 ring-blue-500/20'
+                        : 'border-gray-200/50 dark:border-gray-700 hover:border-blue-100/50 dark:hover:border-blue-900/30'
+                    }`}
+                  >
+                    <div className='flex gap-4 items-start'>
+                      {/* Ranking Index / Reordering Controls */}
+                      <div className='flex flex-col items-center gap-1 shrink-0 p-1 bg-gray-50 dark:bg-gray-900 rounded-xl border border-gray-100 dark:border-gray-700/50 w-10 sm:w-12'>
+                        {isOwner && (
+                          <button
+                            onClick={() => handleMoveItem(index, -1)}
+                            disabled={index === 0}
+                            className='p-1 text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 disabled:opacity-30'
+                            title='Move Up'
+                          >
+                            <ArrowUp className='h-4 w-4' />
+                          </button>
+                        )}
+                        <span className='font-display font-extrabold text-lg text-gray-900 dark:text-white'>
+                          {index + 1}
+                        </span>
+                        {isOwner && (
+                          <button
+                            onClick={() => handleMoveItem(index, 1)}
+                            disabled={index === list.items.length - 1}
+                            className='p-1 text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 disabled:opacity-30'
+                            title='Move Down'
+                          >
+                            <ArrowDown className='h-4 w-4' />
+                          </button>
+                        )}
+                      </div>
+
+                      {/* Item Meta & Actions */}
+                      <div className='flex-1 min-w-0 space-y-3'>
+                        <div className='flex justify-between items-start gap-2'>
+                          <div className='min-w-0'>
+                            <Link
+                              to={`/dive-sites/${site.id}/${site.slug || ''}`}
+                              className='text-base sm:text-lg font-bold text-gray-900 dark:text-white hover:text-blue-600 transition-colors block truncate'
+                            >
+                              {site.name}
+                            </Link>
+                            <p className='text-xs text-gray-400 dark:text-gray-500 font-medium truncate mt-0.5 capitalize'>
+                              📍 {site.region ? `${site.region}, ` : ''}
+                              {site.country}
+                            </p>
+                          </div>
+                          {isOwner && (
+                            <button
+                              onClick={() => handleRemoveItem(item.id)}
+                              className='text-gray-400 hover:text-red-500 p-1 hover:bg-red-50 dark:hover:bg-red-950/20 rounded-md transition-colors'
+                              title='Remove from list'
+                            >
+                              <Trash2 className='h-4.5 w-4.5' />
+                            </button>
+                          )}
+                        </div>
+
+                        {/* Badges block */}
+                        <div className='flex flex-wrap gap-2 items-center'>
+                          <DifficultyBadge
+                            code={site.difficulty_code}
+                            label={site.difficulty_label}
+                          />
+                          {site.max_depth && (
+                            <span className='inline-flex items-center text-[10px] font-bold bg-blue-50/50 dark:bg-blue-900/10 text-blue-600 border border-blue-100/50 dark:border-blue-900/30 px-2 py-0.5 rounded'>
+                              Max Depth: {site.max_depth}m
+                            </span>
+                          )}
+                        </div>
+
+                        {/* Custom notes segment */}
+                        <div className='mt-3 bg-blue-50/20 dark:bg-blue-950/10 rounded-xl p-4 border border-blue-100/30 dark:border-blue-900/10 relative'>
+                          <div className='flex items-center gap-1.5 text-blue-600 dark:text-blue-400 font-bold text-xs uppercase tracking-wider mb-1.5'>
+                            <FileText className='h-3.5 w-3.5' />
+                            {isOwner ? 'Custom Annotations (Editable)' : 'Curator Annotations'}
+                          </div>
+                          {isOwner ? (
+                            <textarea
+                              defaultValue={item.notes || ''}
+                              placeholder='Add some personal tips, landmarks or directions for this dive site...'
+                              onBlur={e => {
+                                const val = e.target.value.trim();
+                                if (val !== (item.notes || '')) {
+                                  handleItemNoteUpdate(item.id, val || null);
+                                }
+                              }}
+                              className='w-full text-sm text-gray-700 dark:text-gray-300 bg-transparent border-b border-transparent hover:border-gray-200 focus:border-blue-500 focus:outline-none py-1 resize-y min-h-[48px]'
+                            />
+                          ) : (
+                            <p className='text-sm text-gray-600 dark:text-gray-300 leading-relaxed italic'>
+                              {item.notes || 'No annotations written yet.'}
+                            </p>
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                );
+              })
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default UserListDetail;

--- a/frontend/src/pages/UserProfile.jsx
+++ b/frontend/src/pages/UserProfile.jsx
@@ -39,6 +39,10 @@ import {
   Trophy,
   Medal,
   Globe,
+  Bookmark,
+  Eye,
+  FolderHeart,
+  Loader2,
 } from 'lucide-react';
 import { useState, useEffect, useMemo } from 'react';
 import toast from 'react-hot-toast';
@@ -51,6 +55,7 @@ import {
   getUserFriendships,
   sendFriendRequest,
   createChatRoom,
+  getUserPublicLists,
 } from '../api';
 import Avatar from '../components/Avatar';
 import OrganizationLogo from '../components/OrganizationLogo';
@@ -176,6 +181,8 @@ const UserProfile = () => {
   const [error, setError] = useState(null);
   const [friendshipStatus, setFriendshipStatus] = useState(null); // null, 'PENDING', 'ACCEPTED'
   const [isProcessingFriendship, setIsProcessingFriendship] = useState(false);
+  const [lists, setLists] = useState([]);
+  const [loadingLists, setLoadingLists] = useState(true);
 
   useEffect(() => {
     const fetchProfile = async () => {
@@ -184,6 +191,16 @@ const UserProfile = () => {
         setError(null);
         const data = await getUserPublicProfile(username);
         setProfile(data);
+
+        // Fetch lists
+        try {
+          const listsData = await getUserPublicLists(username);
+          setLists(listsData);
+        } catch (listsErr) {
+          console.error('Failed to fetch user public lists:', listsErr);
+        } finally {
+          setLoadingLists(false);
+        }
 
         // Fetch friendship status if logged in and not viewing self
         if (currentUser && currentUser.username !== username) {
@@ -1150,6 +1167,59 @@ const UserProfile = () => {
                 </div>
               </div>
             )}
+
+            {/* Curated Lists / Collections */}
+            <div className='bg-white dark:bg-gray-800 rounded-lg shadow-md p-4 sm:p-6 border border-gray-100 dark:border-gray-700'>
+              <h2 className='text-xl font-semibold text-gray-900 dark:text-white mb-6 flex items-center gap-2'>
+                <Bookmark className='h-5 w-5 text-blue-600 dark:text-blue-400' />
+                Curated Collections
+              </h2>
+              {loadingLists ? (
+                <div className='flex justify-center py-6'>
+                  <Loader2 className='animate-spin text-blue-600 dark:text-blue-400 h-6 w-6' />
+                </div>
+              ) : lists.length === 0 ? (
+                <p className='text-center py-6 text-sm text-gray-500 dark:text-gray-400 italic'>
+                  No public collections displayed yet.
+                </p>
+              ) : (
+                <div className='grid grid-cols-1 md:grid-cols-2 gap-4'>
+                  {lists.map(lst => (
+                    <Link
+                      key={lst.id}
+                      to={`/users/${username}/lists/${lst.id}/${lst.slug}`}
+                      className='block p-4 rounded-xl border border-gray-100 dark:border-gray-700 hover:border-blue-100 dark:hover:border-blue-900 hover:shadow-sm transition-all duration-200 bg-gray-50/30 dark:bg-gray-900/10'
+                    >
+                      <div className='flex justify-between items-start gap-2 mb-1'>
+                        <h3 className='font-bold text-gray-900 dark:text-white text-base hover:text-blue-600 dark:hover:text-blue-400 transition-colors leading-snug'>
+                          {lst.title}
+                        </h3>
+                        {lst.system_type && (
+                          <span className='inline-flex items-center px-2 py-0.5 rounded-full text-[9px] font-bold bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300 uppercase tracking-tighter'>
+                            DEFAULT
+                          </span>
+                        )}
+                      </div>
+                      {lst.description && (
+                        <p className='text-sm text-gray-500 dark:text-gray-400 line-clamp-2 mb-3'>
+                          {lst.description}
+                        </p>
+                      )}
+                      <div className='flex items-center gap-4 text-xs text-gray-400 dark:text-gray-500 font-medium'>
+                        <span className='flex items-center gap-1'>
+                          <FolderHeart className='h-3.5 w-3.5 text-blue-500' />
+                          {lst.items?.length || 0} sites
+                        </span>
+                        <span className='flex items-center gap-1'>
+                          <Eye className='h-3.5 w-3.5 text-gray-400' />
+                          {lst.view_count || 0} views
+                        </span>
+                      </div>
+                    </Link>
+                  ))}
+                </div>
+              )}
+            </div>
 
             {/* Mobile Certifications (hidden on lg) */}
             {profile.certifications && profile.certifications.length > 0 && (

--- a/frontend/src/utils/shareUtils.js
+++ b/frontend/src/utils/shareUtils.js
@@ -32,6 +32,9 @@ export function generateShareUrl(entityType, entityId, params = {}, baseUrl = nu
     case 'diving-center':
       path = `/diving-centers/${entityId}${slug}`;
       break;
+    case 'list':
+      path = `/users/${params.username}/lists/${entityId}${slug}`;
+      break;
     default:
       throw new Error(`Unknown entity type: ${entityType}`);
   }
@@ -101,6 +104,7 @@ export function getTwitterShareUrl(url, title, description = '', entityType = ''
     'dive-site': 'dive site',
     route: 'dive route',
     'diving-center': 'diving center',
+    list: 'curated list',
   };
   const entityLabel = entityLabels[entityType] || '';
   const prefix = entityLabel ? `Check out this ${entityLabel} on Divemap: ` : '';
@@ -135,6 +139,7 @@ export function getFacebookShareUrl(url, title = '', entityType = '') {
       'dive-site': 'dive site',
       route: 'dive route',
       'diving-center': 'diving center',
+      list: 'curated list',
     };
     const entityLabel = entityLabels[entityType] || '';
     const quote = entityLabel ? `Check out this ${entityLabel} on Divemap: ${title}` : title;
@@ -158,6 +163,7 @@ export function getWhatsAppShareUrl(url, title, description = '', entityType = '
     'dive-site': 'dive site',
     route: 'dive route',
     'diving-center': 'diving center',
+    list: 'curated list',
   };
   const entityLabel = entityLabels[entityType] || '';
   const prefix = entityLabel ? `Check out this ${entityLabel} on Divemap: ` : '';
@@ -186,6 +192,7 @@ export function getViberShareUrl(url, title, description = '', entityType = '') 
     'dive-site': 'dive site',
     route: 'dive route',
     'diving-center': 'diving center',
+    list: 'curated list',
   };
   const entityLabel = entityLabels[entityType] || '';
   const prefix = entityLabel ? `Check out this ${entityLabel} on Divemap: ` : '';
@@ -213,6 +220,7 @@ export function getRedditShareUrl(url, title, entityType = '') {
     'dive-site': 'dive site',
     route: 'dive route',
     'diving-center': 'diving center',
+    list: 'curated list',
   };
   const entityLabel = entityLabels[entityType] || '';
   const redditTitle = entityLabel ? `Check out this ${entityLabel} on Divemap: ${title}` : title;
@@ -239,6 +247,7 @@ export function getEmailShareUrl(url, title, description = '', entityType = '') 
     'dive-site': 'dive site',
     route: 'dive route',
     'diving-center': 'diving center',
+    list: 'curated list',
   };
   const entityLabel = entityLabels[entityType] || '';
   const subjectText = entityLabel
@@ -434,6 +443,22 @@ export function generateShareContent(entityType, entityData) {
 
       url = generateShareUrl('diving-center', entityData.id, {
         slug: slugify(entityData.name || ''),
+      });
+      break;
+
+    case 'list':
+      title = entityData.title || 'Curated Dive Site List';
+      description =
+        entityData.description || `Explore this curated collection of dive sites on Divemap!`;
+
+      // Add item stats if available
+      if (entityData.items && entityData.items.length > 0) {
+        description += `\n\nContains ${entityData.items.length} top dive sites curated by ${entityData.username || 'a user'}.`;
+      }
+
+      url = generateShareUrl('list', entityData.id, {
+        username: entityData.username,
+        slug: slugify(entityData.title || 'list'),
       });
       break;
 


### PR DESCRIPTION
Implement user curated dive site collections feature

Add normalized relational database tables for `dive_site_lists`
and `dive_site_list_items`. Build complete REST endpoints under
`/api/v1/lists` and user profile delegation at
`/api/v1/users/{username}/lists`.

- Support system default "My Favorites" and "My Wishlist" auto-init.
- Support background, transaction-safe list view tracking.
- Build premium "Save to List" modal with checkmarks.
- Implement custom ordering and custom annotations on items.
- Build split-screen interactive list detail pages with maps.
- Include social media share extensions and admin statistics.
- Optimize profile page real estate by condensing account metadata.
- Re-order profile sections to place list collections above certifications.
- Enforce strict logical dependency where public profile listing of a collection requires public visibility to be checked first.