### PR TITLE
Implement collaborative dive site lists

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -162,6 +162,11 @@ Documentation is consolidated in the `docs/` directory. Major changes should be 
 - **Performance:** Eliminate waterfalls (parallelize async), use `React.lazy` for heavy components, and animate wrapper `div`s (not SVGs).
 - **Architecture:** Avoid 'barrel files', place interaction logic in event handlers (not effects), and use functional state updates.
 - **State:** Use lazy initialization `useState(() => ...)` for expensive values (and localStorage!), and `useRef` for transient high-frequency updates.
+- **Temporal Dead Zone (TDZ):** Always define component constants derived from hooks or state (like `isOwner` or `canEdit`) *above* any hook definitions (like `useEffect`) that reference them to prevent `ReferenceError: Cannot access 'X' before initialization` during component mounting.
+
+## Backend Development Best Practices
+- **FastAPI Background Tasks & Session Lifetimes:** NEVER pass the active request's `db` session dependency directly to a background task (using `background_tasks.add_task`). Because the HTTP request finishes and closes/recycles the request session before the background task completes, this triggers a `DetachedInstanceError`. Instead, import `SessionLocal` and instantiate/close an isolated session locally inside the task function using a `try...finally` block.
+- **N+1 Query Prevention:** When serializing lists containing nested relational data (such as user models or owners), always use SQLAlchemy's `joinedload` (e.g., `joinedload(DiveSiteList.user)`) in the initial query to eager-load the records. Avoid querying the database inside loops (`db.query().filter()`), as it leads to $N+1$ query performance degradation on profiles.
 
 ## UI Styling Standards
 - **Standardized Hover:** Use `hover:bg-interactive-hover` and `dark:hover:bg-interactive-hover-dark` for high-interaction lists (notifications, chat, buddy requests) to ensure brand-consistent visual feedback.

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -200,6 +200,7 @@ class User(Base):
     social_links = relationship("UserSocialLink", back_populates="user", cascade="all, delete-orphan")
     push_subscriptions = relationship("PushSubscription", back_populates="user", cascade="all, delete-orphan")
     dive_site_lists = relationship("DiveSiteList", back_populates="user", cascade="all, delete-orphan")
+    collaborating_lists = relationship("DiveSiteListCollaborator", back_populates="user", cascade="all, delete-orphan")
 
 class UserSocialLink(Base):
     __tablename__ = "user_social_links"
@@ -242,6 +243,7 @@ class DiveSiteList(Base):
         cascade="all, delete-orphan",
         order_by="DiveSiteListItem.display_order"
     )
+    collaborators = relationship("DiveSiteListCollaborator", back_populates="list", cascade="all, delete-orphan")
 
 class DiveSiteListItem(Base):
     __tablename__ = "dive_site_list_items"
@@ -261,6 +263,33 @@ class DiveSiteListItem(Base):
     __table_args__ = (
         sa.UniqueConstraint('list_id', 'dive_site_id', name='uq_list_dive_site'),
     )
