### PR TITLE
Update domain references to divemap.blue where appropriate

### DIFF
--- a/.gemini/skills/android-publisher/SKILL.md
+++ b/.gemini/skills/android-publisher/SKILL.md
@@ -53,7 +53,7 @@ Use this only for maintaining older versions or if explicitly requested to use B
 ### 3. Verify Digital Asset Links (TWA Only)
 1. Check `frontend/public/.well-known/assetlinks.json`.
 2. Ensure it contains the SHA-256 fingerprints for both the Bubblewrap keystore and Google Play App Signing.
-3. Verify at `https://divemap.gr/.well-known/assetlinks.json`.
+3. Verify at `https://divemap.blue/.well-known/assetlinks.json`.
 
 ---
 

--- a/backend/app/services/social_image_service.py
+++ b/backend/app/services/social_image_service.py
@@ -14,7 +14,7 @@ class SocialImageService:
         ]
         self.default_font_path = next((p for p in self.font_paths if os.path.exists(p)), None)
 
-    def generate(self, dive, profile_data, image_bytes, crop_params, full_url="divemap.gr", requested_metrics=None):
+    def generate(self, dive, profile_data, image_bytes, crop_params, full_url="divemap.blue", requested_metrics=None):
         """
         Generates a social media image with dive profile, metadata, and full URL.
         """

--- a/backend/debug_session.py
+++ b/backend/debug_session.py
@@ -6,7 +6,7 @@ import sys
 
 # Configuration
 # NOTE: This targets the production API as requested
-BASE_URL = "https://divemap.gr"
+BASE_URL = "https://divemap.blue"
 API_PREFIX = "/api/v1"
 SESSION_ID = "52af2018-515b-4f46-bfab-45c044638115"
 

--- a/backend/tests/test_static_html.py
+++ b/backend/tests/test_static_html.py
@@ -130,7 +130,9 @@ def test_json_ld_is_valid_in_output():
         main_content="<main><h1>Test</h1></main>",
         json_ld={"@context": "https://schema.org", "@type": "Place", "name": "Test"},
     )
-    start = page.index('application/ld+json">') + len('application/ld+json">')
+    # Find the script tag and locate its closing '>' to find the JSON-LD payload start robustly
+    tag_index = page.index('type="application/ld+json"')
+    start = page.index('>', tag_index) + 1
     end = page.index("</script>", start)
     payload = json.loads(page[start:end])
     assert payload["@type"] == "Place"

--- a/divemap-android/twa-manifest.json
+++ b/divemap-android/twa-manifest.json
@@ -1,6 +1,6 @@
 {
   "packageId": "gr.divemap.twa",
-  "host": "divemap.gr",
+  "host": "divemap.blue",
   "name": "Divemap - Scuba Dive Site Review Platform",
   "launcherName": "Divemap",
   "display": "standalone",
@@ -13,31 +13,31 @@
   "backgroundColor": "#FFFFFF",
   "enableNotifications": true,
   "startUrl": "/?utm_source=android-twa",
-  "iconUrl": "https://divemap.gr/favicons/android-chrome-512x512.png",
-  "maskableIconUrl": "https://divemap.gr/favicons/android-chrome-512x512.png",
+  "iconUrl": "https://divemap.blue/favicons/android-chrome-512x512.png",
+  "maskableIconUrl": "https://divemap.blue/favicons/android-chrome-512x512.png",
   "splashScreenFadeOutDuration": 300,
   "signingKey": {
     "path": "/home/kargig/src/divemap/divemap-android/android.keystore",
     "alias": "android"
   },
-  "appVersionName": "1.10",
-  "appVersionCode": 27,
+  "appVersionName": "1.20",
+  "appVersionCode": 28,
   "shortcuts": [
     {
       "name": "Explore Map",
       "shortName": "Map",
-      "url": "https://divemap.gr/map",
-      "chosenIconUrl": "https://divemap.gr/favicons/android-chrome-192x192.png"
+      "url": "https://divemap.blue/map",
+      "chosenIconUrl": "https://divemap.blue/favicons/android-chrome-192x192.png"
     },
     {
       "name": "Log Dive",
       "shortName": "Log Dive",
-      "url": "https://divemap.gr/dives/create",
-      "chosenIconUrl": "https://divemap.gr/favicons/android-chrome-192x192.png"
+      "url": "https://divemap.blue/dives/create",
+      "chosenIconUrl": "https://divemap.blue/favicons/android-chrome-192x192.png"
     }
   ],
   "generatorApp": "bubblewrap-cli",
-  "webManifestUrl": "https://divemap.gr/manifest.webmanifest",
+  "webManifestUrl": "https://divemap.blue/manifest.webmanifest",
   "fallbackType": "customtabs",
   "features": {
     "locationDelegation": {
@@ -50,10 +50,10 @@
   "enableSiteSettingsShortcut": true,
   "isChromeOSOnly": false,
   "isMetaQuest": false,
-  "fullScopeUrl": "https://divemap.gr/",
+  "fullScopeUrl": "https://divemap.blue/",
   "minSdkVersion": 21,
   "shareTarget": {
-    "action": "https://divemap.gr/dive-sites",
+    "action": "https://divemap.blue/dive-sites",
     "method": "GET",
     "enctype": "application/x-www-form-urlencoded",
     "params": {
@@ -69,7 +69,7 @@
   "protocolHandlers": [
     {
       "protocol": "web+divemap",
-      "url": "https://divemap.gr/dive-sites?q=%s"
+      "url": "https://divemap.blue/dive-sites?q=%s"
     }
   ],
   "fileHandlers": [],
@@ -82,5 +82,5 @@
     "standalone",
     "minimal-ui"
   ],
-  "appVersion": "1.10"
+  "appVersion": "1.20"
 }

--- a/divemap-llm-worker/late-moon-cc3c/src/index.ts
+++ b/divemap-llm-worker/late-moon-cc3c/src/index.ts
@@ -2,7 +2,7 @@ export interface Env {
 	LLM_CONTENT: R2Bucket;
 }
 
-const HARDCODED_ORIGIN = 'https://divemap.gr';
+const HARDCODED_ORIGIN = 'https://divemap.blue';
 
 export default {
 	async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -78,7 +78,7 @@ The `feature/nginx-proxy-implementation` branch is now **100% production-ready**
 
 #### **Key Benefits** 🚀
 
-- **Unified Domain**: Single domain (divemap.gr) for frontend and backend
+- **Unified Domain**: Single domain (divemap.blue) for frontend and backend
 - **No CORS Issues**: Same-origin requests eliminate cross-origin cookie problems
 - **Enterprise Security**: Comprehensive security headers and rate limiting
 - **Simplified Deployment**: No SSL certificate management required
@@ -92,7 +92,7 @@ Internet (HTTPS)
     ▼
 ┌─────────────────┐
 │  Fly.io Proxy   │  ← TLS termination happens here
-│  (divemap.gr)   │
+│  (divemap.blue) │
 └─────────────────┘
     │ (HTTP internally)
     ▼
@@ -124,7 +124,7 @@ fly deploy -a divemap-nginx-proxy
 ```
 
 #### Nginx Proxy Features
-- **SSL Termination**: Handles HTTPS for divemap.gr
+- **SSL Termination**: Handles HTTPS for divemap.blue
 - **Unified Domain**: Single domain for frontend and backend
 - **Security Headers**: Comprehensive security protection
 - **Rate Limiting**: API protection and abuse prevention
@@ -132,12 +132,12 @@ fly deploy -a divemap-nginx-proxy
 - **Performance**: Gzip compression and caching
 
 #### Production URLs
-- **Main Application**: https://divemap.gr/
-- **API Endpoints**: https://divemap.gr/api/
-- **Documentation**: https://divemap.gr/docs
+- **Main Application**: https://divemap.blue/
+- **API Endpoints**: https://divemap.blue/api/
+- **Documentation**: https://divemap.blue/docs
 
 #### Prerequisites
-- SSL certificates for divemap.gr
+- SSL certificates for divemap.blue
 - Existing Fly.io apps (db, backend, frontend) running
 - Domain DNS configured
 

--- a/docs/deployment/cloudflare-workers.md
+++ b/docs/deployment/cloudflare-workers.md
@@ -11,7 +11,7 @@ Currently, we maintain two active workers:
 ## 1. Presentations Worker (`divemap-presentations-worker`)
 
 ### Purpose
-Intercepts any request to `https://divemap.gr/presentations/*` and serves the file directly from the `divemap-presentations` R2 bucket. It applies an aggressive 1-year cache control header (`max-age=31536000, immutable`), which is ideal for published PDFs and slide decks.
+Intercepts any request to `https://divemap.blue/presentations/*` and serves the file directly from the `divemap-presentations` R2 bucket. It applies an aggressive 1-year cache control header (`max-age=31536000, immutable`), which is ideal for published PDFs and slide decks.
 
 ### How to Upload a New Presentation
 To host a new presentation (e.g., `my_slides.pdf`), you must upload it to the R2 bucket using the Wrangler CLI.
@@ -29,7 +29,7 @@ To host a new presentation (e.g., `my_slides.pdf`), you must upload it to the R2
      --content-type "application/pdf" \
      --remote
    ```
-3. The file is instantly available at: `https://divemap.gr/presentations/my_slides.pdf`
+3. The file is instantly available at: `https://divemap.blue/presentations/my_slides.pdf`
 
 *Note: The `--remote` flag is critical. Without it, Wrangler will default to uploading to a local development emulator instead of the actual Cloudflare cloud.*
 
@@ -91,4 +91,4 @@ To manually refresh the data served by the worker:
 
 - **404 Not Found on R2 Uploads:** Ensure you used the `--remote` flag when running `wrangler r2 object put`.
 - **PWA Interception:** If the Divemap PWA is installed on a device, the Service Worker might try to intercept the request and return the React app (`index.html`) instead of the PDF. Ensure the path (e.g., `/^\/presentations\/?.*$/`) is included in the `navigateFallbackDenylist` array within `frontend/vite.config.mjs`.
-- **Worker Not Intercepting:** Check the `routes` array in the worker's `wrangler.toml`/`wrangler.jsonc` file. It must exactly match the domain (e.g., `divemap.gr/presentations/*`).
+- **Worker Not Intercepting:** Check the `routes` array in the worker's `wrangler.toml`/`wrangler.jsonc` file. It must exactly match the domain (e.g., `divemap.blue/presentations/*`).

--- a/docs/deployment/fly-io.md
+++ b/docs/deployment/fly-io.md
@@ -614,7 +614,7 @@ Internet (HTTPS)
     ▼
 ┌─────────────────┐
 │  Fly.io Proxy   │  ← TLS termination happens here
-│  (divemap.gr)   │
+│  (divemap.blue) │
 └─────────────────┘
     │ (HTTP internally)
     ▼
@@ -629,7 +629,7 @@ Internet (HTTPS)
 
 ### Key Features
 
-- **Unified Domain**: Single domain (divemap.gr) for frontend and backend
+- **Unified Domain**: Single domain (divemap.blue) for frontend and backend
 - **No CORS Issues**: Same-origin requests eliminate cross-origin cookie problems
 - **Security Headers**: Comprehensive security protection
 - **Rate Limiting**: API protection and abuse prevention
@@ -663,10 +663,10 @@ fly deploy -a divemap-nginx-proxy
 
 ```bash
 # Add your domain to the app
-fly domains add divemap.gr -a divemap-nginx-proxy
+fly domains add divemap.blue -a divemap-nginx-proxy
 
 # Add www subdomain
-fly domains add www.divemap.gr -a divemap-nginx-proxy
+fly domains add www.divemap.blue -a divemap-nginx-proxy
 ```
 
 #### Step 4: Verify Deployment
@@ -679,7 +679,7 @@ fly status -a divemap-nginx-proxy
 fly logs -a divemap-nginx-proxy
 
 # Test health endpoint
-curl https://divemap.gr/health
+curl https://divemap.blue/health
 ```
 
 ### Configuration Details
@@ -739,7 +739,7 @@ The backend app (`divemap-backend`) should be configured with:
 
 ```bash
 # CORS origins
-fly secrets set ALLOWED_ORIGINS="https://divemap.gr" -a divemap-backend
+fly secrets set ALLOWED_ORIGINS="https://divemap.blue" -a divemap-backend
 
 # Security configuration for production proxy chain
 fly secrets set SUSPICIOUS_PROXY_CHAIN_LENGTH="6" -a divemap-backend
@@ -754,7 +754,7 @@ The frontend app (`divemap-frontend`) should be configured with:
 
 ```bash
 # API URL pointing to nginx proxy
-fly secrets set VITE_API_URL="https://divemap.gr/api" -a divemap-frontend
+fly secrets set VITE_API_URL="https://divemap.blue/api" -a divemap-frontend
 ```
 
 ### Monitoring and Health Checks
@@ -763,7 +763,7 @@ fly secrets set VITE_API_URL="https://divemap.gr/api" -a divemap-frontend
 
 ```bash
 # Health check URL
-GET https://divemap.gr/health
+GET https://divemap.blue/health
 
 # Expected response
 HTTP/1.1 200 OK

--- a/docs/development/api.md
+++ b/docs/development/api.md
@@ -96,7 +96,7 @@ Pass your PAT in the `Authorization` header just like a standard JWT:
 
 ```bash
 curl -H "Authorization: Bearer dm_pat_abc123..." \
-     https://divemap.gr/api/v1/auth/me
+     https://divemap.blue/api/v1/auth/me
 ```text
 
 #### Rate Limiting for PATs

--- a/docs/development/work/SEO_PROPOSALS.md
+++ b/docs/development/work/SEO_PROPOSALS.md
@@ -57,7 +57,7 @@ Reuse and rename the "LLM Content" generation pattern to a more general "Static 
 
 **Priority:** Medium | **Status:** Done
 
-- Updated `robots.txt` to include `Sitemap: https://divemap.gr/sitemap.xml` and block `/api/`, `/admin/`.
+- Updated `robots.txt` to include `Sitemap: https://divemap.blue/sitemap.xml` and block `/api/`, `/admin/`.
 
 ---
 

--- a/env.example
+++ b/env.example
@@ -74,8 +74,8 @@ CHAT_MASTER_KEY=your_chat_master_key_here
 
 # Production Environment
 #ENVIRONMENT=production
-#CORS_ORIGINS=https://divemap.gr,https://divemap.fly.dev
-#ALLOWED_ORIGINS=https://divemap.gr,https://divemap.fly.dev
+#CORS_ORIGINS=https://divemap.blue,https://divemap.fly.dev
+#ALLOWED_ORIGINS=https://divemap.blue,https://divemap.fly.dev
 #REFRESH_TOKEN_COOKIE_SECURE=true       # HTTPS required in production
 #REFRESH_TOKEN_COOKIE_SAMESITE=strict   # Maximum security in production
 #SUSPICIOUS_PROXY_CHAIN_LENGTH=6       # Production: Cloudflare + Fly.io + nginx + frontend + backend = ~6 hops

--- a/frontend/capacitor.config.ts
+++ b/frontend/capacitor.config.ts
@@ -5,11 +5,11 @@ const config: CapacitorConfig = {
   appName: 'Divemap',
   webDir: 'dist',
   server: {
-    url: 'https://divemap.gr',
-    hostname: 'divemap.gr',
+    url: 'https://divemap.blue',
+    hostname: 'divemap.blue',
     androidScheme: 'https',
     allowNavigation: [
-      'divemap.gr',
+      'divemap.blue',
       'accounts.google.com',
       'challenges.cloudflare.com'
     ],

--- a/frontend/deploy.sh
+++ b/frontend/deploy.sh
@@ -78,4 +78,4 @@ fly deploy -a divemap-frontend \
   $GA_BUILD_ARG
 
 echo "Deployment completed successfully!"
-echo "Visit your app at: https://divemap.gr/" 
+echo "Visit your app at: https://divemap.blue/"

--- a/frontend/public/.well-known/api-catalog
+++ b/frontend/public/.well-known/api-catalog
@@ -1,15 +1,15 @@
 {
   "linkset": [
     {
-      "anchor": "https://divemap.gr/api/v1/",
+      "anchor": "https://divemap.blue/api/v1/",
       "service-desc": [
-        {"href": "https://divemap.gr/openapi.json", "type": "application/vnd.oai.openapi+json;version=3.1.0"}
+        {"href": "https://divemap.blue/openapi.json", "type": "application/vnd.oai.openapi+json;version=3.1.0"}
       ],
       "service-doc": [
-        {"href": "https://divemap.gr/docs", "type": "text/html"}
+        {"href": "https://divemap.blue/docs", "type": "text/html"}
       ],
       "status": [
-        {"href": "https://divemap.gr/api/v1/health", "type": "application/json"}
+        {"href": "https://divemap.blue/api/v1/health", "type": "application/json"}
       ]
     }
   ]

--- a/frontend/public/.well-known/oauth-authorization-server
+++ b/frontend/public/.well-known/oauth-authorization-server
@@ -1,8 +1,8 @@
 {
-  "issuer": "https://divemap.gr",
-  "token_endpoint": "https://divemap.gr/api/v1/auth/login",
+  "issuer": "https://divemap.blue",
+  "token_endpoint": "https://divemap.blue/api/v1/auth/login",
   "response_types_supported": ["token"],
   "grant_types_supported": ["password", "refresh_token"],
   "token_endpoint_auth_methods_supported": ["client_secret_post"],
-  "service_documentation": "https://divemap.gr/docs"
+  "service_documentation": "https://divemap.blue/docs"
 }

--- a/frontend/public/.well-known/oauth-protected-resource
+++ b/frontend/public/.well-known/oauth-protected-resource
@@ -1,4 +1,4 @@
 {
-  "resource": "https://divemap.gr/api/v1/",
-  "authorization_servers": ["https://divemap.gr"]
+  "resource": "https://divemap.blue/api/v1/",
+  "authorization_servers": ["https://divemap.blue"]
 }

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,7 +1,7 @@
 # https://www.robotstxt.org/robotstxt.html
 
 # 1. Point to the sitemap (CRITICAL for discovery)
-Sitemap: https://divemap.gr/sitemap.xml
+Sitemap: https://divemap.blue/sitemap.xml
 
 # 2. General bot optimization
 User-agent: *

--- a/frontend/src/pages/Privacy.jsx
+++ b/frontend/src/pages/Privacy.jsx
@@ -550,8 +550,8 @@ const Privacy = () => {
                   contact us:
                 </p>
                 <div className='space-y-1 text-gray-600 dark:text-gray-400'>
-                  <p>Email: privacy@divemap.gr</p>
-                  <p>Subject: Divemap.gr Privacy Policy Inquiry</p>
+                  <p>Email: privacy@divemap.blue</p>
+                  <p>Subject: Divemap.blue Privacy Policy Inquiry</p>
                 </div>
               </div>
             </section>

--- a/frontend/vite.config.mjs
+++ b/frontend/vite.config.mjs
@@ -155,7 +155,7 @@ export default defineConfig(({ mode }) => {
     server: {
     host: true, // Needed for Docker
     port: 3000, // Maintain existing port
-    allowedHosts: ['dev.divemap.gr'], // Fix DNS rebinding block
+    allowedHosts: ['dev.divemap.gr','dev.divemap.blue'], // Fix DNS rebinding block
     watch: {
       usePolling: true, // Needed for some Docker environments
     },

--- a/utils/update_dive_site_locations.env.example
+++ b/utils/update_dive_site_locations.env.example
@@ -3,7 +3,7 @@
 
 # Base URL for the Divemap API
 # Development: http://localhost:8000
-# Production: https://divemap.gr
+# Production: https://divemap.blue
 DIVEMAP_BASE_URL=http://localhost
 
 # Authentication credentials


### PR DESCRIPTION
Migrate appropriate occurrences of 'https://divemap.gr' to the new
production domain 'https://divemap.blue' across frontend configs,
associated deployment documentation, worker scripts, and metadata catalogs.

Ensure backward-compatibility logic remains intact by preserving legacy
detection blocks for 'divemap.gr' inside the backend SEO router and
avoiding blind updates to redirect-testing acceptance criteria.