+
+class DiveSiteListCollaborator(Base):
+    __tablename__ = "dive_site_list_collaborators"
+    __table_args__ = (
+        sa.UniqueConstraint('list_id', 'user_id', name='uq_list_collaborator'),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    list_id = Column(Integer, ForeignKey("dive_site_lists.id", ondelete="CASCADE"), nullable=False, index=True)
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
+    role = Column(String(20), default="editor", nullable=False)
+    show_on_profile = Column(Boolean, default=True, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+    # Relationships
+    list = relationship("DiveSiteList", back_populates="collaborators")
+    user = relationship("User", back_populates="collaborating_lists")
+
+    @property
+    def username(self) -> str:
+        if hasattr(self, "_username_val") and self._username_val:
+            return self._username_val
+        return self.user.username if self.user else "unknown"
+
+    @username.setter
+    def username(self, value: str):
+        self._username_val = value
 
 class DiveSite(Base):
     __tablename__ = "dive_sites"

--- a/backend/app/routers/lists.py
+++ b/backend/app/routers/lists.py
@@ -47,45 +47,51 @@ def check_list_write_permission(list_id: int, user: User, db: Session) -> DiveSi
         
     return lst
 
-def notify_collaborative_list_activity(list_id: int, initiator_id: int, action: str, details: str, db: Session):
-    # Fetch list and collaborators
-    lst = db.query(DiveSiteList).filter(DiveSiteList.id == list_id).first()
-    if not lst:
-        return
+def notify_collaborative_list_activity(list_id: int, initiator_id: int, action: str, details: str, db: Optional[Session] = None):
+    from app.database import SessionLocal
+    local_db = db or SessionLocal()
+    try:
+        # Fetch list and collaborators
+        lst = local_db.query(DiveSiteList).filter(DiveSiteList.id == list_id).first()
+        if not lst:
+            return
+            
+        initiator = local_db.query(User).filter(User.id == initiator_id).first()
+        initiator_username = initiator.username if initiator else "Someone"
         
-    initiator = db.query(User).filter(User.id == initiator_id).first()
-    initiator_username = initiator.username if initiator else "Someone"
-    
-    # Participants
-    participants = {lst.user_id} | {c.user_id for c in lst.collaborators}
-    target_users = participants - {initiator_id}
-    
-    owner = db.query(User).filter(User.id == lst.user_id).first()
-    owner_username = owner.username if owner else "unknown"
-    
-    message_body = ""
-    if action == "add":
-        message_body = f"{initiator_username} added {details} to the list '{lst.title}'."
-    elif action == "edit_notes":
-        message_body = f"{initiator_username} updated notes for {details} in the list '{lst.title}'."
-    elif action == "remove":
-        message_body = f"{initiator_username} removed {details} from the list '{lst.title}'."
-    elif action == "reorder":
-        message_body = f"{initiator_username} reordered the dive sites in the list '{lst.title}'."
+        # Participants
+        participants = {lst.user_id} | {c.user_id for c in lst.collaborators}
+        target_users = participants - {initiator_id}
         
-    from app.services.notification_service import NotificationService
-    notif_service = NotificationService()
-    
-    for uid in target_users:
-        notif_service.create_notification(
-            user_id=uid,
-            category="collaborative_list",
-            title=f"List Updated: {lst.title}",
-            message=message_body,
-            link_url=f"/users/{owner_username}/lists/{lst.id}/{lst.slug}",
-            entity_type="dive_site",
-            db=db
-        )
+        owner = local_db.query(User).filter(User.id == lst.user_id).first()
+        owner_username = owner.username if owner else "unknown"
+        
+        message_body = ""
+        if action == "add":
+            message_body = f"{initiator_username} added {details} to the list '{lst.title}'."
+        elif action == "edit_notes":
+            message_body = f"{initiator_username} updated notes for {details} in the list '{lst.title}'."
+        elif action == "remove":
+            message_body = f"{initiator_username} removed {details} from the list '{lst.title}'."
+        elif action == "reorder":
+            message_body = f"{initiator_username} reordered the dive sites in the list '{lst.title}'."
+            
+        from app.services.notification_service import NotificationService
+        notif_service = NotificationService()
+        
+        for uid in target_users:
+            notif_service.create_notification(
+                user_id=uid,
+                category="collaborative_list",
+                title=f"List Updated: {lst.title}",
+                message=message_body,
+                link_url=f"/users/{owner_username}/lists/{lst.id}/{lst.slug}",
+                entity_type="dive_site",
+                db=local_db
+            )
+    finally:
+        if not db:
+            local_db.close()
 
 @router.get("/my-lists", response_model=List[UserDiveSiteListResponse])
 async def get_my_lists(
@@ -102,7 +108,8 @@ async def get_my_lists(
         joinedload(DiveSiteList.items).joinedload(DiveSiteListItem.dive_site).options(
             selectinload(DiveSite.tags).joinedload(DiveSiteTag.tag)
         ),
-        joinedload(DiveSiteList.collaborators).joinedload(DiveSiteListCollaborator.user)
+        joinedload(DiveSiteList.collaborators).joinedload(DiveSiteListCollaborator.user),
+        joinedload(DiveSiteList.user)
     ).all()
     
     # Query mappings where current user is a collaborator
@@ -112,7 +119,8 @@ async def get_my_lists(
         joinedload(DiveSiteListCollaborator.list).joinedload(DiveSiteList.items).joinedload(DiveSiteListItem.dive_site).options(
             selectinload(DiveSite.tags).joinedload(DiveSiteTag.tag)
         ),
-        joinedload(DiveSiteListCollaborator.list).joinedload(DiveSiteList.collaborators).joinedload(DiveSiteListCollaborator.user)
+        joinedload(DiveSiteListCollaborator.list).joinedload(DiveSiteList.collaborators).joinedload(DiveSiteListCollaborator.user),
+        joinedload(DiveSiteListCollaborator.list).joinedload(DiveSiteList.user)
     ).all()
     
     collab_lists = [mapping.list for mapping in collab_mappings if mapping.list]
@@ -121,8 +129,7 @@ async def get_my_lists(
     
     # Set helper properties for response serialization
     for lst in all_lists:
-        owner = db.query(User).filter(User.id == lst.user_id).first()
-        lst.username = owner.username if owner else "unknown"
+        lst.username = lst.user.username if lst.user else "unknown"
         lst.is_collaborator = (lst.user_id != current_user.id)
         lst.role = "owner" if lst.user_id == current_user.id else "editor"
         sanitize_list_for_response(lst)
@@ -301,7 +308,7 @@ async def add_list_item(
     if db_item and db_item.dive_site:
         db_item.dive_site.tags = []
         
-    background_tasks.add_task(notify_collaborative_list_activity, list_id, current_user.id, "add", site.name, db)
+    background_tasks.add_task(notify_collaborative_list_activity, list_id, current_user.id, "add", site.name)
     return db_item
 
 @router.put("/{list_id}/items/{item_id}", response_model=DiveSiteListItemResponse)
@@ -331,7 +338,7 @@ async def update_list_item(
     db.refresh(item)
     
     site_name = item.dive_site.name if item.dive_site else "a site"
-    background_tasks.add_task(notify_collaborative_list_activity, list_id, current_user.id, "edit_notes", site_name, db)
+    background_tasks.add_task(notify_collaborative_list_activity, list_id, current_user.id, "edit_notes", site_name)
     return item
 
 @router.delete("/{list_id}/items/{item_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -355,7 +362,7 @@ async def remove_list_item(
     db.delete(item)
     db.commit()
     
-    background_tasks.add_task(notify_collaborative_list_activity, list_id, current_user.id, "remove", site_name, db)
+    background_tasks.add_task(notify_collaborative_list_activity, list_id, current_user.id, "remove", site_name)
     return None
 
 @router.put("/{list_id}/reorder")
@@ -377,7 +384,7 @@ async def reorder_list_items(
             item_map[item_id].display_order = index
 
     db.commit()
-    background_tasks.add_task(notify_collaborative_list_activity, list_id, current_user.id, "reorder", "", db)
+    background_tasks.add_task(notify_collaborative_list_activity, list_id, current_user.id, "reorder", "")
     return {"status": "success"}
 
 @router.post("/{list_id}/collaborators", response_model=CollaboratorResponse, status_code=status.HTTP_201_CREATED)

--- a/backend/app/routers/lists.py
+++ b/backend/app/routers/lists.py
@@ -4,13 +4,14 @@ from datetime import datetime
 from fastapi import APIRouter, Depends, HTTPException, status, Request, BackgroundTasks
 from sqlalchemy.orm import Session, joinedload, selectinload
 from app.database import get_db
-from app.models import DiveSiteList, DiveSiteListItem, DiveSite, User, DiveSiteTag
+from app.models import DiveSiteList, DiveSiteListItem, DiveSite, User, DiveSiteTag, DiveSiteListCollaborator, UserFriendship
 from app.auth import get_current_active_user, get_current_user_optional, get_current_admin_user
 from app.utils import increment_view_count
 from app.schemas import (
     UserDiveSiteListResponse, UserDiveSiteListCreate, UserDiveSiteListUpdate,
     DiveSiteListItemResponse, DiveSiteListItemCreate, DiveSiteListItemUpdate,
-    UserDiveSiteListReorder, UserDiveSiteListMembershipResponse
+    UserDiveSiteListReorder, UserDiveSiteListMembershipResponse,
+    CollaboratorResponse, AddCollaboratorRequest, UpdateCollaboratorPreference
 )
 
 router = APIRouter()
@@ -25,26 +26,108 @@ def sanitize_list_for_response(lst: Optional[DiveSiteList]) -> Optional[DiveSite
     """Sanitize nested dive site tags list objects to match Pydantic schema validation expectation"""
     return lst
 
+def check_list_write_permission(list_id: int, user: User, db: Session) -> DiveSiteList:
+    lst = db.query(DiveSiteList).filter(DiveSiteList.id == list_id).first()
+    if not lst:
+        raise HTTPException(status_code=404, detail="List not found")
+    
+    # 1. Owner & Admin check
+    if lst.user_id == user.id or user.is_admin:
+        return lst
+        
+    # 2. Collaborator check
+    collab = db.query(DiveSiteListCollaborator).filter(
+        DiveSiteListCollaborator.list_id == list_id,
+        DiveSiteListCollaborator.user_id == user.id,
+        DiveSiteListCollaborator.role == "editor"
+    ).first()
+    
+    if not collab:
+        raise HTTPException(status_code=403, detail="You do not have write access to this list")
+        
+    return lst
+
+def notify_collaborative_list_activity(list_id: int, initiator_id: int, action: str, details: str, db: Session):
+    # Fetch list and collaborators
+    lst = db.query(DiveSiteList).filter(DiveSiteList.id == list_id).first()
+    if not lst:
+        return
+        
+    initiator = db.query(User).filter(User.id == initiator_id).first()
+    initiator_username = initiator.username if initiator else "Someone"
+    
+    # Participants
+    participants = {lst.user_id} | {c.user_id for c in lst.collaborators}
+    target_users = participants - {initiator_id}
+    
+    owner = db.query(User).filter(User.id == lst.user_id).first()
+    owner_username = owner.username if owner else "unknown"
+    
+    message_body = ""
+    if action == "add":
+        message_body = f"{initiator_username} added {details} to the list '{lst.title}'."
+    elif action == "edit_notes":
+        message_body = f"{initiator_username} updated notes for {details} in the list '{lst.title}'."
+    elif action == "remove":
+        message_body = f"{initiator_username} removed {details} from the list '{lst.title}'."
+    elif action == "reorder":
+        message_body = f"{initiator_username} reordered the dive sites in the list '{lst.title}'."
+        
+    from app.services.notification_service import NotificationService
+    notif_service = NotificationService()
+    
+    for uid in target_users:
+        notif_service.create_notification(
+            user_id=uid,
+            category="collaborative_list",
+            title=f"List Updated: {lst.title}",
+            message=message_body,
+            link_url=f"/users/{owner_username}/lists/{lst.id}/{lst.slug}",
+            entity_type="dive_site",
+            db=db
+        )
+
 @router.get("/my-lists", response_model=List[UserDiveSiteListResponse])
 async def get_my_lists(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_active_user)
 ):
-    """Get all curated lists of the authenticated user (including system lists)"""
+    """Get all curated lists of the authenticated user (including system lists and collaborative lists)"""
     ensure_default_lists(db, current_user.id)
-    lists = db.query(DiveSiteList).filter(
+    
+    # Query lists owned by the current user
+    owned_lists = db.query(DiveSiteList).filter(
         DiveSiteList.user_id == current_user.id
     ).options(
         joinedload(DiveSiteList.items).joinedload(DiveSiteListItem.dive_site).options(
             selectinload(DiveSite.tags).joinedload(DiveSiteTag.tag)
-        )
+        ),
+        joinedload(DiveSiteList.collaborators).joinedload(DiveSiteListCollaborator.user)
     ).all()
     
-    # Map usernames and sanitize tags
-    for lst in lists:
-        lst.username = current_user.username
+    # Query mappings where current user is a collaborator
+    collab_mappings = db.query(DiveSiteListCollaborator).filter(
+        DiveSiteListCollaborator.user_id == current_user.id
+    ).options(
+        joinedload(DiveSiteListCollaborator.list).joinedload(DiveSiteList.items).joinedload(DiveSiteListItem.dive_site).options(
+            selectinload(DiveSite.tags).joinedload(DiveSiteTag.tag)
+        ),
+        joinedload(DiveSiteListCollaborator.list).joinedload(DiveSiteList.collaborators).joinedload(DiveSiteListCollaborator.user)
+    ).all()
+    
+    collab_lists = [mapping.list for mapping in collab_mappings if mapping.list]
+    
+    all_lists = owned_lists + collab_lists
+    
+    # Set helper properties for response serialization
+    for lst in all_lists:
+        owner = db.query(User).filter(User.id == lst.user_id).first()
+        lst.username = owner.username if owner else "unknown"
+        lst.is_collaborator = (lst.user_id != current_user.id)
+        lst.role = "owner" if lst.user_id == current_user.id else "editor"
         sanitize_list_for_response(lst)
-    return lists
+        
+    return all_lists
 
 @router.post("", response_model=UserDiveSiteListResponse, status_code=status.HTTP_201_CREATED)
 async def create_list(
@@ -84,7 +167,8 @@ async def get_list_by_id(
     lst = db.query(DiveSiteList).filter(DiveSiteList.id == list_id).options(
         joinedload(DiveSiteList.items).joinedload(DiveSiteListItem.dive_site).options(
             selectinload(DiveSite.tags).joinedload(DiveSiteTag.tag)
-        )
+        ),
+        joinedload(DiveSiteList.collaborators).joinedload(DiveSiteListCollaborator.user)
     ).first()
 
     if not lst:
@@ -95,8 +179,22 @@ async def get_list_by_id(
 
     # Privacy enforcement
     is_owner = current_user and current_user.id == lst.user_id
-    if not lst.is_public and not is_owner and not (current_user and current_user.is_admin):
+    is_collab = False
+    collab_role = None
+    if current_user:
+        collab_entry = db.query(DiveSiteListCollaborator).filter(
+            DiveSiteListCollaborator.list_id == list_id,
+            DiveSiteListCollaborator.user_id == current_user.id
+        ).first()
+        if collab_entry:
+            is_collab = True
+            collab_role = collab_entry.role
+
+    if not lst.is_public and not is_owner and not is_collab and not (current_user and current_user.is_admin):
         raise HTTPException(status_code=403, detail="This list is private")
+
+    lst.is_collaborator = is_collab
+    lst.role = "owner" if is_owner else collab_role
 
     # Track views
     if not is_owner:
@@ -166,13 +264,12 @@ async def delete_list(
 async def add_list_item(
     list_id: int,
     data: DiveSiteListItemCreate,
+    background_tasks: BackgroundTasks,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_active_user)
 ):
     """Add a site to a list with optional notes"""
-    lst = db.query(DiveSiteList).filter(DiveSiteList.id == list_id).first()
-    if not lst or lst.user_id != current_user.id:
-        raise HTTPException(status_code=403, detail="Unauthorized")
+    lst = check_list_write_permission(list_id, current_user, db)
 
     # Check site exists
     site = db.query(DiveSite).filter(DiveSite.id == data.dive_site_id).first()
@@ -203,6 +300,8 @@ async def add_list_item(
     db_item = db.query(DiveSiteListItem).options(joinedload(DiveSiteListItem.dive_site)).filter(DiveSiteListItem.id == item.id).first()
     if db_item and db_item.dive_site:
         db_item.dive_site.tags = []
+        
+    background_tasks.add_task(notify_collaborative_list_activity, list_id, current_user.id, "add", site.name, db)
     return db_item
 
 @router.put("/{list_id}/items/{item_id}", response_model=DiveSiteListItemResponse)
@@ -210,6 +309,7 @@ async def update_list_item(
     list_id: int,
     item_id: int,
     data: DiveSiteListItemUpdate,
+    background_tasks: BackgroundTasks,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_active_user)
 ):
@@ -218,8 +318,9 @@ async def update_list_item(
         DiveSiteListItem.id == item_id,
         DiveSiteListItem.list_id == list_id
     ).first()
-    if not item or item.list.user_id != current_user.id:
-        raise HTTPException(status_code=403, detail="Unauthorized")
+    if not item:
+        raise HTTPException(status_code=404, detail="List item not found")
+    check_list_write_permission(list_id, current_user, db)
 
     if data.notes is not None:
         item.notes = data.notes
@@ -228,12 +329,16 @@ async def update_list_item(
 
     db.commit()
     db.refresh(item)
+    
+    site_name = item.dive_site.name if item.dive_site else "a site"
+    background_tasks.add_task(notify_collaborative_list_activity, list_id, current_user.id, "edit_notes", site_name, db)
     return item
 
 @router.delete("/{list_id}/items/{item_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def remove_list_item(
     list_id: int,
     item_id: int,
+    background_tasks: BackgroundTasks,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_active_user)
 ):
@@ -242,24 +347,27 @@ async def remove_list_item(
         DiveSiteListItem.id == item_id,
         DiveSiteListItem.list_id == list_id
     ).first()
-    if not item or item.list.user_id != current_user.id:
-        raise HTTPException(status_code=403, detail="Unauthorized")
+    if not item:
+        raise HTTPException(status_code=404, detail="List item not found")
+    check_list_write_permission(list_id, current_user, db)
 
+    site_name = item.dive_site.name if item.dive_site else "a site"
     db.delete(item)
     db.commit()
+    
+    background_tasks.add_task(notify_collaborative_list_activity, list_id, current_user.id, "remove", site_name, db)
     return None
 
 @router.put("/{list_id}/reorder")
 async def reorder_list_items(
     list_id: int,
     data: UserDiveSiteListReorder,
+    background_tasks: BackgroundTasks,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_active_user)
 ):
     """Bulk reorder items of a list securely in a single transaction"""
-    lst = db.query(DiveSiteList).filter(DiveSiteList.id == list_id).first()
-    if not lst or lst.user_id != current_user.id:
-        raise HTTPException(status_code=403, detail="Unauthorized")
+    lst = check_list_write_permission(list_id, current_user, db)
 
     items = db.query(DiveSiteListItem).filter(DiveSiteListItem.list_id == list_id).all()
     item_map = {item.id: item for item in items}
@@ -269,7 +377,154 @@ async def reorder_list_items(
             item_map[item_id].display_order = index
 
     db.commit()
+    background_tasks.add_task(notify_collaborative_list_activity, list_id, current_user.id, "reorder", "", db)
     return {"status": "success"}
+
+@router.post("/{list_id}/collaborators", response_model=CollaboratorResponse, status_code=status.HTTP_201_CREATED)
+async def add_list_collaborator(
+    list_id: int,
+    data: AddCollaboratorRequest,
+    background_tasks: BackgroundTasks,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user)
+):
+    lst = db.query(DiveSiteList).filter(DiveSiteList.id == list_id).first()
+    if not lst or lst.user_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Only list owners can manage collaborators")
+
+    if lst.system_type:
+        raise HTTPException(status_code=403, detail="System lists cannot have collaborators")
+
+    target_user = db.query(User).filter(User.username == data.username).first()
+    if not target_user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    # Enforce accepted friendships
+    friendship = db.query(UserFriendship).filter(
+        ((UserFriendship.user_id == current_user.id) & (UserFriendship.friend_id == target_user.id)) |
+        ((UserFriendship.user_id == target_user.id) & (UserFriendship.friend_id == current_user.id)),
+        UserFriendship.status == "ACCEPTED"
+    ).first()
+    if not friendship:
+        raise HTTPException(status_code=400, detail="You can only collaborate with accepted buddies")
+
+    # Check already exists
+    exists = db.query(DiveSiteListCollaborator).filter(
+        DiveSiteListCollaborator.list_id == list_id,
+        DiveSiteListCollaborator.user_id == target_user.id
+    ).first()
+    if exists:
+        raise HTTPException(status_code=400, detail="User is already a collaborator")
+
+    collab = DiveSiteListCollaborator(
+        list_id=list_id,
+        user_id=target_user.id,
+        role="editor",
+        show_on_profile=True
+    )
+    db.add(collab)
+    db.commit()
+    db.refresh(collab)
+    
+    # 1. Trigger Web Push System Notification and Email
+    from app.services.notification_service import NotificationService
+    notif_service = NotificationService()
+    notification = notif_service.create_notification(
+        user_id=target_user.id,
+        category="collaborative_list",
+        title="New Shared List",
+        message=f"{current_user.username} added you as an editor on '{lst.title}'",
+        link_url=f"/users/{current_user.username}/lists/{lst.id}/{lst.slug}",
+        db=db
+    )
+    if notification:
+        # Trigger email delivery logic 
+        notif_service._queue_email_notification(notification, target_user, 'shared_list', db)
+    
+    # 2. Inject interactive shared list card inside DM chat if room exists
+    try:
+        from app.models import UserChatRoom, UserChatRoomMember, UserChatMessage
+        from sqlalchemy import func
+        from app.services.encryption_service import encrypt_message
+        import json
+        
+        room_ids_subquery = db.query(UserChatRoomMember.room_id).filter(
+            UserChatRoomMember.user_id.in_([current_user.id, target_user.id])
+        ).group_by(UserChatRoomMember.room_id).having(func.count(UserChatRoomMember.user_id) == 2).subquery()
+
+        room = db.query(UserChatRoom).filter(
+            UserChatRoom.id.in_(room_ids_subquery),
+            UserChatRoom.is_group == False,
+            UserChatRoom.diving_center_id.is_(None)
+        ).first()
+        
+        if room:
+            payload = json.dumps({
+                "list_id": lst.id,
+                "list_slug": lst.slug,
+                "list_title": lst.title,
+                "text": f"{current_user.username} added you as a collaborator on the list '{lst.title}'."
+            })
+            ciphertext = encrypt_message(payload, room.encrypted_dek)
+            msg = UserChatMessage(
+                room_id=room.id,
+                sender_id=current_user.id,
+                content=ciphertext,
+                message_type="system_shared_list"
+            )
+            db.add(msg)
+            db.commit()
+    except Exception as e:
+        import logging
+        logging.getLogger(__name__).error(f"Failed to inject shared list card in DM chat: {e}")
+    
+    # Dynamic fields for response mapping
+    collab.username = target_user.username
+    return collab
+
+@router.delete("/{list_id}/collaborators/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def remove_list_collaborator(
+    list_id: int,
+    user_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user)
+):
+    lst = db.query(DiveSiteList).filter(DiveSiteList.id == list_id).first()
+    if not lst:
+        raise HTTPException(status_code=404, detail="List not found")
+
+    if lst.user_id != current_user.id and current_user.id != user_id:
+        raise HTTPException(status_code=403, detail="Unauthorized")
+
+    collab = db.query(DiveSiteListCollaborator).filter(
+        DiveSiteListCollaborator.list_id == list_id,
+        DiveSiteListCollaborator.user_id == user_id
+    ).first()
+    if not collab:
+        raise HTTPException(status_code=404, detail="Collaborator not found")
+
+    db.delete(collab)
+    db.commit()
+    return None
+
+@router.put("/{list_id}/collaborators/preference", response_model=CollaboratorResponse)
+async def update_collaborator_profile_preference(
+    list_id: int,
+    data: UpdateCollaboratorPreference,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user)
+):
+    collab = db.query(DiveSiteListCollaborator).filter(
+        DiveSiteListCollaborator.list_id == list_id,
+        DiveSiteListCollaborator.user_id == current_user.id
+    ).first()
+    if not collab:
+        raise HTTPException(status_code=404, detail="Collaborator not found")
+
+    collab.show_on_profile = data.show_on_profile
+    db.commit()
+    db.refresh(collab)
+    return collab
 
 @router.get("/dive-site/{dive_site_id}/my-status", response_model=List[UserDiveSiteListMembershipResponse])
 async def get_dive_site_membership_status(

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -996,12 +996,12 @@ async def get_user_public_lists(
         joinedload(DiveSiteList.items).joinedload(DiveSiteListItem.dive_site).options(
             selectinload(DiveSite.tags).joinedload(DiveSiteTag.tag)
         ),
-        joinedload(DiveSiteList.collaborators).joinedload(DiveSiteListCollaborator.user)
+        joinedload(DiveSiteList.collaborators).joinedload(DiveSiteListCollaborator.user),
+        joinedload(DiveSiteList.user)
     ).all()
 
     for lst in lists:
-        owner = db.query(User).filter(User.id == lst.user_id).first()
-        lst.username = owner.username if owner else "unknown"
+        lst.username = lst.user.username if lst.user else "unknown"
         lst.is_collaborator = (lst.user_id != user.id)
         lst.role = "owner" if lst.user_id == user.id else "editor"
         sanitize_list_for_response(lst)

--- a/backend/app/routers/users.py
+++ b/backend/app/routers/users.py
@@ -974,20 +974,36 @@ async def get_user_public_lists(
     from app.routers.lists import ensure_default_lists, sanitize_list_for_response
     ensure_default_lists(db, user.id)
 
-    # Public profile endpoint always returns only public lists flagged to be shown on public profiles
+    from app.models import DiveSiteListCollaborator
+    from sqlalchemy import or_
+
+    # Subquery to find list IDs where this profile user is a collaborator and show_on_profile is True
+    collab_list_ids_subquery = db.query(DiveSiteListCollaborator.list_id).filter(
+        DiveSiteListCollaborator.user_id == user.id,
+        DiveSiteListCollaborator.show_on_profile == True
+    ).subquery()
+
+    # Query public lists owned by the user, or public lists where the user is a collaborator
     query = db.query(DiveSiteList).filter(
-        DiveSiteList.user_id == user.id,
         DiveSiteList.is_public == True,
-        DiveSiteList.show_on_profile == True
+        or_(
+            (DiveSiteList.user_id == user.id) & (DiveSiteList.show_on_profile == True),
+            DiveSiteList.id.in_(collab_list_ids_subquery)
+        )
     )
 
     lists = query.options(
         joinedload(DiveSiteList.items).joinedload(DiveSiteListItem.dive_site).options(
             selectinload(DiveSite.tags).joinedload(DiveSiteTag.tag)
-        )
+        ),
+        joinedload(DiveSiteList.collaborators).joinedload(DiveSiteListCollaborator.user)
     ).all()
+
     for lst in lists:
-        lst.username = user.username
+        owner = db.query(User).filter(User.id == lst.user_id).first()
+        lst.username = owner.username if owner else "unknown"
+        lst.is_collaborator = (lst.user_id != user.id)
+        lst.role = "owner" if lst.user_id == user.id else "editor"
         sanitize_list_for_response(lst)
     return lists
 

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -889,6 +889,22 @@ class DiveSiteListItemResponse(BaseModel):
 
     model_config = ConfigDict(from_attributes=True)
 
+class CollaboratorResponse(BaseModel):
+    id: int
+    user_id: int
+    username: str
+    role: str
+    show_on_profile: bool
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+class AddCollaboratorRequest(BaseModel):
+    username: str = Field(..., description="Username of the buddy to add")
+
+class UpdateCollaboratorPreference(BaseModel):
+    show_on_profile: bool
+
 class UserDiveSiteListResponse(BaseModel):
     id: int
     user_id: int
@@ -903,6 +919,9 @@ class UserDiveSiteListResponse(BaseModel):
     created_at: datetime
     updated_at: datetime
     items: List[DiveSiteListItemResponse] = []
+    collaborators: List[CollaboratorResponse] = []
+    is_collaborator: bool = False
+    role: Optional[str] = None
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/backend/app/templates/emails/shared_list.html
+++ b/backend/app/templates/emails/shared_list.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>{{ notification.title }} - {{ site_name }}</title>
+    <style type="text/css">
+        @media only screen and (max-width: 600px) {
+            .email-container { width: 100% !important; padding: 10px !important; }
+            .email-content { padding: 30px 20px !important; }
+            .email-header { padding: 25px 15px !important; }
+            .logo-img { height: 90px !important; }
+            .header-title { font-size: 22px !important; }
+            .footer-content { padding: 20px 15px !important; }
+            .icon-circle { width: 50px !important; height: 50px !important; }
+            .icon-emoji { font-size: 26px !important; }
+        }
+    </style>
+</head>
+<body style="margin: 0; padding: 0; background-color: #f0f4f7; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;">
+    <div style="display: none; max-height: 0; overflow: hidden; font-size: 1px; line-height: 1px; color: transparent;">
+        {{ notification.title }} - {{ notification.message }}
+    </div>
+    
+    <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="background-color: #f0f4f7; padding: 20px 0;">
+        <tr>
+            <td align="center" class="email-container" style="padding: 20px 10px;">
+                <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="max-width: 600px; background-color: #ffffff; border-radius: 12px; overflow: hidden; box-shadow: 0 4px 12px rgba(0,0,0,0.08);">
+                    
+                    <!-- Header -->
+                    <tr>
+                        <td class="email-header" style="background: linear-gradient(135deg, #0072B2 0%, #004d7a 100%); padding: 35px 30px; text-align: center;">
+                            <div>
+                                <img src="https://raw.githubusercontent.com/kargig/divemap/refs/heads/main/frontend/public/divemap_navbar_logo.png" alt="{{ site_name }} Logo" class="logo-img" width="120" height="120" style="display: block; height: 120px; width: auto; margin: 0 auto 12px;">
+                                <h1 class="header-title" style="margin: 0; color: #ffffff; font-size: 28px; font-weight: 600; text-shadow: 0 1px 3px rgba(0,0,0,0.2); letter-spacing: 0.5px;">{{ site_name }}</h1>
+                            </div>
+                        </td>
+                    </tr>
+                    
+                    <!-- Main Content -->
+                    <tr>
+                        <td class="email-content" style="padding: 50px 40px; background-color: #ffffff;">
+                            
+                            <!-- Icon Header -->
+                            <div style="text-align: center; margin-bottom: 30px;">
+                                <div class="icon-circle" style="width: 60px; height: 60px; background: linear-gradient(135deg, #e0f2fe 0%, #bae6fd 100%); border-radius: 50%; margin: 0 auto 20px; display: table-cell; vertical-align: middle; text-align: center;">
+                                    <span class="icon-emoji" style="font-size: 32px; line-height: 60px; display: inline-block; vertical-align: middle;">🤝</span>
+                                </div>
+                                <h2 style="color: #0072B2; margin: 0 0 15px 0; font-size: 26px; font-weight: 700; line-height: 1.3;">{{ notification.title }}</h2>
+                            </div>
+                            
+                            <p style="color: #475569; font-size: 16px; line-height: 1.7; margin-bottom: 30px; text-align: center;">
+                                {{ notification.message }}
+                            </p>
+                            
+                            {% if notification.link_url %}
+                            <!-- CTA Button -->
+                            <div style="text-align: center; margin: 40px 0;">
+                                <a href="{{ site_url }}{{ notification.link_url }}" style="display: inline-block; background: linear-gradient(135deg, #0072B2 0%, #004d7a 100%); color: #ffffff; padding: 18px 40px; text-decoration: none; border-radius: 8px; font-weight: 600; font-size: 17px; box-shadow: 0 4px 12px rgba(0, 114, 178, 0.35); letter-spacing: 0.3px;">
+                                    View Shared List
+                                </a>
+                            </div>
+                            {% endif %}
+                            
+                        </td>
+                    </tr>
+                    
+                    <!-- Footer -->
+                    <tr>
+                        <td class="footer-content" style="background: linear-gradient(180deg, #f8fafc 0%, #f1f5f9 100%); padding: 30px 40px; text-align: center; border-top: 1px solid #e2e8f0;">
+                            <p style="margin: 0 0 12px 0; color: #64748b; font-size: 13px;">
+                                You're receiving this email because you have notifications enabled for collaborative lists.
+                            </p>
+                            {% if unsubscribe_url and unsubscribe_all_url %}
+                            <p style="margin: 0 0 12px 0; color: #64748b; font-size: 12px;">
+                                <a href="{{ unsubscribe_url }}" style="color: #64748b; text-decoration: underline;">Unsubscribe from list emails</a> | 
+                                <a href="{{ unsubscribe_all_url }}" style="color: #64748b; text-decoration: underline;">Unsubscribe from all emails</a>
+                            </p>
+                            {% endif %}
+                            <p style="margin: 0 0 20px 0;">
+                                <a href="{{ site_url }}/profile/notifications" style="display: inline-block; color: #0072B2; text-decoration: none; font-weight: 600; font-size: 14px; padding: 10px 20px; border: 2px solid #0072B2; border-radius: 6px;">
+                                    Manage Preferences
+                                </a>
+                            </p>
+                            <p style="margin: 0; color: #94a3b8; font-size: 11px; line-height: 1.5;">
+                                &copy; {{ current_year }} {{ site_name }}. All rights reserved.
+                            </p>
+                        </td>
+                    </tr>
+                    
+                </table>
+            </td>
+        </tr>
+    </table>
+</body>
+</html>

--- a/backend/app/templates/emails/shared_list.txt
+++ b/backend/app/templates/emails/shared_list.txt
@@ -1,0 +1,20 @@
+{{ notification.title }} - {{ site_name }}
+=========================================
+
+{{ notification.message }}
+
+{% if notification.link_url %}
+View Shared List:
+{{ site_url }}{{ notification.link_url }}
+{% endif %}
+
+-----------------------------------------
+You're receiving this email because you have notifications enabled for collaborative lists.
+
+{% if unsubscribe_url and unsubscribe_all_url %}
+Unsubscribe from list emails: {{ unsubscribe_url }}
+Unsubscribe from all emails: {{ unsubscribe_all_url }}
+{% endif %}
+
+Manage Preferences: {{ site_url }}/profile/notifications
+© {{ current_year }} {{ site_name }}. All rights reserved.

--- a/backend/migrations/versions/0092_add_list_collaborators.py
+++ b/backend/migrations/versions/0092_add_list_collaborators.py
@@ -1,0 +1,35 @@
+"""add list collaborators
+
+Revision ID: 0092
+Revises: 0091
+Create Date: 2026-07-10 10:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '0092'
+down_revision = '0091'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.create_table(
+        'dive_site_list_collaborators',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('list_id', sa.Integer(), nullable=False),
+        sa.Column('user_id', sa.Integer(), nullable=False),
+        sa.Column('role', sa.String(length=20), nullable=False, server_default='editor'),
+        sa.Column('show_on_profile', sa.Boolean(), nullable=False, server_default='1'),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.ForeignKeyConstraint(['list_id'], ['dive_site_lists.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('list_id', 'user_id', name='uq_list_collaborator')
+    )
+    op.create_index('ix_dive_site_list_collaborators_id', 'dive_site_list_collaborators', ['id'], unique=False)
+    op.create_index('ix_dive_site_list_collaborators_list_id', 'dive_site_list_collaborators', ['list_id'], unique=False)
+    op.create_index('ix_dive_site_list_collaborators_user_id', 'dive_site_list_collaborators', ['user_id'], unique=False)
+
+def downgrade():
+    op.drop_table('dive_site_list_collaborators')

--- a/backend/tests/test_collaborative_lists.py
+++ b/backend/tests/test_collaborative_lists.py
@@ -1,0 +1,211 @@
+import pytest
+from fastapi import status
+from sqlalchemy.orm import Session
+from app.models import User, DiveSite, DiveSiteList, DiveSiteListItem, UserFriendship, DiveSiteListCollaborator
+from unittest.mock import patch, MagicMock
+
+def setup_friendship(db_session: Session, user_a_id: int, user_b_id: int, status: str = "ACCEPTED"):
+    # Enforce user_id < friend_id for uniqueness
+    uid, fid = sorted([user_a_id, user_b_id])
+    friendship = UserFriendship(
+        user_id=uid,
+        friend_id=fid,
+        status=status,
+        initiator_id=user_a_id
+    )
+    db_session.add(friendship)
+    db_session.commit()
+    return friendship
+
+def test_collaborator_permissions_and_workflow(
+    client,
+    db_session: Session,
+    test_user,
+    test_user_other,
+    test_dive_site,
+    auth_headers,
+    auth_headers_other_user
+):
+    # 1. Create a custom private list owned by test_user
+    response = client.post(
+        "/api/v1/lists",
+        json={
+            "title": "Collaborative Cave Exploring",
+            "description": "Planning cave exploration",
+            "is_public": False,
+            "show_on_profile": True
+        },
+        headers=auth_headers
+    )
+    assert response.status_code == 201
+    lst_data = response.json()
+    lst_id = lst_data["id"]
+
+    # 2. Try to view private list as test_user_other (non-collaborator, non-owner) -> should be 403
+    response = client.get(f"/api/v1/lists/{lst_id}", headers=auth_headers_other_user)
+    assert response.status_code == 403
+
+    # 3. Try to add collaborator as a non-owner -> should be 403
+    response = client.post(
+        f"/api/v1/lists/{lst_id}/collaborators",
+        json={"username": test_user_other.username},
+        headers=auth_headers_other_user
+    )
+    assert response.status_code == 403
+
+    # 4. Try to add collaborator who is not a buddy (yet) -> should be 400
+    response = client.post(
+        f"/api/v1/lists/{lst_id}/collaborators",
+        json={"username": test_user_other.username},
+        headers=auth_headers
+    )
+    assert response.status_code == 400
+    assert "accepted buddies" in response.json()["detail"]
+
+    # 5. Establish friendship / buddy status
+    setup_friendship(db_session, test_user.id, test_user_other.id, "ACCEPTED")
+
+    # 6. Add collaborator successfully as owner (Mock notifications to prevent network SQS/APNS errors)
+    with patch("app.services.notification_service.NotificationService.create_notification") as mock_notif:
+        response = client.post(
+            f"/api/v1/lists/{lst_id}/collaborators",
+            json={"username": test_user_other.username},
+            headers=auth_headers
+        )
+        assert response.status_code == 201
+        collab_data = response.json()
+        assert collab_data["username"] == test_user_other.username
+        assert collab_data["role"] == "editor"
+        assert collab_data["show_on_profile"] is True
+        
+        # Verify notification mock triggers
+        mock_notif.assert_called_once()
+
+    # 7. Try to add duplicate collaborator -> should be 400
+    response = client.post(
+        f"/api/v1/lists/{lst_id}/collaborators",
+        json={"username": test_user_other.username},
+        headers=auth_headers
+    )
+    assert response.status_code == 400
+    assert "already a collaborator" in response.json()["detail"]
+
+    # 8. View the private list as collaborator -> should now succeed with 200
+    response = client.get(f"/api/v1/lists/{lst_id}", headers=auth_headers_other_user)
+    assert response.status_code == 200
+    details = response.json()
+    assert details["is_collaborator"] is True
+    assert details["role"] == "editor"
+    assert len(details["collaborators"]) == 1
+    assert details["collaborators"][0]["username"] == test_user_other.username
+
+    # 9. Add list item as collaborator -> should succeed
+    with patch("app.routers.lists.notify_collaborative_list_activity") as mock_activity:
+        response = client.post(
+            f"/api/v1/lists/{lst_id}/items",
+            json={"dive_site_id": test_dive_site.id, "notes": "Deep cave entrance"},
+            headers=auth_headers_other_user
+        )
+        assert response.status_code == 201
+        item_data = response.json()
+        assert item_data["notes"] == "Deep cave entrance"
+
+    # 10. Update list item note as collaborator -> should succeed
+    response = client.put(
+        f"/api/v1/lists/{lst_id}/items/{item_data['id']}",
+        json={"notes": "Deep cave entrance - verified"},
+        headers=auth_headers_other_user
+    )
+    assert response.status_code == 200
+    updated_item = response.json()
+    assert updated_item["notes"] == "Deep cave entrance - verified"
+
+    # 11. Collaborator toggles profile preference -> should succeed
+    response = client.put(
+        f"/api/v1/lists/{lst_id}/collaborators/preference",
+        json={"show_on_profile": False},
+        headers=auth_headers_other_user
+    )
+    assert response.status_code == 200
+    pref_data = response.json()
+    assert pref_data["show_on_profile"] is False
+
+    # 12. Collaborator tries to update list-wide metadata (title/description) -> should be 403 (Owner only!)
+    response = client.put(
+        f"/api/v1/lists/{lst_id}",
+        json={"title": "Unauthorized Title Hack"},
+        headers=auth_headers_other_user
+    )
+    assert response.status_code == 403
+
+    # 13. Collaborator leaves list successfully
+    response = client.delete(
+        f"/api/v1/lists/{lst_id}/collaborators/{test_user_other.id}",
+        headers=auth_headers_other_user
+    )
+    assert response.status_code == 204
+
+    # 14. Access private list again as the former collaborator -> should be 403 again
+    response = client.get(f"/api/v1/lists/{lst_id}", headers=auth_headers_other_user)
+    assert response.status_code == 403
+
+
+def test_collaborator_public_profile_visibility(
+    client,
+    db_session: Session,
+    test_user,
+    test_user_other,
+    auth_headers,
+    auth_headers_other_user
+):
+    # 1. Create a public list owned by test_user
+    response = client.post(
+        "/api/v1/lists",
+        json={
+            "title": "Public Reef Hunt",
+            "description": "Public list for reefs",
+            "is_public": True,
+            "show_on_profile": True
+        },
+        headers=auth_headers
+    )
+    assert response.status_code == 201
+    lst_id = response.json()["id"]
+
+    # 2. Add test_user_other as collaborator
+    setup_friendship(db_session, test_user.id, test_user_other.id, "ACCEPTED")
+    with patch("app.services.notification_service.NotificationService.create_notification"):
+        response = client.post(
+            f"/api/v1/lists/{lst_id}/collaborators",
+            json={"username": test_user_other.username},
+            headers=auth_headers
+        )
+        assert response.status_code == 201
+
+    # 3. By default, collaborators have show_on_profile = True.
+    # Check if this list shows up on test_user_other's public profile list endpoint.
+    response = client.get(f"/api/v1/users/{test_user_other.username}/lists")
+    assert response.status_code == 200
+    pub_lists = response.json()
+    assert len(pub_lists) >= 1
+    
+    collab_list = next((l for l in pub_lists if l["id"] == lst_id), None)
+    assert collab_list is not None
+    assert collab_list["is_collaborator"] is True
+    assert collab_list["role"] == "editor"
+    assert collab_list["username"] == test_user.username  # Owner username!
+
+    # 4. If test_user_other sets show_on_profile = False, it should no longer show on their public profile
+    response = client.put(
+        f"/api/v1/lists/{lst_id}/collaborators/preference",
+        json={"show_on_profile": False},
+        headers=auth_headers_other_user
+    )
+    assert response.status_code == 200
+
+    response = client.get(f"/api/v1/users/{test_user_other.username}/lists")
+    assert response.status_code == 200
+    pub_lists_after = response.json()
+    collab_list_after = next((l for l in pub_lists_after if l["id"] == lst_id), None)
+    assert collab_list_after is None
+

--- a/backend/tests/test_collaborative_lists_schemas.py
+++ b/backend/tests/test_collaborative_lists_schemas.py
@@ -1,0 +1,72 @@
+from datetime import datetime, timezone
+from app.schemas import (
+    CollaboratorResponse,
+    AddCollaboratorRequest,
+    UpdateCollaboratorPreference,
+    UserDiveSiteListResponse
+)
+
+def test_collaborator_response_schema():
+    data = {
+        "id": 1,
+        "user_id": 42,
+        "username": "buddy_diver",
+        "role": "editor",
+        "show_on_profile": True,
+        "created_at": datetime.now(timezone.utc)
+    }
+    schema = CollaboratorResponse(**data)
+    assert schema.id == 1
+    assert schema.user_id == 42
+    assert schema.username == "buddy_diver"
+    assert schema.role == "editor"
+    assert schema.show_on_profile is True
+    assert isinstance(schema.created_at, datetime)
+
+def test_add_collaborator_request_schema():
+    data = {"username": "scuba_sam"}
+    schema = AddCollaboratorRequest(**data)
+    assert schema.username == "scuba_sam"
+
+def test_update_collaborator_preference_schema():
+    data = {"show_on_profile": False}
+    schema = UpdateCollaboratorPreference(**data)
+    assert schema.show_on_profile is False
+
+def test_user_dive_site_list_response_with_collaborators():
+    data = {
+        "id": 101,
+        "user_id": 10,
+        "username": "list_owner",
+        "title": "My Favorite Wrecks",
+        "slug": "my-favorite-wrecks",
+        "description": "Best shipwrecks",
+        "is_public": True,
+        "show_on_profile": True,
+        "system_type": "custom",
+        "view_count": 5,
+        "created_at": datetime.now(timezone.utc),
+        "updated_at": datetime.now(timezone.utc),
+        "items": [],
+        "collaborators": [
+            {
+                "id": 1,
+                "user_id": 42,
+                "username": "buddy_diver",
+                "role": "editor",
+                "show_on_profile": True,
+                "created_at": datetime.now(timezone.utc)
+            }
+        ],
+        "is_collaborator": True,
+        "role": "editor"
+    }
+    schema = UserDiveSiteListResponse(**data)
+    assert schema.id == 101
+    assert schema.user_id == 10
+    assert schema.username == "list_owner"
+    assert schema.title == "My Favorite Wrecks"
+    assert len(schema.collaborators) == 1
+    assert schema.collaborators[0].username == "buddy_diver"
+    assert schema.is_collaborator is True
+    assert schema.role == "editor"

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -326,6 +326,22 @@ export const getAdminPopularLists = async () => {
   return response.data;
 };
 
+export const addListCollaborator = async (listId, username) => {
+  const response = await api.post(`/api/v1/lists/${listId}/collaborators`, { username });
+  return response.data;
+};
+
+export const removeListCollaborator = async (listId, userId) => {
+  await api.delete(`/api/v1/lists/${listId}/collaborators/${userId}`);
+};
+
+export const updateCollaboratorPreference = async (listId, showOnProfile) => {
+  const response = await api.put(`/api/v1/lists/${listId}/collaborators/preference`, {
+    show_on_profile: showOnProfile,
+  });
+  return response.data;
+};
+
 // Logged-in user private feedback history API functions
 export const getMyComments = async (params = {}) => {
   const response = await api.get('/api/v1/users/me/comments', { params });

--- a/frontend/src/components/ShareButton.jsx
+++ b/frontend/src/components/ShareButton.jsx
@@ -79,7 +79,7 @@ const ShareButton = ({
 };
 
 ShareButton.propTypes = {
-  entityType: PropTypes.oneOf(['dive', 'dive-site', 'route', 'diving-center']).isRequired,
+  entityType: PropTypes.oneOf(['dive', 'dive-site', 'route', 'diving-center', 'list']).isRequired,
   entityData: PropTypes.object.isRequired,
   additionalParams: PropTypes.object,
   className: PropTypes.string,

--- a/frontend/src/components/UserChat/MessageBubble.jsx
+++ b/frontend/src/components/UserChat/MessageBubble.jsx
@@ -1,5 +1,5 @@
 import { format } from 'date-fns';
-import { Edit2, Check, CheckCheck, Clock, MapPin } from 'lucide-react';
+import { Edit2, Check, CheckCheck, Clock, MapPin, Users, FolderHeart } from 'lucide-react';
 import PropTypes from 'prop-types';
 import React, { useMemo } from 'react';
 import ReactMarkdown from 'react-markdown';
@@ -127,7 +127,60 @@ const MessageBubble = ({
                   : `bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100 border border-gray-100 dark:border-gray-600 rounded-2xl ${!showName ? 'rounded-tl-[4px]' : ''} ${isLastInGroup ? 'rounded-bl-sm' : 'rounded-bl-[4px]'}`
             }`}
           >
-            {message.message_type === 'TRIP_AD' ? (
+            {message.message_type === 'system_shared_list' ||
+            message.message_type === 'SYSTEM_SHARED_LIST' ? (
+              (() => {
+                let listData;
+                try {
+                  listData = JSON.parse(message.content);
+                } catch (e) {
+                  listData = { text: message.content };
+                }
+
+                const ownerUsername = message.sender?.username || 'unknown';
+                const listUrl =
+                  listData.list_id && listData.list_slug
+                    ? `/users/${ownerUsername}/lists/${listData.list_id}/${listData.list_slug}`
+                    : '#';
+
+                return (
+                  <div className='bg-white dark:bg-gray-800 rounded-xl overflow-hidden shadow-md mt-1 mb-2 border border-gray-200/60 dark:border-gray-700 min-w-[200px] sm:min-w-[280px] max-w-sm'>
+                    {/* Header bar */}
+                    <div className='p-2 sm:p-3 border-b border-gray-100 dark:border-gray-700 bg-blue-50/50 dark:bg-blue-950/20 flex items-center gap-2'>
+                      <Users className='h-4 w-4 text-blue-600 dark:text-blue-400' />
+                      <span className='text-[10px] sm:text-xs font-bold text-blue-700 dark:text-blue-400 uppercase tracking-wider'>
+                        Shared Collaborative List
+                      </span>
+                    </div>
+                    {/* Body */}
+                    <div className='p-3 sm:p-4 space-y-3.5'>
+                      <div className='flex items-start gap-2.5'>
+                        <div className='bg-blue-100/40 dark:bg-blue-950/30 p-2 rounded-xl text-blue-600 dark:text-blue-400 mt-0.5 shrink-0'>
+                          <FolderHeart className='h-5 w-5' />
+                        </div>
+                        <div className='space-y-1 text-left'>
+                          <h4 className='font-bold text-gray-900 dark:text-white text-sm sm:text-base leading-snug'>
+                            {listData.list_title || 'Curated List'}
+                          </h4>
+                          <p className='text-xs sm:text-sm text-gray-600 dark:text-gray-300 leading-normal'>
+                            {listData.text || 'You have been added as a collaborator.'}
+                          </p>
+                        </div>
+                      </div>
+
+                      {listData.list_id && (
+                        <Link
+                          to={listUrl}
+                          className='block w-full text-center bg-divemap-blue hover:opacity-90 text-white font-semibold py-2 text-xs sm:text-sm rounded-xl transition-colors shadow-sm'
+                        >
+                          View Collaborative List
+                        </Link>
+                      )}
+                    </div>
+                  </div>
+                );
+              })()
+            ) : message.message_type === 'TRIP_AD' ? (
               (() => {
                 let tripData;
                 try {

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -43,7 +43,12 @@ import toast from 'react-hot-toast';
 import { useQuery, useMutation } from 'react-query';
 import { Link, useNavigate } from 'react-router-dom';
 
-import api, { getUserPublicProfile, getMyLists, createList } from '../api';
+import api, {
+  getUserPublicProfile,
+  getMyLists,
+  createList,
+  updateCollaboratorPreference,
+} from '../api';
 import Avatar from '../components/Avatar';
 import AvatarEditor from '../components/AvatarEditor';
 import { FormField } from '../components/forms/FormField';
@@ -1287,20 +1292,52 @@ const Profile = () => {
                               <Lock size={8} /> PRIVATE
                             </span>
                           )}
+                          {lst.is_collaborator && (
+                            <span className='inline-flex items-center px-1.5 py-0.5 rounded text-[8px] font-bold bg-blue-50 text-blue-700 border border-blue-100 uppercase tracking-tighter gap-0.5'>
+                              <Users size={8} /> SHARED
+                            </span>
+                          )}
                         </div>
                       </div>
                       {lst.description && (
                         <p className='text-xs text-gray-500 line-clamp-2 mb-3'>{lst.description}</p>
                       )}
-                      <div className='flex items-center gap-4 text-[11px] text-gray-400 font-medium'>
-                        <span className='flex items-center gap-0.5'>
-                          <FolderHeart className='h-3.5 w-3.5 text-blue-500' />
-                          {lst.items?.length || 0} sites
-                        </span>
-                        <span className='flex items-center gap-0.5'>
-                          <Eye className='h-3.5 w-3.5 text-gray-400' />
-                          {lst.view_count || 0} views
-                        </span>
+                      <div className='flex items-center justify-between mt-2.5 pt-2 border-t border-gray-100 dark:border-gray-700/50'>
+                        <div className='flex items-center gap-4 text-[11px] text-gray-400 font-medium'>
+                          <span className='flex items-center gap-0.5'>
+                            <FolderHeart className='h-3.5 w-3.5 text-blue-500' />
+                            {lst.items?.length || 0} sites
+                          </span>
+                          <span className='flex items-center gap-0.5'>
+                            <Eye className='h-3.5 w-3.5 text-gray-400' />
+                            {lst.view_count || 0} views
+                          </span>
+                        </div>
+                        {lst.is_collaborator && (
+                          <label
+                            className='flex items-center gap-1.5 text-[10px] font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wider bg-white dark:bg-gray-800 border dark:border-gray-700 rounded px-2 py-0.5 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700'
+                            onClick={e => {
+                              e.stopPropagation();
+                            }}
+                          >
+                            <input
+                              type='checkbox'
+                              checked={lst.show_on_profile}
+                              onChange={async e => {
+                                e.stopPropagation();
+                                try {
+                                  await updateCollaboratorPreference(lst.id, e.target.checked);
+                                  toast.success('Profile preference updated!');
+                                  fetchLists();
+                                } catch (err) {
+                                  toast.error('Failed to update preference');
+                                }
+                              }}
+                              className='rounded border-gray-300 dark:border-gray-600 text-blue-600 focus:ring-blue-500 h-3 w-3'
+                            />
+                            Show on Profile
+                          </label>
+                        )}
                       </div>
                     </Link>
                   ))}

--- a/frontend/src/pages/UserListDetail.jsx
+++ b/frontend/src/pages/UserListDetail.jsx
@@ -33,6 +33,10 @@ import {
   Pencil,
   Fish,
   ChevronDown,
+  Users,
+  Plus,
+  LogOut,
+  X,
 } from 'lucide-react';
 import React, { useState, useEffect, useRef } from 'react';
 import { toast } from 'react-hot-toast';
@@ -46,6 +50,9 @@ import {
   updateListItem,
   deleteListItem,
   reorderListItems,
+  addListCollaborator,
+  removeListCollaborator,
+  getUserFriendships,
 } from '../api';
 import Avatar from '../components/Avatar';
 import ShareButton from '../components/ShareButton';
@@ -236,6 +243,85 @@ const UserListDetail = () => {
   const [updatingMeta, setUpdatingMeta] = useState(false);
   const [activeSiteId, setActiveSiteId] = useState(null);
   const [showAddInstructions, setShowAddInstructions] = useState(false);
+  const [showCollabModal, setShowCollabModal] = useState(false);
+  const [buddies, setBuddies] = useState([]);
+  const [buddiesLoading, setBuddiesLoading] = useState(false);
+
+  const isOwner = user && list && user.id === list.user_id;
+  const canEdit = isOwner || (list && list.is_collaborator);
+
+  // Load buddies for adding collaborators (only list owner needs this)
+  useEffect(() => {
+    if (isOwner && showCollabModal) {
+      const fetchBuddies = async () => {
+        try {
+          setBuddiesLoading(true);
+          const data = await getUserFriendships('ACCEPTED');
+          setBuddies(data);
+        } catch (err) {
+          console.error('Failed to load buddies:', err);
+        } finally {
+          setBuddiesLoading(false);
+        }
+      };
+      fetchBuddies();
+    }
+  }, [isOwner, showCollabModal]);
+
+  const filterAddableBuddies = () => {
+    if (!list) return [];
+    const collabUserIds = new Set(list.collaborators?.map(c => c.user_id) || []);
+    collabUserIds.add(list.user_id); // Include owner
+
+    return buddies
+      .map(friendship => {
+        if (!friendship.user || !friendship.friend) return null;
+        return friendship.user.id === user.id ? friendship.friend : friendship.user;
+      })
+      .filter(buddyUser => buddyUser && !collabUserIds.has(buddyUser.id));
+  };
+
+  const handleAddCollab = async targetUsername => {
+    try {
+      const collab = await addListCollaborator(id, targetUsername);
+      setList(prev => ({
+        ...prev,
+        collaborators: [...(prev.collaborators || []), collab],
+      }));
+      toast.success(`@${targetUsername} added as editor!`);
+    } catch (err) {
+      toast.error(err.response?.data?.detail || 'Failed to add buddy');
+    }
+  };
+
+  const handleRemoveCollab = async collabUserId => {
+    try {
+      await removeListCollaborator(id, collabUserId);
+      setList(prev => ({
+        ...prev,
+        collaborators: prev.collaborators.filter(c => c.user_id !== collabUserId),
+      }));
+      toast.success('Editor removed');
+    } catch (err) {
+      toast.error('Failed to remove buddy');
+    }
+  };
+
+  const handleLeaveList = async () => {
+    if (
+      window.confirm(
+        'Are you sure you want to leave this collaborative list? You will lose edit access.'
+      )
+    ) {
+      try {
+        await removeListCollaborator(id, user.id);
+        toast.success('You have left the list');
+        navigate('/profile');
+      } catch (err) {
+        toast.error('Failed to leave list');
+      }
+    }
+  };
 
   useEffect(() => {
     if (typeof window !== 'undefined' && window.innerWidth >= 1024) {
@@ -246,8 +332,6 @@ const UserListDetail = () => {
   // References for in-place edit input blurs
   const titleInputRef = useRef(null);
   const descInputRef = useRef(null);
-
-  const isOwner = user && list && user.id === list.user_id;
 
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -305,7 +389,7 @@ const UserListDetail = () => {
   };
 
   const handleItemNoteUpdate = async (itemId, notes) => {
-    if (!isOwner) return;
+    if (!canEdit) return;
     try {
       await updateListItem(id, itemId, { notes });
       setList(prev => ({
@@ -319,7 +403,7 @@ const UserListDetail = () => {
   };
 
   const handleRemoveItem = async itemId => {
-    if (!isOwner) return;
+    if (!canEdit) return;
     if (window.confirm('Are you sure you want to remove this dive site from your collection?')) {
       try {
         await deleteListItem(id, itemId);
@@ -335,6 +419,7 @@ const UserListDetail = () => {
   };
 
   const handleDragEnd = async event => {
+    if (!canEdit) return;
     const { active, over } = event;
     if (!over || active.id === over.id) return;
 
@@ -413,6 +498,30 @@ const UserListDetail = () => {
               >
                 @{username}
               </Link>
+
+              {/* Collaborator Roster */}
+              {list.collaborators && list.collaborators.length > 0 && (
+                <div className='flex items-center -space-x-1 ml-2 border-l border-gray-200 dark:border-gray-700 pl-2'>
+                  {list.collaborators.map(c => (
+                    <div key={c.id} className='relative group' title={`Editor: @${c.username}`}>
+                      <Avatar
+                        username={c.username}
+                        size='xs'
+                        className='ring-2 ring-white dark:ring-gray-800'
+                      />
+                      {isOwner && (
+                        <button
+                          onClick={() => handleRemoveCollab(c.user_id)}
+                          className='absolute -top-1 -right-1 hidden group-hover:flex bg-red-500 hover:bg-red-600 text-white rounded-full p-0.5 shadow-sm'
+                          title='Remove editor'
+                        >
+                          <X className='h-2.5 w-2.5' />
+                        </button>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
             </div>
           </div>
 
@@ -425,13 +534,18 @@ const UserListDetail = () => {
               />
             )}
             {isOwner && !list.system_type && (
-              <Button
-                variant='outline'
-                size='sm'
-                onClick={handleDeleteList}
-                className='text-red-500 hover:text-red-700 dark:text-red-400 border-red-200 hover:bg-red-50 dark:hover:bg-red-950/20'
-              >
+              <Button variant='primary' size='sm' onClick={() => setShowCollabModal(true)}>
+                <Plus className='h-4 w-4 mr-1' /> Collaborators
+              </Button>
+            )}
+            {isOwner && !list.system_type && (
+              <Button variant='danger' size='sm' onClick={handleDeleteList}>
                 <Trash2 className='h-4 w-4 mr-1' /> Delete List
+              </Button>
+            )}
+            {list.is_collaborator && (
+              <Button variant='danger-outline' size='sm' onClick={handleLeaveList}>
+                <LogOut className='h-4 w-4 mr-1' /> Leave List
               </Button>
             )}
           </div>
@@ -462,34 +576,6 @@ const UserListDetail = () => {
                   <Bookmark className='h-7 w-7 text-blue-600 dark:text-blue-400 shrink-0' />
                   {list.title}
                 </h1>
-              )}
-
-              {isOwner ? (
-                <div className='relative group/desc w-full mt-1'>
-                  <textarea
-                    ref={descInputRef}
-                    defaultValue={list.description || ''}
-                    placeholder='Write a description for this collection...'
-                    onBlur={e => {
-                      const val = e.target.value.trim();
-                      if (val !== (list.description || '')) {
-                        handleMetaUpdate('description', val || null);
-                      }
-                    }}
-                    className='text-sm text-gray-600 dark:text-gray-300 bg-gray-50/50 dark:bg-gray-900/30 hover:bg-gray-50 dark:hover:bg-gray-900/50 focus:bg-white dark:focus:bg-gray-900 border border-dashed border-gray-200 dark:border-gray-700/80 hover:border-blue-300 dark:hover:border-blue-800 focus:border-blue-500 focus:ring-1 focus:ring-blue-500/10 focus:outline-none w-full p-3 pr-3 sm:pr-24 rounded-xl resize-y transition-all min-h-[64px]'
-                    rows={2}
-                  />
-                  <div className='absolute right-2.5 bottom-3.5 hidden sm:flex items-center gap-1.5 text-[10px] font-bold uppercase tracking-wider text-gray-400 dark:text-gray-500 pointer-events-none opacity-80 group-hover/desc:text-blue-500 dark:group-hover/desc:text-blue-400 transition-colors'>
-                    <Pencil className='h-3 w-3' />
-                    <span>Edit description</span>
-                  </div>
-                </div>
-              ) : (
-                list.description && (
-                  <p className='text-sm text-gray-600 dark:text-gray-400 leading-relaxed font-normal whitespace-pre-wrap mt-1'>
-                    {list.description}
-                  </p>
-                )
               )}
             </div>
 
@@ -561,6 +647,35 @@ const UserListDetail = () => {
               </div>
             </div>
           </div>
+
+          {/* Description Block */}
+          {isOwner ? (
+            <div className='relative group/desc w-full mt-2'>
+              <textarea
+                ref={descInputRef}
+                defaultValue={list.description || ''}
+                placeholder='Write a description for this collection...'
+                onBlur={e => {
+                  const val = e.target.value.trim();
+                  if (val !== (list.description || '')) {
+                    handleMetaUpdate('description', val || null);
+                  }
+                }}
+                className='text-sm text-gray-600 dark:text-gray-300 bg-gray-50/50 dark:bg-gray-900/30 hover:bg-gray-50 dark:hover:bg-gray-900/50 focus:bg-white dark:focus:bg-gray-900 border border-dashed border-gray-200 dark:border-gray-700/80 hover:border-blue-300 dark:hover:border-blue-800 focus:border-blue-500 focus:ring-1 focus:ring-blue-500/10 focus:outline-none w-full p-3 pr-3 sm:pr-24 rounded-xl resize-y transition-all min-h-[64px]'
+                rows={2}
+              />
+              <div className='absolute right-2.5 bottom-3.5 hidden sm:flex items-center gap-1.5 text-[10px] font-bold uppercase tracking-wider text-gray-400 dark:text-gray-500 pointer-events-none opacity-80 group-hover/desc:text-blue-500 dark:group-hover/desc:text-blue-400 transition-colors'>
+                <Pencil className='h-3 w-3' />
+                <span>Edit description</span>
+              </div>
+            </div>
+          ) : (
+            list.description && (
+              <p className='text-sm text-gray-600 dark:text-gray-400 leading-relaxed font-normal whitespace-pre-wrap mt-2'>
+                {list.description}
+              </p>
+            )
+          )}
         </div>
 
         {/* Double Splitscreen Column Layout (Map + Cards List) */}
@@ -609,7 +724,7 @@ const UserListDetail = () => {
 
           {/* Cards Column (Lg: spans 3/5) */}
           <div className='lg:col-span-3 space-y-4'>
-            {isOwner && (
+            {canEdit && (
               <div className='bg-gradient-to-r from-blue-50 to-indigo-50 dark:from-blue-950/20 dark:to-indigo-950/20 rounded-2xl border border-blue-100/50 dark:border-blue-900/30 shadow-sm mb-4 overflow-hidden transition-all duration-300'>
                 <button
                   onClick={() => setShowAddInstructions(!showAddInstructions)}
@@ -680,7 +795,7 @@ const UserListDetail = () => {
                   </Link>
                 </div>
               </div>
-            ) : isOwner ? (
+            ) : canEdit ? (
               <DndContext
                 sensors={sensors}
                 collisionDetection={closestCenter}
@@ -798,6 +913,101 @@ const UserListDetail = () => {
           </div>
         </div>
       </div>
+
+      {/* Collaborator Modal / Dialog */}
+      {showCollabModal && (
+        <div className='fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-[9999] animate-fade-in'>
+          <div className='bg-white dark:bg-gray-800 rounded-2xl p-6 max-w-md w-full shadow-xl border border-gray-100 dark:border-gray-700 space-y-4'>
+            <div className='flex items-center justify-between border-b border-gray-100 dark:border-gray-700 pb-3'>
+              <h3 className='text-lg font-bold text-gray-900 dark:text-white flex items-center gap-2'>
+                <Users className='h-5 w-5 text-blue-600' />
+                Manage Editors
+              </h3>
+              <button
+                onClick={() => setShowCollabModal(false)}
+                className='text-gray-400 hover:text-gray-600 dark:hover:text-gray-200'
+              >
+                <X className='h-5 w-5' />
+              </button>
+            </div>
+
+            <div className='space-y-4'>
+              {/* Current Collaborators */}
+              <div>
+                <h4 className='text-xs font-bold uppercase tracking-wider text-gray-400 dark:text-gray-500 mb-2'>
+                  Current Editors
+                </h4>
+                {list.collaborators && list.collaborators.length > 0 ? (
+                  <div className='divide-y divide-gray-100 dark:divide-gray-700/50 max-h-40 overflow-y-auto pr-1'>
+                    {list.collaborators.map(c => (
+                      <div key={c.id} className='flex items-center justify-between py-2'>
+                        <div className='flex items-center gap-2'>
+                          <Avatar username={c.username} size='xs' />
+                          <span className='text-sm font-semibold text-gray-800 dark:text-gray-200'>
+                            @{c.username}
+                          </span>
+                        </div>
+                        {isOwner && (
+                          <button
+                            onClick={() => handleRemoveCollab(c.user_id)}
+                            className='text-xs font-bold text-red-500 hover:text-red-700'
+                          >
+                            Remove
+                          </button>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <p className='text-xs text-gray-500 dark:text-gray-400 italic'>
+                    No collaborators added yet.
+                  </p>
+                )}
+              </div>
+
+              {/* Add Collaborator */}
+              {isOwner && (
+                <div>
+                  <h4 className='text-xs font-bold uppercase tracking-wider text-gray-400 dark:text-gray-500 mb-2'>
+                    Add Editor
+                  </h4>
+                  {buddiesLoading ? (
+                    <div className='flex justify-center py-2'>
+                      <Loader2 className='animate-spin h-5 w-5 text-blue-600' />
+                    </div>
+                  ) : filterAddableBuddies().length > 0 ? (
+                    <div className='divide-y divide-gray-100 dark:divide-gray-700/50 max-h-40 overflow-y-auto pr-1'>
+                      {filterAddableBuddies().map(buddyUser => (
+                        <div
+                          key={buddyUser.id}
+                          className='flex items-center justify-between py-2 hover:bg-blue-100/50 dark:hover:bg-blue-900/40 px-2 rounded-lg transition-colors'
+                        >
+                          <div className='flex items-center gap-2'>
+                            <Avatar username={buddyUser.username} size='xs' />
+                            <span className='text-sm font-semibold text-gray-800 dark:text-gray-200'>
+                              @{buddyUser.username}
+                            </span>
+                          </div>
+                          <button
+                            onClick={() => handleAddCollab(buddyUser.username)}
+                            className='inline-flex items-center gap-1 text-xs font-bold bg-blue-50 hover:bg-blue-100 dark:bg-blue-950/40 dark:hover:bg-blue-950/80 text-blue-600 dark:text-blue-400 border border-blue-100/50 dark:border-blue-900/30 px-2 py-1 rounded-md'
+                          >
+                            <Plus className='h-3 w-3' /> Add
+                          </button>
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className='text-xs text-gray-500 dark:text-gray-400 italic'>
+                      No addable buddies. Only accepted buddies can be added.
+                    </p>
+                  )}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
Enable divers to share curated lists with their accepted buddies. Allows co-editors to view private lists, reorder items, edit notes, and toggle individual list visibility on their public profiles.

- Add database model for list collaborators and sequential migrations.
- Establish backend endpoints for collaborator addition and removal.
- Inject beautiful list sharing card and system messages in chat.
- Wire frontend client functions for adding/removing collaborators.
- Refactor list details layout to stretch descriptions full-width.
- Style buttons following standard primary and danger UI guidelines.
- Handle dynamic public profile listing for collaborated lists.
- Write comprehensive integration test coverage for all features.